### PR TITLE
Resolve #2411: Harden DI introspection and override lifecycle contracts

### DIFF
--- a/.changeset/harden-di-introspection-overrides.md
+++ b/.changeset/harden-di-introspection-overrides.md
@@ -1,0 +1,6 @@
+---
+"@fluojs/di": patch
+"@fluojs/testing": patch
+---
+
+Harden DI introspection snapshots and override stale-instance disposal ordering so framework-owned state cannot be observed through live maps and replacement resolution waits for stale teardown failures. Update testing module sync cache adoption to consume the snapshot introspection contract.

--- a/packages/di/README.ko.md
+++ b/packages/di/README.ko.md
@@ -67,7 +67,7 @@ const service = await container.resolve(UserService);
 
 - **클래스 provider**: `container.register(MyService)` 또는 `{ provide, useClass }`
 - **값 provider**: `{ provide: 'API_URL', useValue: 'https://api.example.com' }`
-- **팩토리 provider**: `{ provide, useFactory, inject }`
+- **팩토리 provider**: `{ provide, useFactory, inject }`. 팩토리가 참조 클래스의 `@Scope(...)` 같은 DI metadata를 상속해야 하고 provider `scope`를 명시하지 않았다면 `resolverClass`를 함께 지정합니다.
 - **별칭(Alias) provider**: `{ provide: ILogger, useExisting: PinoLogger }`를 사용하여 하나의 토큰을 기존에 등록된 다른 provider로 매핑할 수 있습니다.
 
 ### scope-aware 수명 주기 관리
@@ -80,7 +80,7 @@ dispose 중에는 각 컨테이너가 자신이 소유한 살아 있는 request 
 
 ### provider override
 
-테스트나 request-local 경계에서 기존 등록을 의도적으로 교체해야 할 때는 `override(...providers)`를 사용합니다. override는 각 토큰의 현재 provider set을 교체하고 현재 컨테이너와 이미 materialize된 request-scope 자식의 cached instance를 무효화하며, 오래된 instance를 즉시 dispose합니다. multi provider override는 해당 토큰의 전체 multi-provider set을 교체하므로 필요한 replacement provider를 한 번에 모두 전달하세요. 같은 토큰에 single replacement와 multi replacement를 한 override 호출에서 섞으면 모호한 교체로 보고 거부합니다.
+테스트나 request-local 경계에서 기존 등록을 의도적으로 교체해야 할 때는 `override(...providers)`를 사용합니다. override는 각 토큰의 현재 provider set을 교체하고 현재 컨테이너와 이미 materialize된 request-scope 자식의 cached instance를 무효화하며, 다음 replacement resolution이 계속되기 전에 오래된 instance의 dispose가 끝나도록 보장합니다. multi provider override는 해당 토큰의 전체 multi-provider set을 교체하므로 필요한 replacement provider를 한 번에 모두 전달하세요. 같은 토큰에 single replacement와 multi replacement를 한 override 호출에서 섞으면 모호한 교체로 보고 거부합니다.
 
 ### request scope 분리
 
@@ -157,17 +157,17 @@ const service = await container.resolve(DataService);
 
 ## 공개 API
 
-| Export | 설명 |
-|---|---|
-| `Container` | 메인 DI 컨테이너 클래스입니다. |
-| `register(...providers)` | 하나 이상의 프로바이더를 등록합니다. |
-| `override(...providers)` | 기존 provider를 교체하고 cached instance를 무효화하며 오래된 instance를 dispose합니다. |
-| `resolve<T>(token)` | 토큰을 인스턴스로 비동기 해석합니다. |
-| `inspectResolutionState()` | read-only map view, frozen provider record, controlled cache adoption을 통해 cache ownership을 보존해야 하는 testing/tooling helper를 위한 지원 대상 framework-owned container introspection seam을 노출합니다. 애플리케이션 코드는 `has(...)`와 `resolve(...)`를 우선 사용하세요. |
-| `createRequestScope()` | 요청 스코프 의존성을 위한 자식 컨테이너를 생성합니다. |
-| `has(token)` | 컨테이너나 부모에 토큰이 등록되어 있는지 확인합니다. |
-| `hasRequestScopedDependency(token)` | 토큰 해석 시 provider 그래프에 request-scoped 의존성이나 순환이 있어 request-scope 컨테이너가 필요할 수 있는지 확인합니다. |
-| `dispose()` | request child와 루트가 소유한 singleton instance를 정리합니다. |
+| Surface | 종류 | 설명 |
+|---|---|---|
+| `Container` | Root export | 메인 DI 컨테이너 클래스입니다. |
+| `container.register(...providers)` | `Container` instance method | 하나 이상의 프로바이더를 등록합니다. |
+| `container.override(...providers)` | `Container` instance method | 기존 provider를 교체하고 cached instance를 무효화하며 다음 replacement resolution이 계속되기 전에 오래된 instance dispose가 settle되도록 보장합니다. |
+| `container.resolve<T>(token)` | `Container` instance method | 토큰을 인스턴스로 비동기 해석합니다. |
+| `container.inspectResolutionState()` | `Container` instance method | snapshot read-only map view, frozen provider record, controlled cache adoption을 통해 cache ownership을 보존해야 하는 testing/tooling helper를 위한 지원 대상 framework-owned container introspection seam을 노출합니다. 애플리케이션 코드는 `has(...)`와 `resolve(...)`를 우선 사용하세요. |
+| `container.createRequestScope()` | `Container` instance method | 요청 스코프 의존성을 위한 자식 컨테이너를 생성합니다. |
+| `container.has(token)` | `Container` instance method | 컨테이너나 부모에 토큰이 등록되어 있는지 확인합니다. |
+| `container.hasRequestScopedDependency(token)` | `Container` instance method | 토큰 해석 시 provider 그래프에 request-scoped 의존성이나 순환이 있어 request-scope 컨테이너가 필요할 수 있는지 확인합니다. |
+| `container.dispose()` | `Container` instance method | request child와 루트가 소유한 singleton instance를 정리합니다. |
 | `forwardRef(fn)` | 선언 순서 문제를 위해 조회를 지연하는 토큰 래퍼를 반환합니다. 실제 생성자 순환을 해석 가능하게 만들지는 않습니다. |
 | `isForwardRef(value)` | `forwardRef(...)`가 만든 값인지 확인하는 type guard입니다. 커스텀 provider tooling이 DI token wrapper와 통합될 때 사용할 수 있습니다. |
 | `optional(token)` | 하나의 의존성을 optional로 표시하는 토큰 래퍼를 반환합니다. 누락된 optional dependency는 `undefined`로 해석됩니다. |

--- a/packages/di/README.md
+++ b/packages/di/README.md
@@ -67,7 +67,7 @@ const result = await service.getStatus();
 fluo DI supports four provider shapes:
 - **Class Providers**: `container.register(MyService)` or `{ provide: MyToken, useClass: MyService }`.
 - **Value Providers**: `{ provide: 'API_URL', useValue: 'https://api.example.com' }`.
-- **Factory Providers**: `{ provide: 'ASYNC_CONFIG', useFactory: async (db) => await db.load(), inject: [Database] }`.
+- **Factory Providers**: `{ provide: 'ASYNC_CONFIG', useFactory: async (db) => await db.load(), inject: [Database] }`. Add `resolverClass` when the factory should inherit the referenced class's DI metadata, such as `@Scope(...)`, unless an explicit provider `scope` is set.
 - **Alias Providers**: `{ provide: ILogger, useExisting: PinoLogger }` allows mapping one token to another existing provider.
 
 ### Scope Management
@@ -79,7 +79,7 @@ During disposal, each container first recursively tears down live request-scope 
 
 ### Provider Overrides
 
-Use `override(...providers)` when a test or request-local boundary needs to replace existing registrations deliberately. Overrides replace the current provider set for each token, invalidate cached instances in the current container and already-materialized request-scope descendants, and dispose stale instances immediately. Multi-provider overrides replace the full multi-provider set for that token, so pass every replacement provider together; mixing single and multi replacements for the same token in one override call is rejected as ambiguous.
+Use `override(...providers)` when a test or request-local boundary needs to replace existing registrations deliberately. Overrides replace the current provider set for each token, invalidate cached instances in the current container and already-materialized request-scope descendants, and dispose stale instances before the next replacement resolution continues. Multi-provider overrides replace the full multi-provider set for that token, so pass every replacement provider together; mixing single and multi replacements for the same token in one override call is rejected as ambiguous.
 
 ### Request Scoping
 Isolated containers can be created to handle per-request state without polluting the root container.
@@ -157,17 +157,17 @@ Ensure all required providers are registered in the container. If you use `creat
 
 ## Public API
 
-| Export | Description |
-|---|---|
-| `Container` | The main DI container class. |
-| `register(...providers)` | Registers one or more providers. |
-| `override(...providers)` | Replaces existing providers, invalidates cached instances, and disposes stale instances. |
-| `resolve<T>(token)` | Asynchronously resolves a token to an instance. |
-| `inspectResolutionState()` | Exposes the supported framework-owned container introspection seam for testing/tooling helpers that must preserve cache ownership through read-only map views, frozen provider records, and controlled cache adoption. Prefer `has(...)` and `resolve(...)` for application code. |
-| `createRequestScope()` | Creates a child container for request-scoped dependencies. |
-| `has(token)` | Checks if a token is registered in the container or its parents. |
-| `hasRequestScopedDependency(token)` | Checks whether resolving a token may require a request-scope container because its provider graph contains request-scoped dependencies or is cyclic. |
-| `dispose()` | Disposes request children and root-owned singleton instances. |
+| Surface | Kind | Description |
+|---|---|---|
+| `Container` | Root export | The main DI container class. |
+| `container.register(...providers)` | `Container` instance method | Registers one or more providers. |
+| `container.override(...providers)` | `Container` instance method | Replaces existing providers, invalidates cached instances, and ensures stale instance disposal settles before the next replacement resolution continues. |
+| `container.resolve<T>(token)` | `Container` instance method | Asynchronously resolves a token to an instance. |
+| `container.inspectResolutionState()` | `Container` instance method | Exposes the supported framework-owned container introspection seam for testing/tooling helpers that must preserve cache ownership through snapshot read-only map views, frozen provider records, and controlled cache adoption. Prefer `has(...)` and `resolve(...)` for application code. |
+| `container.createRequestScope()` | `Container` instance method | Creates a child container for request-scoped dependencies. |
+| `container.has(token)` | `Container` instance method | Checks if a token is registered in the container or its parents. |
+| `container.hasRequestScopedDependency(token)` | `Container` instance method | Checks whether resolving a token may require a request-scope container because its provider graph contains request-scoped dependencies or is cyclic. |
+| `container.dispose()` | `Container` instance method | Disposes request children and root-owned singleton instances. |
 | `forwardRef(fn)` | Returns a token wrapper that defers lookup for declaration-order issues; it does not make constructor dependency cycles resolvable. |
 | `isForwardRef(value)` | Type guard for values produced by `forwardRef(...)`; useful when integrating custom provider tooling with DI token wrappers. |
 | `optional(token)` | Returns a token wrapper that marks one dependency as optional; missing optional dependencies resolve to `undefined`. |

--- a/packages/di/src/container.test.ts
+++ b/packages/di/src/container.test.ts
@@ -837,6 +837,13 @@ describe('Container', () => {
       expect(() => new Container().register(provider)).toThrow('provide token');
     });
 
+    it('throws InvalidProviderError when an object provider uses undefined provide', () => {
+      const provider = { provide: undefined, useValue: 'missing-token' } as unknown as Provider;
+
+      expect(() => new Container().register(provider)).toThrow(InvalidProviderError);
+      expect(() => new Container().register(provider)).toThrow('provide token');
+    });
+
     it('throws InvalidProviderError when an object provider has no strategy', () => {
       const provider = { provide: Symbol('strategy-less-provider') } as unknown as Provider;
 
@@ -1586,6 +1593,33 @@ describe('Container', () => {
       await expect(container.resolve(token)).resolves.toBe('value');
       await expect(container.resolve<string[]>(plugins)).resolves.toEqual(['plugin']);
     });
+
+    it('returns snapshots that do not reflect later registration or cache mutation', async () => {
+      const firstToken = Symbol('first-introspection-token');
+      const secondToken = Symbol('second-introspection-token');
+      const plugins = Symbol('snapshot-plugins');
+      const container = new Container().register(
+        { provide: firstToken, useValue: 'first' },
+        { provide: plugins, useValue: 'plugin-a', multi: true },
+      );
+
+      await container.resolve(firstToken);
+      await container.resolve(plugins);
+
+      const state = container.inspectResolutionState();
+      const singletonCacheSize = state.singletonCache.size;
+      const multiSingletonCacheSize = state.multiSingletonCache.size;
+
+      container.register({ provide: secondToken, useValue: 'second' });
+      container.override({ provide: plugins, useValue: 'plugin-b', multi: true });
+      await container.resolve(secondToken);
+      await container.resolve(plugins);
+
+      expect(state.registrations.has(secondToken)).toBe(false);
+      expect(state.multiRegistrations.get(plugins)?.map((provider) => provider.useValue)).toEqual(['plugin-a']);
+      expect(state.singletonCache.size).toBe(singletonCacheSize);
+      expect(state.multiSingletonCache.size).toBe(multiSingletonCacheSize);
+    });
   });
 
   describe('dispose', () => {
@@ -1848,6 +1882,52 @@ describe('Container', () => {
       expect(events).toEqual(['request', 'root']);
     });
 
+    it('aggregates failures from multiple request-scope children before root disposal failures', async () => {
+      class RootService {
+        onDestroy() {
+          throw new Error('root failed');
+        }
+      }
+
+      class RequestService {
+        constructor(readonly name: string) {}
+
+        onDestroy() {
+          throw new Error(`${this.name} failed`);
+        }
+      }
+
+      const token = Symbol('multi-child-request-service');
+      const root = new Container().register(
+        RootService,
+        {
+          provide: token,
+          scope: Scope.REQUEST,
+          useFactory: () => new RequestService('first child'),
+        },
+      );
+      const firstRequestScope = root.createRequestScope();
+      const secondRequestScope = root.createRequestScope();
+
+      await root.resolve(RootService);
+      await firstRequestScope.resolve(token);
+      root.override({
+        provide: token,
+        scope: Scope.REQUEST,
+        useFactory: () => new RequestService('second child'),
+      });
+      await secondRequestScope.resolve(token);
+
+      const error = await root.dispose().catch((value: unknown) => value);
+
+      expect(error).toBeInstanceOf(AggregateError);
+      expect((error as AggregateError).errors.map((failure) => (failure as Error).message)).toEqual([
+        'first child failed',
+        'second child failed',
+        'root failed',
+      ]);
+    });
+
     it('disposes stale overridden singleton instances immediately and exactly once', async () => {
       const events: string[] = [];
 
@@ -1875,6 +1955,65 @@ describe('Container', () => {
       await container.dispose();
 
       expect(events).toEqual(['first', 'second']);
+    });
+
+    it('waits for stale async singleton disposal before resolving replacements', async () => {
+      const events: string[] = [];
+      let releaseStaleDisposal!: () => void;
+      const staleDisposal = new Promise<void>((resolve) => {
+        releaseStaleDisposal = resolve;
+      });
+
+      class FirstService {
+        async onDestroy() {
+          events.push('first:start');
+          await staleDisposal;
+          events.push('first:end');
+        }
+      }
+
+      class SecondService {
+        onDestroy() {
+          events.push('second');
+        }
+      }
+
+      const token = Symbol('async-stale-disposal-token');
+      const container = new Container().register({ provide: token, useClass: FirstService });
+
+      await container.resolve(token);
+      container.override({ provide: token, useClass: SecondService });
+
+      const replacement = container.resolve(token).then(() => events.push('resolved'));
+      await Promise.resolve();
+
+      expect(events).toEqual(['first:start']);
+
+      releaseStaleDisposal();
+      await replacement;
+      await container.dispose();
+
+      expect(events).toEqual(['first:start', 'first:end', 'resolved', 'second']);
+    });
+
+    it('surfaces stale disposal failures before resolving replacements', async () => {
+      class FirstService {
+        onDestroy() {
+          throw new Error('stale failed');
+        }
+      }
+
+      class SecondService {}
+
+      const token = Symbol('failing-stale-disposal-token');
+      const container = new Container().register({ provide: token, useClass: FirstService });
+
+      await container.resolve(token);
+      container.override({ provide: token, useClass: SecondService });
+
+      await expect(container.resolve(token)).rejects.toThrow('stale failed');
+      await expect(container.resolve(token)).resolves.toBeInstanceOf(SecondService);
+      await container.dispose();
     });
 
     it('disposes stale singleton consumers invalidated by dependency overrides exactly once', async () => {
@@ -1935,6 +2074,52 @@ describe('Container', () => {
       await root.dispose();
 
       expect(events).toEqual(['consumer:before-override', 'consumer:after-override']);
+    });
+
+    it('disposes stale request-scope descendants before resolving replacements', async () => {
+      const events: string[] = [];
+      const CONFIG = Symbol('RequestDescendantConfig');
+      let releaseStaleDisposal!: () => void;
+      const staleDisposal = new Promise<void>((resolve) => {
+        releaseStaleDisposal = resolve;
+      });
+
+      class RequestConsumer {
+        constructor(readonly config: string) {}
+
+        async onDestroy() {
+          events.push(`destroy:start:${this.config}`);
+          await staleDisposal;
+          events.push(`destroy:end:${this.config}`);
+        }
+      }
+
+      const root = new Container().register(
+        { provide: CONFIG, useValue: 'before-override' },
+        { provide: RequestConsumer, scope: Scope.REQUEST, useClass: RequestConsumer, inject: [CONFIG] },
+      );
+      const requestScope = root.createRequestScope();
+
+      await requestScope.resolve(RequestConsumer);
+      root.override({ provide: CONFIG, useValue: 'after-override' });
+
+      const replacement = requestScope.resolve<RequestConsumer>(RequestConsumer).then((consumer) => events.push(`resolved:${consumer.config}`));
+      await Promise.resolve();
+
+      expect(events).toEqual(['destroy:start:before-override']);
+
+      releaseStaleDisposal();
+      await replacement;
+      await requestScope.dispose();
+      await root.dispose();
+
+      expect(events).toEqual([
+        'destroy:start:before-override',
+        'destroy:end:before-override',
+        'resolved:after-override',
+        'destroy:start:after-override',
+        'destroy:end:after-override',
+      ]);
     });
 
     it('disposes stale overridden multi singleton instances immediately and exactly once', async () => {

--- a/packages/di/src/container.ts
+++ b/packages/di/src/container.ts
@@ -509,34 +509,48 @@ export class Container {
    * @returns Read-only provider registrations and resolution caches for this container scope.
    */
   inspectResolutionState(): ContainerResolutionState {
+    const registrations = new Map(this.registrations);
+    const multiRegistrations = new Map(
+      Array.from(this.multiRegistrations, ([token, providers]) => [token, Object.freeze([...providers])] as const),
+    );
+    const multiSingletonCache = new Map(this.multiSingletonCache);
+    const singletonCache = new Map(this.singletonCache);
+
     return {
-      cacheOwner: this.createCacheOwner(),
+      cacheOwner: this.createCacheOwner(singletonCache, multiSingletonCache),
       factoryResolutionKinds: this.createFactoryResolutionState(),
       parent: this.parent?.inspectResolutionState(),
-      registrations: new ReadonlyMapView(this.registrations),
-      multiRegistrations: new ReadonlyMultiRegistrationMapView(this.multiRegistrations),
-      multiSingletonCache: new ReadonlyMapView(this.multiSingletonCache),
+      registrations: new ReadonlyMapView(registrations),
+      multiRegistrations: new ReadonlyMultiRegistrationMapView(multiRegistrations),
+      multiSingletonCache: new ReadonlyMapView(multiSingletonCache),
       requestScopeEnabled: this.requestScopeEnabled,
-      singletonCache: new ReadonlyMapView(this.singletonCache),
+      singletonCache: new ReadonlyMapView(singletonCache),
     };
   }
 
-  private createCacheOwner(): ContainerResolutionCacheOwner {
+  private createCacheOwner(
+    singletonCacheSnapshot: Map<Token, Promise<unknown>>,
+    multiSingletonCacheSnapshot: Map<NormalizedProvider, Promise<unknown>>,
+  ): ContainerResolutionCacheOwner {
     return Object.freeze({
       deleteMultiSingleton: (provider: NormalizedProvider) => {
         this.multiSingletonCache.delete(provider);
+        multiSingletonCacheSnapshot.delete(provider);
       },
       deleteSingleton: (token: Token) => {
         this.singletonCache.delete(token);
+        singletonCacheSnapshot.delete(token);
       },
       recordFactoryResolution: (provider: NormalizedProvider, kind: FactoryResolutionKind) => {
         this.root().factoryResolutionKinds.set(provider, kind);
       },
       setMultiSingleton: (provider: NormalizedProvider, promise: Promise<unknown>) => {
         this.multiSingletonCache.set(provider, promise);
+        multiSingletonCacheSnapshot.set(provider, promise);
       },
       setSingleton: (token: Token, promise: Promise<unknown>) => {
         this.singletonCache.set(token, promise);
+        singletonCacheSnapshot.set(token, promise);
       },
     });
   }
@@ -604,6 +618,8 @@ export class Container {
         { token, hint: 'Ensure all resolves complete before calling container.dispose().' },
       );
     }
+
+    await this.assertStaleDisposalsSettled();
 
     return this.resolveWithChain(token, [], new Set<Token>());
   }
@@ -1260,6 +1276,13 @@ export class Container {
     while (this.staleDisposalTasks.size > 0) {
       await Promise.all(Array.from(this.staleDisposalTasks));
     }
+  }
+
+  private async assertStaleDisposalsSettled(): Promise<void> {
+    await this.waitForStaleDisposalTasks();
+
+    const errors = this.staleDisposalErrors.splice(0, this.staleDisposalErrors.length);
+    this.throwDisposalErrors(errors);
   }
 
   private scheduleStaleDisposal(instancePromise: Promise<unknown>): void {

--- a/packages/di/src/types.ts
+++ b/packages/di/src/types.ts
@@ -50,6 +50,7 @@ export interface FactoryProvider<T = unknown> {
   inject?: InjectionToken[];
   scope?: Scope;
   multi?: boolean;
+  /** Class metadata source used when the factory should inherit `@Scope(...)` metadata. */
   resolverClass?: ClassType;
 }
 

--- a/packages/testing/src/module.override-refresh.test.ts
+++ b/packages/testing/src/module.override-refresh.test.ts
@@ -1,0 +1,101 @@
+import { Module } from '@fluojs/core';
+import { describe, expect, it } from 'vitest';
+
+import { createTestingModule } from './index.js';
+
+type Deferred = {
+  readonly promise: Promise<void>;
+  readonly resolve: () => void;
+};
+
+function createDeferred(): Deferred {
+  let resolve: (() => void) | undefined;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+
+  if (!resolve) {
+    throw new Error('Deferred resolver was not initialized.');
+  }
+
+  return { promise, resolve };
+}
+
+describe('TestingModuleRef post-compile overrides', () => {
+  it('returns the replacement after container.override() invalidates a sync singleton read through get()', async () => {
+    type ServiceValue = {
+      readonly label: string;
+    };
+
+    const TOKEN = Symbol('post-compile-override-token');
+    const originalValue: ServiceValue = { label: 'original' };
+    const replacementValue: ServiceValue = { label: 'replacement' };
+
+    @Module({ providers: [{ provide: TOKEN, useValue: originalValue }] })
+    class OverrideModule {}
+
+    const testingModule = await createTestingModule({ rootModule: OverrideModule }).compile();
+
+    const original = testingModule.get<ServiceValue>(TOKEN);
+    testingModule.container.override({ provide: TOKEN, useValue: replacementValue });
+    const replacement = testingModule.get<ServiceValue>(TOKEN);
+
+    expect(original).toBe(originalValue);
+    expect(replacement).toBe(replacementValue);
+  });
+
+  it('preserves async stale-disposal ordering after container.override() and replacement get()', async () => {
+    const TOKEN = Symbol('post-compile-async-disposal-token');
+    const events: string[] = [];
+    const originalDestroyStarted = createDeferred();
+    const finishOriginalDestroy = createDeferred();
+
+    class OriginalService {
+      readonly label = 'original';
+
+      async onDestroy(): Promise<void> {
+        events.push('original:destroy:start');
+        originalDestroyStarted.resolve();
+        await finishOriginalDestroy.promise;
+        events.push('original:destroy:end');
+      }
+    }
+
+    class ReplacementService {
+      readonly label = 'replacement';
+
+      onDestroy(): void {
+        events.push('replacement:destroy');
+      }
+    }
+
+    @Module({ providers: [{ provide: TOKEN, useClass: OriginalService }] })
+    class AsyncDisposalOverrideModule {}
+
+    const testingModule = await createTestingModule({ rootModule: AsyncDisposalOverrideModule }).compile();
+
+    const original = testingModule.get<OriginalService | ReplacementService>(TOKEN);
+    testingModule.container.override({ provide: TOKEN, useClass: ReplacementService });
+    const replacement = testingModule.get<OriginalService | ReplacementService>(TOKEN);
+
+    expect(original).toBeInstanceOf(OriginalService);
+    expect(replacement).toBeInstanceOf(ReplacementService);
+
+    const disposePromise = testingModule.container.dispose().then(() => {
+      events.push('container:disposed');
+    });
+
+    await originalDestroyStarted.promise;
+    expect(events).toEqual(['original:destroy:start']);
+
+    finishOriginalDestroy.resolve();
+    await disposePromise;
+
+    expect(events).toEqual([
+      'original:destroy:start',
+      'original:destroy:end',
+      'replacement:destroy',
+      'container:disposed',
+    ]);
+  });
+});

--- a/packages/testing/src/module.override-refresh.test.ts
+++ b/packages/testing/src/module.override-refresh.test.ts
@@ -44,6 +44,58 @@ describe('TestingModuleRef post-compile overrides', () => {
     expect(replacement).toBe(replacementValue);
   });
 
+  it('keeps get() aligned after container.override() is repopulated through container.resolve()', async () => {
+    type ServiceValue = {
+      readonly label: string;
+    };
+
+    const TOKEN = Symbol('post-compile-override-resolve-token');
+    const originalValue: ServiceValue = { label: 'original' };
+    const replacementValue: ServiceValue = { label: 'replacement' };
+
+    @Module({ providers: [{ provide: TOKEN, useValue: originalValue }] })
+    class OverrideResolveModule {}
+
+    const testingModule = await createTestingModule({ rootModule: OverrideResolveModule }).compile();
+
+    const original = testingModule.get<ServiceValue>(TOKEN);
+    testingModule.container.override({ provide: TOKEN, useValue: replacementValue });
+    const resolvedReplacement = await testingModule.container.resolve<ServiceValue>(TOKEN);
+    const syncReplacement = testingModule.get<ServiceValue>(TOKEN);
+
+    expect(original).toBe(originalValue);
+    expect(resolvedReplacement).toBe(replacementValue);
+    expect(syncReplacement).toBe(replacementValue);
+  });
+
+  it('keeps multi-provider get() aligned when a dependency override is repopulated through container.resolve()', async () => {
+    const DEPENDENCY = Symbol('post-compile-multi-dependency-token');
+    const PLUGINS = Symbol('post-compile-multi-plugins-token');
+
+    class Plugin {
+      constructor(readonly value: string) {}
+    }
+
+    @Module({
+      providers: [
+        { provide: DEPENDENCY, useValue: 'original' },
+        { provide: PLUGINS, useClass: Plugin, inject: [DEPENDENCY], multi: true },
+      ],
+    })
+    class MultiOverrideResolveModule {}
+
+    const testingModule = await createTestingModule({ rootModule: MultiOverrideResolveModule }).compile();
+
+    const original = testingModule.get<Plugin[]>(PLUGINS);
+    testingModule.container.override({ provide: DEPENDENCY, useValue: 'replacement' });
+    const resolvedReplacement = await testingModule.container.resolve<Plugin[]>(PLUGINS);
+    const syncReplacement = testingModule.get<Plugin[]>(PLUGINS);
+
+    expect(original.map((plugin) => plugin.value)).toEqual(['original']);
+    expect(resolvedReplacement.map((plugin) => plugin.value)).toEqual(['replacement']);
+    expect(syncReplacement.map((plugin) => plugin.value)).toEqual(['replacement']);
+  });
+
   it('preserves async stale-disposal ordering after container.override() and replacement get()', async () => {
     const TOKEN = Symbol('post-compile-async-disposal-token');
     const events: string[] = [];

--- a/packages/testing/src/module.ts
+++ b/packages/testing/src/module.ts
@@ -157,8 +157,13 @@ interface SyncResolverState {
   multiSingletonCache: ReadonlyMap<NormalizedProvider, Promise<unknown>>;
   resolutionChain: Set<Token>;
   singletonCache: ReadonlyMap<Token, Promise<unknown>>;
-  syncMultiSingletonValues: Map<NormalizedProvider, unknown>;
-  syncSingletonValues: Map<Token, unknown>;
+  syncMultiSingletonValues: Map<NormalizedProvider, SyncSingletonMemo>;
+  syncSingletonValues: Map<Token, SyncSingletonMemo>;
+}
+
+interface SyncSingletonMemo {
+  readonly cacheEntry: Promise<unknown>;
+  readonly value: unknown;
 }
 
 interface SyncResolver {
@@ -494,8 +499,10 @@ function resolveSyncProvider(provider: NormalizedProvider, state: SyncResolverSt
     return instantiateSyncProvider(provider, state);
   }
 
-  if (state.syncSingletonValues.has(provider.provide)) {
-    return state.syncSingletonValues.get(provider.provide);
+  const memo = state.syncSingletonValues.get(provider.provide);
+
+  if (memo) {
+    return memo.value;
   }
 
   if (state.singletonCache.has(provider.provide)) {
@@ -505,8 +512,9 @@ function resolveSyncProvider(provider: NormalizedProvider, state: SyncResolverSt
   }
 
   const instance = instantiateSyncProvider(provider, state);
-  state.syncSingletonValues.set(provider.provide, instance);
-  state.cacheOwner.setSingleton(provider.provide, Promise.resolve(instance));
+  const cacheEntry = Promise.resolve(instance);
+  state.syncSingletonValues.set(provider.provide, { cacheEntry, value: instance });
+  state.cacheOwner.setSingleton(provider.provide, cacheEntry);
   return instance;
 }
 
@@ -519,8 +527,10 @@ function resolveSyncMultiProvider(provider: NormalizedProvider, state: SyncResol
     return instantiateSyncProvider(provider, state);
   }
 
-  if (state.syncMultiSingletonValues.has(provider)) {
-    return state.syncMultiSingletonValues.get(provider);
+  const memo = state.syncMultiSingletonValues.get(provider);
+
+  if (memo) {
+    return memo.value;
   }
 
   if (state.multiSingletonCache.has(provider)) {
@@ -530,8 +540,9 @@ function resolveSyncMultiProvider(provider: NormalizedProvider, state: SyncResol
   }
 
   const instance = instantiateSyncProvider(provider, state);
-  state.syncMultiSingletonValues.set(provider, instance);
-  state.cacheOwner.setMultiSingleton(provider, Promise.resolve(instance));
+  const cacheEntry = Promise.resolve(instance);
+  state.syncMultiSingletonValues.set(provider, { cacheEntry, value: instance });
+  state.cacheOwner.setMultiSingleton(provider, cacheEntry);
   return instance;
 }
 
@@ -571,8 +582,8 @@ function createSyncResolver(container: BootstrapResult['container']): SyncResolv
     multiSingletonCache: rootIntrospection.multiSingletonCache,
     resolutionChain: new Set<Token>(),
     singletonCache: rootIntrospection.singletonCache,
-    syncMultiSingletonValues: new Map<NormalizedProvider, unknown>(),
-    syncSingletonValues: new Map<Token, unknown>(),
+    syncMultiSingletonValues: new Map<NormalizedProvider, SyncSingletonMemo>(),
+    syncSingletonValues: new Map<Token, SyncSingletonMemo>(),
   };
 
   const refreshState = (): void => {
@@ -585,14 +596,14 @@ function createSyncResolver(container: BootstrapResult['container']): SyncResolv
     state.multiSingletonCache = freshRootIntrospection.multiSingletonCache;
     state.singletonCache = freshRootIntrospection.singletonCache;
 
-    for (const token of state.syncSingletonValues.keys()) {
-      if (!state.singletonCache.has(token)) {
+    for (const [token, memo] of state.syncSingletonValues) {
+      if (state.singletonCache.get(token) !== memo.cacheEntry) {
         state.syncSingletonValues.delete(token);
       }
     }
 
-    for (const provider of state.syncMultiSingletonValues.keys()) {
-      if (!state.multiSingletonCache.has(provider)) {
+    for (const [provider, memo] of state.syncMultiSingletonValues) {
+      if (state.multiSingletonCache.get(provider) !== memo.cacheEntry) {
         state.syncMultiSingletonValues.delete(provider);
       }
     }
@@ -611,7 +622,7 @@ function createSyncResolver(container: BootstrapResult['container']): SyncResolv
           continue;
         }
 
-        state.syncSingletonValues.set(token, await promise);
+        state.syncSingletonValues.set(token, { cacheEntry: promise, value: await promise });
       }
 
       for (const [provider, promise] of state.multiSingletonCache) {
@@ -619,7 +630,7 @@ function createSyncResolver(container: BootstrapResult['container']): SyncResolv
           continue;
         }
 
-        state.syncMultiSingletonValues.set(provider, await promise);
+        state.syncMultiSingletonValues.set(provider, { cacheEntry: promise, value: await promise });
       }
     },
   };
@@ -715,6 +726,13 @@ class DefaultTestingModuleBuilder implements TestingModuleBuilder {
     await runTestingBootstrapLifecycle(bootstrapped, this.overrides);
     await syncResolver.syncFromContainer();
 
+    const resolve = bootstrapped.container.resolve.bind(bootstrapped.container);
+    bootstrapped.container.resolve = async <T>(token: Token<T>): Promise<T> => {
+      const value = await resolve<T>(token);
+      await syncResolver.syncFromContainer();
+      return value;
+    };
+
     return this.createTestingModuleRef(bootstrapped, syncResolver);
   }
 
@@ -739,11 +757,7 @@ class DefaultTestingModuleBuilder implements TestingModuleBuilder {
       ...bootstrapped,
       has: (token) => bootstrapped.container.has(token),
       get: (token) => syncResolver.get(token),
-      resolve: async <T>(token: Token<T>) => {
-        const value = await bootstrapped.container.resolve<T>(token);
-        await syncResolver.syncFromContainer();
-        return value;
-      },
+      resolve: <T>(token: Token<T>) => bootstrapped.container.resolve<T>(token),
       resolveAll: async <T>(tokens: Token<T>[]): Promise<T[]> => {
         const results: T[] = [];
         const errors: Array<{ token: Token; error: unknown }> = [];
@@ -763,8 +777,6 @@ class DefaultTestingModuleBuilder implements TestingModuleBuilder {
 
           throw new Error(`Failed to resolve ${errors.length} of ${tokens.length} tokens:\n${summary}`);
         }
-
-        await syncResolver.syncFromContainer();
 
         return results;
       },

--- a/packages/testing/src/module.ts
+++ b/packages/testing/src/module.ts
@@ -564,7 +564,6 @@ function resolveSyncToken(token: Token, state: SyncResolverState): unknown {
 function createSyncResolver(container: BootstrapResult['container']): SyncResolver {
   const introspection = toContainerIntrospection(container);
   const rootIntrospection = rootContainerIntrospection(introspection);
-
   const state: SyncResolverState = {
     cacheOwner: rootIntrospection.cacheOwner,
     factoryResolutionKinds: rootIntrospection.factoryResolutionKinds,
@@ -576,9 +575,25 @@ function createSyncResolver(container: BootstrapResult['container']): SyncResolv
     syncSingletonValues: new Map<Token, unknown>(),
   };
 
+  const refreshState = (): void => {
+    const freshIntrospection = toContainerIntrospection(container);
+    const freshRootIntrospection = rootContainerIntrospection(freshIntrospection);
+
+    state.cacheOwner = freshRootIntrospection.cacheOwner;
+    state.factoryResolutionKinds = freshRootIntrospection.factoryResolutionKinds;
+    state.introspection = freshIntrospection;
+    state.multiSingletonCache = freshRootIntrospection.multiSingletonCache;
+    state.singletonCache = freshRootIntrospection.singletonCache;
+  };
+
   return {
-    get: <T>(token: Token<T>): T => resolveSyncToken(token, state) as T,
+    get: <T>(token: Token<T>): T => {
+      refreshState();
+      return resolveSyncToken(token, state) as T;
+    },
     syncFromContainer: async (): Promise<void> => {
+      refreshState();
+
       for (const [token, promise] of state.singletonCache) {
         if (!canPromoteCachedSingleton(state, token)) {
           continue;

--- a/packages/testing/src/module.ts
+++ b/packages/testing/src/module.ts
@@ -584,6 +584,18 @@ function createSyncResolver(container: BootstrapResult['container']): SyncResolv
     state.introspection = freshIntrospection;
     state.multiSingletonCache = freshRootIntrospection.multiSingletonCache;
     state.singletonCache = freshRootIntrospection.singletonCache;
+
+    for (const token of state.syncSingletonValues.keys()) {
+      if (!state.singletonCache.has(token)) {
+        state.syncSingletonValues.delete(token);
+      }
+    }
+
+    for (const provider of state.syncMultiSingletonValues.keys()) {
+      if (!state.multiSingletonCache.has(provider)) {
+        state.syncMultiSingletonValues.delete(provider);
+      }
+    }
   };
 
   return {


### PR DESCRIPTION
## Summary

Harden `@fluojs/di` introspection and provider override lifecycle contracts. `inspectResolutionState()` now exposes snapshot provider/cache views while preserving controlled cache adoption for framework tooling, and replacement resolution waits for stale async teardown failures before continuing.

Linked context: Closes #2411

## Changes

- Snapshot DI introspection map views and keep `cacheOwner`-mediated cache adoption reflected in that snapshot.
- Add override lifecycle barriers so stale singleton/request descendant disposal settles before replacement resolution proceeds, with stale disposal failures surfaced on the next resolve.
- Add regression coverage for snapshot introspection, stale disposal ordering/failures, request descendant stale disposal, `provide: undefined`, and multi-child disposal aggregation.
- Refresh `@fluojs/testing` sync resolver state before `get()`/`syncFromContainer()` so testing helpers consume the snapshot introspection contract.
- Update EN/KO DI README provider/API docs and add Changesets patch metadata for `@fluojs/di` and `@fluojs/testing`.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm --dir packages/core build`
- `pnpm --dir packages/di test -- --runInBand`
- `pnpm exec vitest run --project packages packages/testing/src/module.test.ts`
- `pnpm --dir packages/di typecheck`
- `pnpm --dir packages/testing typecheck`
- `pnpm --dir packages/di build`
- `pnpm --dir packages/testing build`
- `pnpm verify:public-export-tsdoc`
- `pnpm verify:platform-consistency-governance`
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main`
- `node --input-type=module -e ...` smoke for built `packages/di/dist/index.js` replacement resolution and snapshot introspection
- `pnpm verify` was run twice. After fixing the DI/testing-related failures, the remaining failure is one unrelated CLI sandbox test: `packages/cli/src/cli.test.ts > CLI command runner > keeps the local sandbox outside the repo workspace` expected status `0` but received `1`.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Patch changesets are included for `@fluojs/di` and `@fluojs/testing`.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

`FactoryProvider.resolverClass` now has source-level TSDoc and the DI README public API table distinguishes root exports from `Container` instance methods.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

Override stale-instance teardown, request-scope descendant invalidation, introspection snapshot ownership, provider validation, and multi-child disposal aggregation are covered in `packages/di/src/container.test.ts`.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests, such as `createPlatformConformanceHarness(...)` for platform component contracts or `createHttpAdapterPortabilityHarness(...)` for HTTP adapter portability contracts.

No platform contract docs changed. EN/KO package README changes were kept aligned, and `pnpm verify:platform-consistency-governance` passed.