### PR TITLE
Resolve #2419: govern Express listen retry shutdown

### DIFF
--- a/.changeset/express-close-listen-retry.md
+++ b/.changeset/express-close-listen-retry.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/platform-express': patch
+---
+
+Cancel and join in-flight Express adapter listen retry loops during `close()` so a busy-port startup cannot bind after shutdown has already resolved.

--- a/packages/platform-express/README.ko.md
+++ b/packages/platform-express/README.ko.md
@@ -106,6 +106,9 @@ const app = await fluoFactory.create(AppModule, {
 
 문서화된 fluo semantics를 바꾸지 않기 위해 `/:id` 와 `/:slug`처럼 shape가 겹치는 파라미터 라우트, `@All(...)` 핸들러, `OPTIONS` 소유권, non-URI versioning, 그리고 duplicate slash/trailing slash 정규화에 의존하는 요청은 catch-all fallback 경로에 남겨둡니다.
 
+### Startup Retry와 Shutdown
+`listen()`은 adapter가 열린 상태인 동안에만 `retryDelayMs` 및 `retryLimit`에 따라 `EADDRINUSE`를 재시도합니다. Startup이 retry loop에서 대기 중일 때 `close()`가 호출되면, underlying Node server가 아직 listening 상태에 도달하지 않았더라도 adapter는 in-flight listen attempt를 abort하고 그 작업이 settle될 때까지 기다린 뒤 `close()`를 완료합니다. `close()`가 resolve된 뒤 막혀 있던 port를 해제해도 adapter가 나중에 bind되지 않으며, 다시 시작하려면 호출자가 명시적으로 `listen()`을 다시 호출해야 합니다.
+
 ## 어댑터 계약
 
 - **공유 dispatcher 소유권 유지**: Native Express Router 매치 이후에도 실제 요청은 공유 fluo dispatcher가 처리하므로 middleware, guards, interceptors, observers, params, error envelope 계약은 그대로 유지됩니다.
@@ -116,7 +119,7 @@ const app = await fluoFactory.create(AppModule, {
 - **버저닝 parity**: Express Router가 최초 path match를 하더라도 header/media-type/custom version 선택은 계속 dispatcher가 최종 결정합니다.
 - **Middleware rewrite parity**: App middleware가 method/path를 rewrite하면 native handoff는 무효화되고 rewrite된 요청을 기준으로 다시 매칭합니다.
 - **응답 serialization parity**: String response는 기본적으로 `text/plain`, object/array는 JSON, binary payload는 `application/octet-stream`으로 serialize되며 `set-cookie` 값은 병합됩니다.
-- **Startup과 shutdown**: 어댑터는 HTTP/HTTPS startup, `retryLimit` 소진 전까지 retry option에 따른 `EADDRINUSE` 재시도, 이미 시작된 adapter에 대한 중복 `listen()` 호출의 idempotent 처리와 live dispatcher 보존, 정상 close 시 idle keep-alive socket drain, 동시에 들어온 `close()` 호출의 단일 in-flight close lifecycle 재사용, shutdown timeout 이후 force-close를 지원하며, `shutdownTimeoutMs`가 `0`이면 즉시 force-close합니다.
+- **Startup과 shutdown**: 어댑터는 HTTP/HTTPS startup, adapter가 열린 상태에서 `retryLimit` 소진 전까지 retry option에 따른 `EADDRINUSE` 재시도, `close()` 중 in-flight listen retry loop를 abort 및 join한 뒤 shutdown 완료 보고, 이미 시작된 adapter에 대한 중복 `listen()` 호출의 idempotent 처리와 live dispatcher 보존, 정상 close 시 idle keep-alive socket drain, 동시에 들어온 `close()` 호출의 단일 in-flight close lifecycle 재사용, shutdown timeout 이후 force-close를 지원하며, `shutdownTimeoutMs`가 `0`이면 즉시 force-close합니다.
 
 ## 공개 API 개요
 
@@ -138,4 +141,4 @@ const app = await fluoFactory.create(AppModule, {
 ## 예제 소스
 
 - `packages/platform-express/src/adapter.test.ts`
-- 이 패키지는 아직 전용 `examples/platform-express` 앱을 제공하지 않습니다. Express bootstrap 형태는 이 README의 빠른 시작을 사용하고, SSE framing, native-route fallback parity, duplicate listen idempotency, retry exhaustion, idle keep-alive drain, forced shutdown을 포함한 실행 가능한 Express adapter coverage는 `packages/platform-express/src/adapter.test.ts`를 사용하세요. `examples/minimal/src/main.ts`는 Fastify 기반이므로 Express 예제 소스로 취급하지 않아야 합니다.
+- 이 패키지는 아직 전용 `examples/platform-express` 앱을 제공하지 않습니다. Express bootstrap 형태는 이 README의 빠른 시작을 사용하고, SSE framing, native-route fallback parity, duplicate listen idempotency, retry exhaustion, shutdown 중 startup retry cancellation, idle keep-alive drain, forced shutdown을 포함한 실행 가능한 Express adapter coverage는 `packages/platform-express/src/adapter.test.ts`를 사용하세요. `examples/minimal/src/main.ts`는 Fastify 기반이므로 Express 예제 소스로 취급하지 않아야 합니다.

--- a/packages/platform-express/README.md
+++ b/packages/platform-express/README.md
@@ -106,6 +106,9 @@ If app middleware rewrites the framework request method or path after the adapte
 
 To avoid changing documented fluo semantics, overlapping same-shape param routes such as `/:id` and `/:slug`, `@All(...)` handlers, `OPTIONS` ownership, non-URI versioning, and requests that rely on fluo's duplicate-slash/trailing-slash normalization stay on the catch-all fallback path.
 
+### Startup Retry and Shutdown
+`listen()` retries `EADDRINUSE` according to `retryDelayMs` and `retryLimit` only while the adapter remains open. If `close()` is called while startup is waiting in that retry loop, the adapter aborts the in-flight listen attempt and waits for it to settle before `close()` resolves, even when the underlying Node server has not reached the listening state yet. Releasing the blocked port after `close()` resolves cannot make the adapter bind later; callers must invoke `listen()` again explicitly to start it.
+
 ## Adapter Contract
 
 - **Shared dispatcher ownership**: Native Express Router matches still hand off to the shared fluo dispatcher, so middleware, guards, interceptors, observers, params, and error envelopes remain framework-defined.
@@ -116,7 +119,7 @@ To avoid changing documented fluo semantics, overlapping same-shape param routes
 - **Versioning parity**: Header/media-type/custom version selection remains dispatcher-owned even when Express Router handles the initial path match.
 - **Middleware rewrite parity**: App middleware that rewrites method or path invalidates native handoff and rematches the rewritten request.
 - **Response serialization parity**: String responses default to `text/plain`, objects/arrays serialize as JSON, binary payloads default to `application/octet-stream`, and `set-cookie` values are merged.
-- **Startup and shutdown**: The adapter supports HTTP/HTTPS startup, retries `EADDRINUSE` according to retry options until `retryLimit` is exhausted, treats duplicate `listen()` calls on an already-started adapter as idempotent without replacing the live dispatcher, drains idle keep-alive sockets on normal close, reuses one in-flight close lifecycle for concurrent `close()` calls, and can force-close connections after shutdown timeout, including immediate force-close when `shutdownTimeoutMs` is `0`.
+- **Startup and shutdown**: The adapter supports HTTP/HTTPS startup, retries `EADDRINUSE` according to retry options until `retryLimit` is exhausted while the adapter is open, aborts and joins an in-flight listen retry loop during `close()` before shutdown completion is reported, treats duplicate `listen()` calls on an already-started adapter as idempotent without replacing the live dispatcher, drains idle keep-alive sockets on normal close, reuses one in-flight close lifecycle for concurrent `close()` calls, and can force-close connections after shutdown timeout, including immediate force-close when `shutdownTimeoutMs` is `0`.
 
 ## Public API Overview
 
@@ -138,4 +141,4 @@ To avoid changing documented fluo semantics, overlapping same-shape param routes
 ## Example Sources
 
 - `packages/platform-express/src/adapter.test.ts`
-- This package does not currently ship a dedicated `examples/platform-express` app. Use the Quick Start in this README for Express bootstrap shape and `packages/platform-express/src/adapter.test.ts` for executable Express adapter coverage, including SSE framing, native-route fallback parity, duplicate listen idempotency, retry exhaustion, idle keep-alive drain, and forced shutdown. `examples/minimal/src/main.ts` is Fastify-based and should not be treated as an Express example source.
+- This package does not currently ship a dedicated `examples/platform-express` app. Use the Quick Start in this README for Express bootstrap shape and `packages/platform-express/src/adapter.test.ts` for executable Express adapter coverage, including SSE framing, native-route fallback parity, duplicate listen idempotency, retry exhaustion, startup retry cancellation during shutdown, idle keep-alive drain, and forced shutdown. `examples/minimal/src/main.ts` is Fastify-based and should not be treated as an Express example source.

--- a/packages/platform-express/src/adapter.test.ts
+++ b/packages/platform-express/src/adapter.test.ts
@@ -2193,6 +2193,82 @@ describe('@fluojs/platform-express', () => {
     }
   });
 
+  it('cancels retrying startup during close before a later Express bind can occur', async () => {
+    const blocker = createHttpServer((_request, response) => {
+      response.statusCode = 200;
+      response.end('blocked');
+    });
+    const port = await findAvailablePort();
+
+    await new Promise<void>((resolve, reject) => {
+      blocker.once('error', reject);
+      blocker.listen({ host: '127.0.0.1', port }, () => {
+        blocker.removeListener('error', reject);
+        resolve();
+      });
+    });
+
+    const closeBlocker = async (): Promise<void> => {
+      if (!blocker.listening) {
+        return;
+      }
+
+      await new Promise<void>((resolve, reject) => {
+        blocker.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+
+          resolve();
+        });
+      });
+    };
+
+    const adapter = new ExpressHttpApplicationAdapter(port, '127.0.0.1', 25, 20, undefined, undefined, 1024, false, 500);
+    const dispatcher = {
+      async dispatch() {},
+    };
+    const listenResult = adapter.listen(dispatcher).then(
+      () => 'listened' as const,
+      (error: unknown) => error,
+    );
+
+    try {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 10);
+      });
+      await expect(adapter.close()).resolves.toBeUndefined();
+      await closeBlocker();
+
+      const result = await listenResult;
+      expect(result).toBeInstanceOf(Error);
+      expect(String(result instanceof Error ? result.message : result)).toContain('startup was cancelled');
+
+      await new Promise((resolve) => {
+        setTimeout(resolve, 60);
+      });
+
+      await new Promise<void>((resolve, reject) => {
+        const probe = createHttpServer();
+        probe.once('error', reject);
+        probe.listen({ host: '127.0.0.1', port }, () => {
+          probe.close((error) => {
+            if (error) {
+              reject(error);
+              return;
+            }
+
+            resolve();
+          });
+        });
+      });
+    } finally {
+      await adapter.close();
+      await closeBlocker();
+    }
+  });
+
   it('fails startup with EADDRINUSE when retryLimit is exhausted', async () => {
     const blocker = createHttpServer((_request, response) => {
       response.statusCode = 200;

--- a/packages/platform-express/src/adapter.ts
+++ b/packages/platform-express/src/adapter.ts
@@ -154,6 +154,13 @@ interface ExpressNativeRouteCandidate {
   shapeKey: string;
 }
 
+interface ExpressListenServerInput {
+  readonly host: string | undefined;
+  readonly port: number;
+  readonly server: ExpressServer;
+  readonly signal: AbortSignal;
+}
+
 type ExpressFrameworkResponse = FrameworkResponse & {
   raw: ExpressResponse;
   sendSimpleJson(body: Record<string, unknown> | unknown[]): ReturnType<FrameworkResponse['send']>;
@@ -173,6 +180,8 @@ type ExpressMultipartLikeError = Error & {
 export class ExpressHttpApplicationAdapter implements HttpApplicationAdapter {
   private closeInFlight?: Promise<void>;
   private dispatcher?: Dispatcher;
+  private listenAbortController?: AbortController;
+  private listenInFlight?: Promise<void>;
   private readonly app: Express;
   private nativeRoutesReady = false;
   private readonly requestResponseFactory: RequestResponseFactory<
@@ -238,13 +247,32 @@ export class ExpressHttpApplicationAdapter implements HttpApplicationAdapter {
 
     this.dispatcher = dispatcher;
     this.registerNativeRoutes(dispatcher);
-    await this.listenWithRetry();
+
+    const abortController = new AbortController();
+    this.listenAbortController = abortController;
+    const listenInFlight = this.listenWithRetry(abortController.signal).finally(() => {
+      if (this.listenInFlight === listenInFlight) {
+        this.listenInFlight = undefined;
+      }
+
+      if (this.listenAbortController === abortController) {
+        this.listenAbortController = undefined;
+      }
+    });
+    this.listenInFlight = listenInFlight;
+
+    await listenInFlight;
   }
 
   async close(): Promise<void> {
     if (this.closeInFlight) {
       await waitForCloseWithTimeout(this.closeInFlight, this.shutdownTimeoutMs);
       return;
+    }
+
+    if (this.listenInFlight) {
+      this.listenAbortController?.abort();
+      await waitForCloseWithTimeout(ignoreCancelledListen(this.listenInFlight), this.shutdownTimeoutMs);
     }
 
     if (!this.server.listening) {
@@ -263,10 +291,23 @@ export class ExpressHttpApplicationAdapter implements HttpApplicationAdapter {
     await waitForCloseWithTimeout(closeInFlight, this.shutdownTimeoutMs);
   }
 
-  private async listenWithRetry(): Promise<void> {
+  private async listenWithRetry(signal: AbortSignal): Promise<void> {
     for (let attempt = 0; ; attempt++) {
+      throwIfListenCancelled(signal);
+
       try {
-        await listenServer(this.server, this.port, this.host);
+        await listenServer({
+          host: this.host,
+          port: this.port,
+          server: this.server,
+          signal,
+        });
+
+        if (signal.aborted) {
+          await closeServerBestEffort(this.server);
+          throw new ExpressListenCancelledError();
+        }
+
         return;
       } catch (error: unknown) {
         if (!isAddressInUseError(error) || attempt >= this.retryLimit) {
@@ -274,7 +315,7 @@ export class ExpressHttpApplicationAdapter implements HttpApplicationAdapter {
         }
 
         await closeServerSilently(this.server);
-        await delay(this.retryDelayMs);
+        await delay(this.retryDelayMs, signal);
       }
     }
   }
@@ -911,32 +952,75 @@ function resolveNonNegativeIntegerOption(name: string, value: number | undefined
   return resolved;
 }
 
-async function listenServer(server: ExpressServer, port: number, host: string | undefined): Promise<void> {
+async function listenServer(input: ExpressListenServerInput): Promise<void> {
+  const { host, port, server, signal } = input;
+
   await new Promise<void>((resolve, reject) => {
-    const onError = (error: NodeJS.ErrnoException) => {
-      cleanup();
-      reject(error);
-    };
+    if (signal.aborted) {
+      reject(new ExpressListenCancelledError());
+      return;
+    }
 
-    const onListening = () => {
-      cleanup();
-      resolve();
-    };
+    let settled = false;
 
-    const cleanup = () => {
+    function onError(error: NodeJS.ErrnoException): void {
+      finishReject(error);
+    }
+
+    function onListening(): void {
+      finishResolve();
+    }
+
+    function onAbort(): void {
+      cleanup();
+      void closeServerBestEffort(server).then(() => {
+        finishReject(new ExpressListenCancelledError());
+      });
+    }
+
+    function cleanup(): void {
       server.off('error', onError);
       server.off('listening', onListening);
-    };
+      signal.removeEventListener('abort', onAbort);
+    }
+
+    function finishResolve(): void {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      cleanup();
+      resolve();
+    }
+
+    function finishReject(error: unknown): void {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      cleanup();
+      reject(error);
+    }
 
     server.once('error', onError);
     server.once('listening', onListening);
+    signal.addEventListener('abort', onAbort, { once: true });
 
     try {
       server.listen({ host, port });
     } catch (error) {
-      cleanup();
-      reject(error);
+      finishReject(error);
     }
+  });
+}
+
+function closeServerBestEffort(server: ExpressServer): Promise<void> {
+  return new Promise((resolve) => {
+    server.close(() => {
+      resolve();
+    });
   });
 }
 
@@ -1020,9 +1104,53 @@ function isAddressInUseError(error: unknown): boolean {
   return (error as NodeJS.ErrnoException).code === 'EADDRINUSE';
 }
 
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
+class ExpressListenCancelledError extends Error {
+  readonly name = 'ExpressListenCancelledError';
+
+  constructor() {
+    super('Express adapter startup was cancelled during shutdown.');
+  }
+}
+
+function throwIfListenCancelled(signal: AbortSignal): void {
+  if (signal.aborted) {
+    throw new ExpressListenCancelledError();
+  }
+}
+
+function isExpressListenCancelledError(error: unknown): boolean {
+  return error instanceof ExpressListenCancelledError;
+}
+
+async function ignoreCancelledListen(listenPromise: Promise<void>): Promise<void> {
+  try {
+    await listenPromise;
+  } catch (error: unknown) {
+    if (isExpressListenCancelledError(error)) {
+      return;
+    }
+
+    throw error;
+  }
+}
+
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new ExpressListenCancelledError());
+      return;
+    }
+
+    const timeout = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timeout);
+      reject(new ExpressListenCancelledError());
+    };
+
+    signal?.addEventListener('abort', onAbort, { once: true });
   });
 }
 


### PR DESCRIPTION
## Summary

Linked context: Resolves #2419

Fixes the Express adapter listen/close lifecycle so an in-flight busy-port retry loop is aborted and joined during shutdown before `close()` resolves.

## Changes

- Track Express `listen()` retry attempts with cancellation state.
- Abort and join in-flight startup retry loops from `close()` before reporting shutdown completion.
- Add regression coverage proving a blocked port cannot be bound after `close()` resolves.
- Document EN/KO startup retry shutdown semantics for `@fluojs/platform-express`.
- Add a patch changeset for `@fluojs/platform-express`.

## Testing

- `pnpm exec vitest run packages/platform-express/src/adapter.test.ts` - 56 tests passed
- `pnpm docs:sync-check` - passed
- `pnpm --filter @fluojs/platform-express typecheck` - passed
- `GIT_MASTER=1 git diff --check origin/main...HEAD` - passed

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [ ] Changed public exports include a source-level summary.
- [ ] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No public exports changed.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests, such as `createPlatformConformanceHarness(...)` for platform component contracts or `createHttpAdapterPortabilityHarness(...)` for HTTP adapter portability contracts.
