### PR TITLE
Resolve #2437: Preserve throttler route-bucket isolation

### DIFF
--- a/.changeset/throttler-route-bucket-isolation.md
+++ b/.changeset/throttler-route-bucket-isolation.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/throttler": patch
+---
+
+Preserve route-bucket isolation for handlers that share the same HTTP method, path, version, and method name by including controller identity in throttler storage keys.

--- a/docs/architecture/security-middleware.ko.md
+++ b/docs/architecture/security-middleware.ko.md
@@ -60,5 +60,5 @@
 - origin을 반영하는 CORS 응답은 캐시가 서로 다른 origin 정책을 합치지 않도록 `Vary: Origin`을 포함해야 합니다.
 - 내장 HTTP rate-limit 미들웨어는 기본적으로 프로세스 로컬 메모리를 사용합니다. 다중 인스턴스 배포에서는 이를 공유 quota 메커니즘으로 취급하면 안 됩니다.
 - 프록시 기반 client identity는 기본적으로 비활성화되어 있습니다. `trustProxyHeaders: true`는 어댑터가 `Forwarded`, `X-Forwarded-For`, `X-Real-IP`를 재작성하는 신뢰 가능한 프록시 뒤에 있을 때만 활성화해야 합니다.
-- `@fluojs/throttler`의 handler 단위 throttling은 해석된 라우트 시그니처와 client identity를 저장소 키로 사용하므로, 하나의 전역 버킷이 아니라 route-handler 경계마다 제한을 적용합니다.
+- `@fluojs/throttler`의 handler 단위 throttling은 해석된 라우트 시그니처, controller/handler identity, client identity를 저장소 키로 사용하므로, 하나의 전역 버킷이 아니라 route-handler 경계마다 제한을 적용합니다.
 - `@Throttle({ ttl, limit })`와 `@SkipThrottle()`는 guard 단계의 throttling 정책만 바꿉니다. app 레벨 HTTP 미들웨어 동작은 바꾸지 않습니다.

--- a/docs/architecture/security-middleware.md
+++ b/docs/architecture/security-middleware.md
@@ -60,5 +60,5 @@ Middleware-specific ordering rules:
 - Reflected-origin CORS responses MUST include `Vary: Origin` so caches do not collapse distinct origin policies.
 - The built-in HTTP rate-limit middleware uses process-local memory by default. Multi-instance deployments should not treat it as a shared quota mechanism.
 - Proxy-derived client identity is disabled by default. `trustProxyHeaders: true` should be enabled only when the adapter is behind a trusted proxy that rewrites `Forwarded`, `X-Forwarded-For`, or `X-Real-IP`.
-- Handler-level throttling in `@fluojs/throttler` uses the resolved route signature plus client identity as the storage key, so it enforces limits per route-handler boundary rather than one global bucket.
+- Handler-level throttling in `@fluojs/throttler` uses the resolved route signature, controller/handler identity, and client identity as the storage key, so it enforces limits per route-handler boundary rather than one global bucket.
 - `@Throttle({ ttl, limit })` and `@SkipThrottle()` modify the guard-stage throttling policy only. They do not change the behavior of app-level HTTP middleware.

--- a/packages/throttler/README.ko.md
+++ b/packages/throttler/README.ko.md
@@ -137,6 +137,7 @@ ThrottlerModule.forRoot({
 
 ### 모듈
 - `ThrottlerModule.forRoot(options)`: 검증된 throttler 옵션과 `ThrottlerGuard`를 모듈 그래프에 제공합니다.
+- `ThrottlerModuleOptions`: `ThrottlerModule.forRoot(...)`가 받는 공개 options shape입니다.
 - 패키지 수준 등록은 `ThrottlerModule.forRoot(options)`를 통해 지원합니다. 내부 프로바이더 조합 헬퍼와 DI 토큰은 공개 계약에 포함되지 않습니다.
 
 `ttl`과 `limit`은 양의 finite integer여야 합니다. `global`은 기본값이 `true`입니다. throttler provider를 가져온 모듈 범위에만 유지하려면 `global: false`를 설정하세요. `trustProxyHeaders`와 `keyGenerator`로 client identity를 조정할 수 있으며, `keyGenerator`를 제공할 때는 함수여야 합니다. 모듈 옵션은 guard가 연결될 때 검증되고 값으로 캡처되므로, 호출자가 나중에 options 객체를 변경해도 실행 중인 throttling 정책은 바뀌지 않습니다. `store` 옵션을 제공하지 않으면 각 `ThrottlerGuard` 인스턴스가 자체 in-memory store를 소유합니다. 저장소를 공유하거나 외부에서 관리해야 한다면 `RedisThrottlerStore` 같은 `ThrottlerStore` 구현을 전달하세요.

--- a/packages/throttler/README.ko.md
+++ b/packages/throttler/README.ko.md
@@ -97,7 +97,7 @@ ThrottlerModule.forRoot({
 
 기본적으로 throttler는 raw socket `remoteAddress`만으로 클라이언트 식별자를 해석합니다. 배포가 `Forwarded`, `X-Forwarded-For`, `X-Real-IP`를 덮어쓰는 신뢰 가능한 리버스 프록시 뒤에 있다면 `trustProxyHeaders: true`로 명시적으로 opt-in 하세요. 신뢰 가능한 소켓 식별자나 프록시 식별자가 없으면 서로 다른 호출자를 같은 버킷으로 합치지 않도록 예외를 던집니다. API 키나 사용자 ID 등 다른 식별자를 사용하도록 커스터마이징할 수도 있습니다.
 
-카운터는 route identity와 client identity로 구분됩니다. route 부분에는 method, path, version, handler identity가 포함되므로 서로 다른 핸들러가 실수로 같은 버킷을 공유하지 않습니다. 요청이 거부되면 `ThrottlerGuard`는 `429`를 반환하고 `Retry-After`를 설정합니다.
+카운터는 route identity와 client identity로 구분됩니다. route 부분에는 module, controller, method, path, version, handler identity가 포함되므로 서로 다른 route-handler 경계가 실수로 같은 버킷을 공유하지 않습니다. 요청이 거부되면 `ThrottlerGuard`는 `429`를 반환하고 `Retry-After`를 설정합니다.
 
 ```typescript
 ThrottlerModule.forRoot({

--- a/packages/throttler/README.md
+++ b/packages/throttler/README.md
@@ -97,7 +97,7 @@ You can also pass any object that implements the `ThrottlerStore` contract throu
 
 By default, the throttler resolves client identity from the raw socket `remoteAddress` only. If your deployment sits behind a trusted reverse proxy that rewrites `Forwarded`, `X-Forwarded-For`, or `X-Real-IP`, opt in with `trustProxyHeaders: true`. If no trusted socket or proxy identity is available, it throws instead of collapsing unrelated callers into a shared bucket. You can also customize this to use API keys, user IDs, or other identifiers.
 
-Counters are scoped by route identity and client identity. The route portion includes method, path, version, and handler identity so different handlers do not share buckets accidentally. When a request is rejected, `ThrottlerGuard` returns `429` and sets `Retry-After`.
+Counters are scoped by route identity and client identity. The route portion includes module, controller, method, path, version, and handler identity so different route-handler boundaries do not share buckets accidentally. When a request is rejected, `ThrottlerGuard` returns `429` and sets `Retry-After`.
 
 ```typescript
 ThrottlerModule.forRoot({

--- a/packages/throttler/README.md
+++ b/packages/throttler/README.md
@@ -137,6 +137,7 @@ When migrating from `@nestjs/throttler`, treat `@fluojs/throttler` as an explici
 
 ### Modules
 - `ThrottlerModule.forRoot(options)`: Provides validated throttler options and `ThrottlerGuard` to the module graph.
+- `ThrottlerModuleOptions`: Public options shape accepted by `ThrottlerModule.forRoot(...)`.
 - Package-level registration is supported through `ThrottlerModule.forRoot(options)`. Internal provider-composition helpers and DI tokens are not part of the public contract.
 
 `ttl` and `limit` must be positive finite integers. `global` defaults to `true`; set `global: false` when the throttler providers should stay scoped to the importing module. `trustProxyHeaders` and `keyGenerator` customize client identity; `keyGenerator`, when provided, must be a function. Module options are validated and captured by value when the guard is wired so later mutation of the caller's options object does not change live throttling policy. If no `store` option is supplied, each `ThrottlerGuard` instance owns its own in-memory store; pass a `ThrottlerStore` implementation such as `RedisThrottlerStore` when storage must be shared or externally managed.

--- a/packages/throttler/src/guard-route-key.test.ts
+++ b/packages/throttler/src/guard-route-key.test.ts
@@ -1,0 +1,97 @@
+import type { GuardContext, HandlerDescriptor, RequestContext } from '@fluojs/http';
+import { describe, expect, it, vi } from 'vitest';
+import { ThrottlerGuard } from './guard.js';
+import type { ThrottlerConsumeInput, ThrottlerStore } from './types.js';
+
+function createRequestContext(remoteAddress: string): RequestContext {
+  const headers: Record<string, string | string[]> = {};
+  const response: RequestContext['response'] = {
+    committed: false,
+    headers,
+    redirect() {},
+    send: vi.fn(async () => {}),
+    setHeader(name: string, value: string | string[]) {
+      headers[name] = value;
+    },
+    setStatus() {},
+    statusCode: 200,
+  };
+
+  return {
+    container: {} as RequestContext['container'],
+    metadata: {},
+    request: {
+      body: undefined,
+      cookies: {},
+      headers,
+      method: 'GET',
+      params: {},
+      path: '/shared',
+      query: {},
+      raw: { socket: { remoteAddress } },
+      url: '/shared',
+    },
+    response,
+  };
+}
+
+function createGuardContext(controllerToken: Function, requestContext: RequestContext): GuardContext {
+  return {
+    handler: {
+      controllerToken: controllerToken as HandlerDescriptor['controllerToken'],
+      metadata: {
+        controllerPath: '',
+        effectivePath: '/shared',
+        effectiveVersion: '1',
+        moduleMiddleware: [],
+        pathParams: [],
+      },
+      methodName: 'action',
+      route: {
+        method: 'GET',
+        path: '/shared',
+        version: '1',
+      },
+    },
+    requestContext,
+  };
+}
+
+describe('ThrottlerGuard route bucket keys', () => {
+  it('keeps route buckets isolated for different controllers with the same handler signature', async () => {
+    const counts = new Map<string, number>();
+    const store: ThrottlerStore = {
+      consume: vi.fn(async (key: string, input: ThrottlerConsumeInput) => {
+        const count = (counts.get(key) ?? 0) + 1;
+        counts.set(key, count);
+
+        return {
+          count,
+          resetAt: input.now + input.ttlSeconds * 1000,
+        };
+      }),
+    };
+
+    class PublicController {
+      action() {}
+    }
+
+    class AdminController {
+      action() {}
+    }
+
+    const guard = new ThrottlerGuard({ limit: 1, store, ttl: 60 });
+    const publicContext = createGuardContext(PublicController, createRequestContext('2001:db8::1'));
+    const adminContext = createGuardContext(AdminController, createRequestContext('2001:db8::1'));
+
+    await expect(guard.canActivate(publicContext)).resolves.toBe(true);
+    await expect(guard.canActivate(adminContext)).resolves.toBe(true);
+
+    const publicKey = vi.mocked(store.consume).mock.calls[0]?.[0];
+    const adminKey = vi.mocked(store.consume).mock.calls[1]?.[0];
+
+    expect(publicKey).toContain('controller%3APublicController');
+    expect(adminKey).toContain('controller%3AAdminController');
+    expect(publicKey).not.toBe(adminKey);
+  });
+});

--- a/packages/throttler/src/guard.ts
+++ b/packages/throttler/src/guard.ts
@@ -53,8 +53,12 @@ function buildStoreKey(encodedHandlerKey: string, clientKey: string): string {
 
 function buildHandlerKey(handler: GuardContext['handler']): string {
   const version = handler.route.version ?? handler.metadata.effectiveVersion ?? 'unversioned';
+  const moduleName = handler.metadata.moduleType?.name || '<moduleless>';
+  const controllerName = handler.controllerToken.name || '<anonymous-controller>';
 
   return [
+    `module:${encodeURIComponent(moduleName)}`,
+    `controller:${encodeURIComponent(controllerName)}`,
     `method:${handler.route.method}`,
     `path:${encodeURIComponent(handler.route.path)}`,
     `version:${encodeURIComponent(version)}`,
@@ -100,7 +104,14 @@ export class ThrottlerGuard implements Guard {
     }
 
     const version = handler.route.version ?? handler.metadata.effectiveVersion ?? 'unversioned';
-    const cacheKey = [handler.methodName, handler.route.method, handler.route.path, version].join('\u0000');
+    const cacheKey = [
+      handler.metadata.moduleType?.name || '<moduleless>',
+      handler.controllerToken.name || '<anonymous-controller>',
+      handler.methodName,
+      handler.route.method,
+      handler.route.path,
+      version,
+    ].join('\u0000');
     const cachedPolicy = controllerPolicies.get(cacheKey);
 
     if (cachedPolicy) {


### PR DESCRIPTION
## Summary

Preserve `@fluojs/throttler` route-bucket isolation when different controllers expose the same HTTP method, path, version, and handler method name.

Linked context: Closes #2437

## Changes

- Include module/controller identity in `ThrottlerGuard` handler storage keys and policy cache keys.
- Add a focused regression test for two controllers with the same handler signature sharing a client identity.
- Add `ThrottlerModuleOptions` to the EN/KO package README public API overview.
- Align EN/KO security middleware docs with the controller/handler route identity contract.
- Add a patch changeset for `@fluojs/throttler`.

## Testing

- `pnpm --filter @fluojs/throttler exec vitest run -c vitest.config.ts src/module.test.ts --testNamePattern "keeps route buckets isolated"` first failed before the implementation, reproducing the bucket collision.
- `pnpm --filter @fluojs/throttler run test` passed: 4 test files, 65 tests.
- `pnpm --filter @fluojs/throttler run typecheck` passed after building workspace dependencies.
- `pnpm --filter @fluojs/throttler run build` passed after building workspace dependencies.
- `pnpm exec biome check packages/throttler/src/guard.ts packages/throttler/src/guard-route-key.test.ts packages/throttler/README.md packages/throttler/README.ko.md docs/architecture/security-middleware.md docs/architecture/security-middleware.ko.md .changeset/throttler-route-bucket-isolation.md` passed.
- `pnpm docs:sync-check` passed.
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main` passed.
- `pnpm verify:release-readiness` was attempted; it reached the full package Vitest suite and failed in an unrelated CLI sandbox test: `packages/cli/src/cli.test.ts > CLI command runner > keeps the local sandbox outside the repo workspace` expected status 0 but received 1.
- LSP diagnostics could not run because the TypeScript LSP server is not installed in this environment and was previously declined.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Patch changeset: `.changeset/throttler-route-bucket-isolation.md`.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No new public exports were added. The existing exported `ThrottlerModuleOptions` type is now named in the EN/KO README public API overview.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

The route-bucket storage key now includes controller/handler identity along with route signature and client identity, matching the documented route-handler boundary.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests, such as `createPlatformConformanceHarness(...)` for platform component contracts or `createHttpAdapterPortabilityHarness(...)` for HTTP adapter portability contracts.

EN/KO package README and security middleware docs were updated together; `pnpm docs:sync-check` passed.