### PR TITLE
Resolve #2431: harden Socket.IO lifecycle gaps

### DIFF
--- a/.changeset/socketio-lifecycle-regression-gaps.md
+++ b/.changeset/socketio-lifecycle-regression-gaps.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/socket.io": patch
+---
+
+Preserve Socket.IO connection bookkeeping across recoverable socket error events and surface Web-standard Bun handshake requests to guard and handler contexts.

--- a/book/intermediate/ch14-socketio.ko.md
+++ b/book/intermediate/ch14-socketio.ko.md
@@ -144,6 +144,10 @@ export class ScalingService {
 
 이 경계는 fluo가 decorator-based surface를 제공하면서도, 하부 라이브러리의 확장 지점을 막지 않도록 합니다. 평소에는 fluo의 선언적 gateway를 쓰고, 운영상 필요한 예외만 raw server 경계로 모을 수 있습니다.
 
+애플리케이션 종료 중 Socket.IO client 정리는 Socket.IO가 소유합니다. underlying HTTP server는 이를 제공한 platform adapter 또는 shared HTTP server 통합이 계속 소유하므로, fluo는 `io.close(...)` 전에 해당 server reference를 분리하고 HTTP listener shutdown은 platform owner에게 남깁니다.
+
+Graceful Socket.IO close가 설정된 shutdown timeout을 넘으면 fluo는 lifecycle state를 정리하기 전에 managed Socket.IO client를 force-disconnect합니다. 해당 forced cleanup도 실패하면 이후 shutdown retry가 같은 Socket.IO instance에서 동작할 수 있도록 managed server reference와 socket/namespace registry를 보존하며, active bookkeeping을 잃지 않습니다.
+
 Handler return value는 reply channel이 아닙니다. fluo는 thrown error를 로깅하고 handler ordering을 결정적으로 유지하기 위해 Socket.IO gateway handler를 await하지만, 반환값은 무시합니다. NestJS `@SubscribeMessage()` handler가 `return { ... }`로 ACK payload를 보내던 경우에는 acknowledgement callback을 positional argument로 받고 명시적으로 호출하세요. Native Socket.IO fan-out, `.volatile`, 고급 ACK orchestration은 `SOCKETIO_SERVER`를 주입하는 서비스에 둡니다.
 
 ```typescript

--- a/book/intermediate/ch14-socketio.md
+++ b/book/intermediate/ch14-socketio.md
@@ -146,6 +146,8 @@ This boundary lets fluo provide a decorator based surface without blocking the e
 
 During shutdown, Socket.IO owns cleanup for connected Socket.IO clients. The underlying HTTP server still belongs to the platform adapter or shared HTTP server integration that supplied it, so fluo detaches that server reference before `io.close(...)` and leaves HTTP listener shutdown to the platform owner.
 
+If graceful Socket.IO close exceeds the configured shutdown timeout, fluo force-disconnects managed Socket.IO clients before clearing lifecycle state. When that forced cleanup also fails, the managed server reference and socket/namespace registries are retained so a later shutdown retry can operate on the same Socket.IO instance instead of losing active bookkeeping.
+
 Handler return values are not a reply channel. fluo awaits a Socket.IO gateway handler so thrown errors can be logged and handler ordering stays deterministic, but the returned value is ignored. If a migrated NestJS `@SubscribeMessage()` handler used `return { ... }` as an ACK payload, accept the acknowledgement callback positionally and call it explicitly. For native Socket.IO fan-out, `.volatile`, or advanced ACK orchestration, keep that logic in a service that injects `SOCKETIO_SERVER`.
 
 ```typescript

--- a/packages/socket.io/src/adapter.ts
+++ b/packages/socket.io/src/adapter.ts
@@ -120,6 +120,15 @@ interface BunEngineOptions {
   path: string;
 }
 
+interface BunHandshakeRequestReference {
+  readonly _query: Readonly<Record<string, string>>;
+  readonly connection: {
+    readonly encrypted: boolean;
+  };
+  readonly headers: Readonly<Record<string, string>>;
+  readonly url: string;
+}
+
 interface BunRealtimeBindingHost {
   configureRealtimeBinding(binding: BunRealtimeBinding | undefined): void;
 }
@@ -275,6 +284,28 @@ function isFetchStyleRealtimeCapability(
   capability: HttpAdapterRealtimeCapability,
 ): capability is FetchStyleRealtimeCapability {
   return capability.kind === 'fetch-style' && capability.contract === 'raw-websocket-expansion';
+}
+
+function isBunHandshakeRequestReference(value: unknown): value is BunHandshakeRequestReference {
+  if (value instanceof Request || typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const candidate = value as Partial<BunHandshakeRequestReference>;
+  return typeof candidate.url === 'string'
+    && typeof candidate.headers === 'object'
+    && candidate.headers !== null
+    && typeof candidate._query === 'object'
+    && candidate._query !== null
+    && typeof candidate.connection === 'object'
+    && candidate.connection !== null;
+}
+
+function toBunHandshakeRequest(reference: BunHandshakeRequestReference): Request {
+  return new Request(reference.url, {
+    headers: reference.headers,
+    method: 'GET',
+  });
 }
 
 function resolveSocketIoBootstrapRuntime(
@@ -750,11 +781,12 @@ export class SocketIoLifecycleService
       return;
     }
 
+    const request = this.resolveHandshakeRequest(socket);
     const rejection = normalizeGuardRejection(
       await guard({
         activeConnectionCount: this.socketRegistry.size,
         namespacePath: path,
-        request: socket.request as SocketIoHandshakeRequest,
+        request,
         socket,
       }),
       'Socket.IO connection rejected.',
@@ -766,7 +798,7 @@ export class SocketIoLifecycleService
   }
 
   private async bindConnectionHandlers(descriptors: WebSocketGatewayDescriptor[], socket: Socket): Promise<void> {
-    const request = socket.request as SocketIoHandshakeRequest;
+    const request = this.resolveHandshakeRequest(socket);
     const resolved = await this.resolveConnectionGateways(descriptors);
     const state = this.createConnectionHandlerState();
 
@@ -775,6 +807,16 @@ export class SocketIoLifecycleService
     await this.runConnectHandlers(resolved, socket, request);
     state.handlersReady = true;
     await this.replayBufferedConnectionEvents(state, resolved, socket, request);
+  }
+
+  private resolveHandshakeRequest(socket: Socket): SocketIoHandshakeRequest {
+    const request = socket.request as unknown;
+
+    if (this.bunEngine && isBunHandshakeRequestReference(request)) {
+      return toBunHandshakeRequest(request);
+    }
+
+    return request as SocketIoHandshakeRequest;
   }
 
   private createConnectionHandlerState(): ConnectionHandlerState {
@@ -841,7 +883,6 @@ export class SocketIoLifecycleService
     });
 
     socket.on('error', (error: Error) => {
-      this.socketRegistry.delete(socket.id);
       this.logger.error('Socket.IO gateway socket emitted an error.', error, 'SocketIoLifecycleService');
     });
 

--- a/packages/socket.io/src/module.test.ts
+++ b/packages/socket.io/src/module.test.ts
@@ -624,6 +624,7 @@ describe('@fluojs/socket.io', () => {
 
   it('passes Node-backed handshake request objects to connection and message guards at runtime', async () => {
     let connectionRequest: SocketIoHandshakeRequest | undefined;
+    let handlerRequest: SocketIoHandshakeRequest | undefined;
     let messageRequest: SocketIoHandshakeRequest | undefined;
 
     @WebSocketGateway({ path: '/node-request-shape' })
@@ -632,9 +633,10 @@ describe('@fluojs/socket.io', () => {
       onPing(
         _payload: unknown,
         _socket: Socket,
-        _request: SocketIoHandshakeRequest,
+        request: SocketIoHandshakeRequest,
         acknowledgement?: (response: string) => void,
       ) {
+        handlerRequest = request;
         acknowledgement?.('ok');
       }
     }
@@ -676,15 +678,18 @@ describe('@fluojs/socket.io', () => {
 
       expect(acknowledgement).toBe('ok');
       const observedConnectionRequest = expectDefined(connectionRequest, 'Expected connection guard request to be captured.');
+      const observedHandlerRequest = expectDefined(handlerRequest, 'Expected handler request to be captured.');
       const observedMessageRequest = expectDefined(messageRequest, 'Expected message guard request to be captured.');
 
       expect(observedConnectionRequest).not.toBeInstanceOf(Request);
+      expect(observedHandlerRequest).not.toBeInstanceOf(Request);
       expect(observedMessageRequest).not.toBeInstanceOf(Request);
-      if (observedConnectionRequest instanceof Request || observedMessageRequest instanceof Request) {
-        throw new Error('Expected Node-backed guards to receive Node-like handshake requests.');
+      if (observedConnectionRequest instanceof Request || observedHandlerRequest instanceof Request || observedMessageRequest instanceof Request) {
+        throw new Error('Expected Node-backed guards and handlers to receive Node-like handshake requests.');
       }
       expect(observedConnectionRequest.method).toBe('GET');
       expect(observedConnectionRequest.headers.host).toContain('127.0.0.1');
+      expect(observedHandlerRequest).toBe(observedConnectionRequest);
       expect(observedMessageRequest).toBe(observedConnectionRequest);
     } finally {
       socket?.close();
@@ -695,6 +700,7 @@ describe('@fluojs/socket.io', () => {
   it('passes Bun Request handshake objects to connection and message guards at runtime', async () => {
     const adapter = new TestBunSocketIoAdapter(0);
     let connectionRequest: SocketIoHandshakeRequest | undefined;
+    let handlerRequest: SocketIoHandshakeRequest | undefined;
     let messageRequest: SocketIoHandshakeRequest | undefined;
 
     @WebSocketGateway({ path: '/bun-request-shape' })
@@ -703,9 +709,10 @@ describe('@fluojs/socket.io', () => {
       onPing(
         _payload: unknown,
         _socket: Socket,
-        _request: SocketIoHandshakeRequest,
+        request: SocketIoHandshakeRequest,
         acknowledgement?: (response: string) => void,
       ) {
+        handlerRequest = request;
         acknowledgement?.('ok');
       }
     }
@@ -750,14 +757,18 @@ describe('@fluojs/socket.io', () => {
 
       expect(acknowledgement).toBe('ok');
       const observedConnectionRequest = expectDefined(connectionRequest, 'Expected connection guard request to be captured.');
+      const observedHandlerRequest = expectDefined(handlerRequest, 'Expected handler request to be captured.');
       const observedMessageRequest = expectDefined(messageRequest, 'Expected message guard request to be captured.');
 
       expect(observedConnectionRequest).toBeInstanceOf(Request);
+      expect(observedHandlerRequest).toBeInstanceOf(Request);
       expect(observedMessageRequest).toBeInstanceOf(Request);
-      if (!(observedConnectionRequest instanceof Request) || !(observedMessageRequest instanceof Request)) {
-        throw new Error('Expected Bun guards to receive Web-standard Request instances.');
+      if (!(observedConnectionRequest instanceof Request) || !(observedHandlerRequest instanceof Request) || !(observedMessageRequest instanceof Request)) {
+        throw new Error('Expected Bun guards and handlers to receive Web-standard Request instances.');
       }
       expect(new URL(observedConnectionRequest.url).pathname).toBe('/socket.io/');
+      expect(observedHandlerRequest.url).toBe(observedConnectionRequest.url);
+      expect(observedHandlerRequest.headers.get('host')).toBe(observedConnectionRequest.headers.get('host'));
       expect(observedMessageRequest.url).toBe(observedConnectionRequest.url);
       expect(observedMessageRequest.headers.get('host')).toBe(observedConnectionRequest.headers.get('host'));
     } finally {

--- a/packages/socket.io/src/module.test.ts
+++ b/packages/socket.io/src/module.test.ts
@@ -91,6 +91,14 @@ function getBoundPortFromAdapter(adapter: HttpApplicationAdapter): number {
   return getBoundPort(server);
 }
 
+function expectDefined<T>(value: T | undefined, message: string): T {
+  if (value === undefined) {
+    throw new Error(message);
+  }
+
+  return value;
+}
+
 async function readRequestBody(request: IncomingMessage): Promise<string | undefined> {
   const chunks: Buffer[] = [];
 
@@ -285,23 +293,6 @@ function onceDisconnected(socket: ClientSocket): Promise<string> {
   return new Promise((resolve) => {
     socket.once('disconnect', (reason: string) => resolve(reason));
   });
-}
-
-async function waitForExpectation(assertion: () => void, timeoutMs = 250): Promise<void> {
-  const startedAt = Date.now();
-
-  while (true) {
-    try {
-      assertion();
-      return;
-    } catch (error) {
-      if (Date.now() - startedAt >= timeoutMs) {
-        throw error;
-      }
-
-      await new Promise((resolve) => setTimeout(resolve, 10));
-    }
-  }
 }
 
 interface SupportedSocketIoAdapterScenario {
@@ -514,6 +505,7 @@ describe('@fluojs/socket.io', () => {
 
   it('boots a Bun-style Socket.IO app through the official Bun engine path', async () => {
     const adapter = new TestBunSocketIoAdapter(0);
+    const disconnectHandled = createDeferred<void>();
 
     class GatewayState {
       connectCount = 0;
@@ -546,6 +538,7 @@ describe('@fluojs/socket.io', () => {
       onDisconnect(_socket: Socket, reason: string) {
         this.state.disconnectCount += 1;
         this.state.disconnectReason = reason;
+        disconnectHandled.resolve();
       }
     }
 
@@ -584,10 +577,9 @@ describe('@fluojs/socket.io', () => {
       socket.disconnect();
 
       expect(await disconnected).toBe('io client disconnect');
-      await waitForExpectation(() => {
-        expect(state.disconnectCount).toBe(1);
-        expect(state.disconnectReason).toBe('client namespace disconnect');
-      });
+      await disconnectHandled.promise;
+      expect(state.disconnectCount).toBe(1);
+      expect(state.disconnectReason).toBe('client namespace disconnect');
     } finally {
       socket?.close();
       await app.close();
@@ -624,6 +616,150 @@ describe('@fluojs/socket.io', () => {
       });
 
       expect(await onceEvent<string>(socket, 'raw:ready')).toBe('ok');
+    } finally {
+      socket?.close();
+      await app.close();
+    }
+  });
+
+  it('passes Node-backed handshake request objects to connection and message guards at runtime', async () => {
+    let connectionRequest: SocketIoHandshakeRequest | undefined;
+    let messageRequest: SocketIoHandshakeRequest | undefined;
+
+    @WebSocketGateway({ path: '/node-request-shape' })
+    class RequestShapeGateway {
+      @OnMessage('ping')
+      onPing(
+        _payload: unknown,
+        _socket: Socket,
+        _request: SocketIoHandshakeRequest,
+        acknowledgement?: (response: string) => void,
+      ) {
+        acknowledgement?.('ok');
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [SocketIoModule.forRoot({
+        auth: {
+          connection({ request }) {
+            connectionRequest = request;
+            return true;
+          },
+          message({ request }) {
+            messageRequest = request;
+            return true;
+          },
+        },
+        transports: ['websocket'],
+      })],
+      providers: [RequestShapeGateway],
+    });
+
+    const { adapter, app } = await createNodejsSocketIoApplication(AppModule);
+    let socket: ClientSocket | undefined;
+
+    try {
+      await app.listen();
+      const port = getBoundPortFromAdapter(adapter);
+
+      socket = createClient(`http://127.0.0.1:${String(port)}/node-request-shape`, {
+        reconnection: false,
+        transports: ['websocket'],
+      });
+      await onceConnected(socket);
+
+      const acknowledgement = await new Promise<unknown>((resolve) => {
+        socket?.emit('ping', 'payload', (response: unknown) => resolve(response));
+      });
+
+      expect(acknowledgement).toBe('ok');
+      const observedConnectionRequest = expectDefined(connectionRequest, 'Expected connection guard request to be captured.');
+      const observedMessageRequest = expectDefined(messageRequest, 'Expected message guard request to be captured.');
+
+      expect(observedConnectionRequest).not.toBeInstanceOf(Request);
+      expect(observedMessageRequest).not.toBeInstanceOf(Request);
+      if (observedConnectionRequest instanceof Request || observedMessageRequest instanceof Request) {
+        throw new Error('Expected Node-backed guards to receive Node-like handshake requests.');
+      }
+      expect(observedConnectionRequest.method).toBe('GET');
+      expect(observedConnectionRequest.headers.host).toContain('127.0.0.1');
+      expect(observedMessageRequest).toBe(observedConnectionRequest);
+    } finally {
+      socket?.close();
+      await app.close();
+    }
+  });
+
+  it('passes Bun Request handshake objects to connection and message guards at runtime', async () => {
+    const adapter = new TestBunSocketIoAdapter(0);
+    let connectionRequest: SocketIoHandshakeRequest | undefined;
+    let messageRequest: SocketIoHandshakeRequest | undefined;
+
+    @WebSocketGateway({ path: '/bun-request-shape' })
+    class RequestShapeGateway {
+      @OnMessage('ping')
+      onPing(
+        _payload: unknown,
+        _socket: Socket,
+        _request: SocketIoHandshakeRequest,
+        acknowledgement?: (response: string) => void,
+      ) {
+        acknowledgement?.('ok');
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [SocketIoModule.forRoot({
+        auth: {
+          connection({ request }) {
+            connectionRequest = request;
+            return true;
+          },
+          message({ request }) {
+            messageRequest = request;
+            return true;
+          },
+        },
+        transports: ['polling'],
+      })],
+      providers: [RequestShapeGateway],
+    });
+
+    const app = await bootstrapApplication({
+      adapter,
+      rootModule: AppModule,
+    });
+    let socket: ClientSocket | undefined;
+
+    try {
+      await app.listen();
+      const port = getBoundPortFromAdapter(adapter);
+
+      socket = createClient(`http://127.0.0.1:${String(port)}/bun-request-shape`, {
+        reconnection: false,
+        transports: ['polling'],
+      });
+      await onceConnected(socket);
+
+      const acknowledgement = await new Promise<unknown>((resolve) => {
+        socket?.emit('ping', 'payload', (response: unknown) => resolve(response));
+      });
+
+      expect(acknowledgement).toBe('ok');
+      const observedConnectionRequest = expectDefined(connectionRequest, 'Expected connection guard request to be captured.');
+      const observedMessageRequest = expectDefined(messageRequest, 'Expected message guard request to be captured.');
+
+      expect(observedConnectionRequest).toBeInstanceOf(Request);
+      expect(observedMessageRequest).toBeInstanceOf(Request);
+      if (!(observedConnectionRequest instanceof Request) || !(observedMessageRequest instanceof Request)) {
+        throw new Error('Expected Bun guards to receive Web-standard Request instances.');
+      }
+      expect(new URL(observedConnectionRequest.url).pathname).toBe('/socket.io/');
+      expect(observedMessageRequest.url).toBe(observedConnectionRequest.url);
+      expect(observedMessageRequest.headers.get('host')).toBe(observedConnectionRequest.headers.get('host'));
     } finally {
       socket?.close();
       await app.close();
@@ -956,6 +1092,8 @@ describe('@fluojs/socket.io', () => {
   });
 
   it('rejects anonymous namespace connections before gateway handlers execute', async () => {
+    const messageHandled = createDeferred<void>();
+
     class GatewayState {
       connectCount = 0;
       messages: unknown[] = [];
@@ -974,6 +1112,7 @@ describe('@fluojs/socket.io', () => {
       @OnMessage('ping')
       onPing(payload: unknown) {
         this.state.messages.push(payload);
+        messageHandled.resolve();
       }
     }
 
@@ -1022,9 +1161,8 @@ describe('@fluojs/socket.io', () => {
       await onceConnected(allowedSocket);
 
       allowedSocket.emit('ping', 'allowed');
-      await waitForExpectation(() => {
-        expect(state.messages).toEqual(['allowed']);
-      });
+      await messageHandled.promise;
+      expect(state.messages).toEqual(['allowed']);
 
       expect(state.connectCount).toBe(1);
     } finally {
@@ -1088,6 +1226,7 @@ describe('@fluojs/socket.io', () => {
 
   it('accepts connection and message guards that return undefined', async () => {
     const guardCalls: string[] = [];
+    const messageHandled = createDeferred<void>();
 
     class GatewayState {
       connectCount = 0;
@@ -1107,6 +1246,7 @@ describe('@fluojs/socket.io', () => {
       @OnMessage('ping')
       onPing(payload: unknown) {
         this.state.messages.push(payload);
+        messageHandled.resolve();
       }
     }
 
@@ -1141,9 +1281,8 @@ describe('@fluojs/socket.io', () => {
       await onceConnected(activeSocket);
 
       activeSocket.emit('ping', 'accepted');
-      await waitForExpectation(() => {
-        expect(state.messages).toEqual(['accepted']);
-      });
+      await messageHandled.promise;
+      expect(state.messages).toEqual(['accepted']);
 
       expect(state.connectCount).toBe(1);
       expect(guardCalls).toEqual(['connection', 'message:accepted']);
@@ -1154,6 +1293,8 @@ describe('@fluojs/socket.io', () => {
   });
 
   it('rejects guarded message events without invoking gateway handlers', async () => {
+    const messageHandled = createDeferred<void>();
+
     class GatewayState {
       messages: unknown[] = [];
     }
@@ -1166,6 +1307,7 @@ describe('@fluojs/socket.io', () => {
       @OnMessage('ping')
       onPing(payload: unknown) {
         this.state.messages.push(payload);
+        messageHandled.resolve();
       }
     }
 
@@ -1223,9 +1365,8 @@ describe('@fluojs/socket.io', () => {
       expect(state.messages).toEqual([]);
 
       activeSocket.emit('ping', 'allowed');
-      await waitForExpectation(() => {
-        expect(state.messages).toEqual(['allowed']);
-      });
+      await messageHandled.promise;
+      expect(state.messages).toEqual(['allowed']);
 
 
       const disconnected = new Promise((resolve) => activeSocket.once('disconnect', resolve));
@@ -1243,6 +1384,7 @@ describe('@fluojs/socket.io', () => {
 
   it('contains async message-guard rejections inside adapter reporting flow', async () => {
     const loggerEvents: string[] = [];
+    const errorLogged = createDeferred<void>();
     const unhandledRejections: unknown[] = [];
     const onUnhandledRejection = (reason: unknown) => {
       unhandledRejections.push(reason);
@@ -1284,6 +1426,9 @@ describe('@fluojs/socket.io', () => {
 
     const errorLog = vi.spyOn(console, 'error').mockImplementation((message: unknown, error?: unknown) => {
       loggerEvents.push(`${String(message)}:${error instanceof Error ? error.message : 'none'}`);
+      if (stripAnsi(String(message)).includes('[SocketIoLifecycleService] Socket.IO message guard for event ping on socket')) {
+        errorLogged.resolve();
+      }
     });
     const { adapter, app } = await createNodejsSocketIoApplication(AppModule);
     const state = await app.container.resolve<GatewayState>(GatewayState);
@@ -1307,14 +1452,13 @@ describe('@fluojs/socket.io', () => {
       expect(rejectedAck).toEqual({ data: { code: 'AUTH_REQUIRED' }, error: 'Forbidden event.' });
       expect(state.messages).toEqual([]);
       expect(unhandledRejections).toEqual([]);
-      await waitForExpectation(() => {
-        expect(
-          loggerEvents.some((event) =>
-            stripAnsi(event).includes('[SocketIoLifecycleService] Socket.IO message guard for event ping on socket'),
-          ),
-        ).toBe(true);
-        expect(loggerEvents.some((event) => event.includes('Forbidden event.'))).toBe(true);
-      });
+      await errorLogged.promise;
+      expect(
+        loggerEvents.some((event) =>
+          stripAnsi(event).includes('[SocketIoLifecycleService] Socket.IO message guard for event ping on socket'),
+        ),
+      ).toBe(true);
+      expect(loggerEvents.some((event) => event.includes('Forbidden event.'))).toBe(true);
     } finally {
       errorLog.mockRestore();
       process.off('unhandledRejection', onUnhandledRejection);
@@ -1439,6 +1583,8 @@ describe('@fluojs/socket.io', () => {
 
   for (const scenario of supportedSocketIoAdapterScenarios) {
     it(`boots a real ${scenario.name} app and handles connect, message, room broadcast, and disconnect`, async () => {
+    const disconnectHandled = createDeferred<void>();
+
     class GatewayState {
       connectCount = 0;
       disconnectCount = 0;
@@ -1472,6 +1618,7 @@ describe('@fluojs/socket.io', () => {
       onDisconnect(_socket: Socket, reason: string) {
         this.state.disconnectCount += 1;
         this.state.disconnectReason = reason;
+        disconnectHandled.resolve();
       }
     }
 
@@ -1516,10 +1663,9 @@ describe('@fluojs/socket.io', () => {
 
         expect(await disconnected).toBe('io client disconnect');
 
-        await waitForExpectation(() => {
-          expect(state.disconnectCount).toBe(1);
-          expect(state.disconnectReason).toBe('client namespace disconnect');
-        });
+        await disconnectHandled.promise;
+        expect(state.disconnectCount).toBe(1);
+        expect(state.disconnectReason).toBe('client namespace disconnect');
       } finally {
         socket?.close();
         await app.close();
@@ -1565,6 +1711,7 @@ describe('@fluojs/socket.io', () => {
 
   it('buffers messages and disconnects until async connect handlers complete', async () => {
     const connected = createDeferred<void>();
+    const disconnectHandled = createDeferred<void>();
 
     class GatewayState {
       disconnects = 0;
@@ -1589,6 +1736,7 @@ describe('@fluojs/socket.io', () => {
       @OnDisconnect()
       onDisconnect() {
         this.state.disconnects += 1;
+        disconnectHandled.resolve();
       }
     }
 
@@ -1619,10 +1767,9 @@ describe('@fluojs/socket.io', () => {
       await disconnected;
 
       connected.resolve();
-      await waitForExpectation(() => {
-        expect(state.messages).toEqual(['early']);
-        expect(state.disconnects).toBe(1);
-      });
+      await disconnectHandled.promise;
+      expect(state.messages).toEqual(['early']);
+      expect(state.disconnects).toBe(1);
 
     } finally {
       socket?.close();
@@ -1633,6 +1780,7 @@ describe('@fluojs/socket.io', () => {
 
   it('runs message guards for buffered pre-connect events before replaying handlers', async () => {
     const connected = createDeferred<void>();
+    const messageHandled = createDeferred<void>();
 
     class GatewayState {
       messages: unknown[] = [];
@@ -1651,6 +1799,7 @@ describe('@fluojs/socket.io', () => {
       @OnMessage('ping')
       onPing(payload: unknown) {
         this.state.messages.push(payload);
+        messageHandled.resolve();
       }
     }
 
@@ -1691,9 +1840,8 @@ describe('@fluojs/socket.io', () => {
       activeSocket.emit('ping', 'allowed');
 
       connected.resolve();
-      await waitForExpectation(() => {
-        expect(state.messages).toEqual(['allowed']);
-      });
+      await messageHandled.promise;
+      expect(state.messages).toEqual(['allowed']);
 
       expect(await rejectedAck).toEqual({ data: { code: 'BUFFERED_REJECTED' }, error: 'Buffered event rejected.' });
     } finally {
@@ -1703,7 +1851,7 @@ describe('@fluojs/socket.io', () => {
     }
   });
 
-  it('drops oldest pre-connect socket.io messages once the pending buffer limit is reached', () => {
+  it('drops oldest pre-connect socket.io messages by default once the pending buffer limit is reached', () => {
     const loggerEvents: string[] = [];
     const service = new SocketIoLifecycleService(
       {} as never,
@@ -1718,7 +1866,6 @@ describe('@fluojs/socket.io', () => {
       {
         buffer: {
           maxPendingMessagesPerSocket: 2,
-          overflowPolicy: 'drop-oldest',
         },
         transports: ['websocket'],
       },
@@ -1753,7 +1900,7 @@ describe('@fluojs/socket.io', () => {
     expect(loggerEvents.some((event) => event.includes('dropped the oldest pending message'))).toBe(true);
   });
 
-  it('removes errored sockets from the registry and logs the error', () => {
+  it('keeps recoverable errored sockets in the registry and logs the error', () => {
     const loggerEvents: string[] = [];
     const service = new SocketIoLifecycleService(
       {} as never,
@@ -1798,7 +1945,7 @@ describe('@fluojs/socket.io', () => {
 
     listeners.error?.(new Error('socket exploded'));
 
-    expect(socketRegistry.has(socket.id)).toBe(false);
+    expect(socketRegistry.has(socket.id)).toBe(true);
     expect(loggerEvents).toContain('error:SocketIoLifecycleService:Socket.IO gateway socket emitted an error.:socket exploded');
   });
 

--- a/packages/socket.io/src/shutdown-lifecycle.test.ts
+++ b/packages/socket.io/src/shutdown-lifecycle.test.ts
@@ -39,14 +39,20 @@ describe('SocketIoLifecycleService shutdown state retention', () => {
         throw new Error('force disconnect failed');
       },
     };
+    const retainedSocket = { id: 'socket-1' };
+    const retainedAttachment = { path: '/chat' };
 
     Reflect.set(service, 'io', io);
+    Reflect.set(service, 'attachments', [retainedAttachment]);
+    (Reflect.get(service, 'socketRegistry') as Map<string, unknown>).set('socket-1', retainedSocket);
 
     const closePromise = service.onApplicationShutdown();
     await vi.advanceTimersByTimeAsync(25);
     await closePromise;
 
     expect(Reflect.get(service, 'io')).toBe(io);
+    expect(Reflect.get(service, 'attachments')).toEqual([retainedAttachment]);
+    expect(Reflect.get(service, 'socketRegistry')).toEqual(new Map([['socket-1', retainedSocket]]));
     expect(loggerEvents).toEqual([
       'Failed to close Socket.IO server within 25ms; retaining managed Socket.IO state for shutdown retry.',
     ]);
@@ -82,14 +88,18 @@ describe('SocketIoLifecycleService shutdown state retention', () => {
         }
       },
     };
+    const retainedSocket = { id: 'socket-1' };
 
     Reflect.set(service, 'io', io);
+    Reflect.set(service, 'attachments', [{ path: '/chat' }]);
+    (Reflect.get(service, 'socketRegistry') as Map<string, unknown>).set('socket-1', retainedSocket);
 
     const firstClose = service.onApplicationShutdown();
     await vi.advanceTimersByTimeAsync(25);
     await firstClose;
 
     expect(Reflect.get(service, 'io')).toBe(io);
+    expect(Reflect.get(service, 'socketRegistry')).toEqual(new Map([['socket-1', retainedSocket]]));
 
     const secondClose = service.onApplicationShutdown();
     expect(closeCallbacks).toHaveLength(2);
@@ -102,6 +112,8 @@ describe('SocketIoLifecycleService shutdown state retention', () => {
     await secondClose;
 
     expect(Reflect.get(service, 'io')).toBeUndefined();
+    expect(Reflect.get(service, 'attachments')).toEqual([]);
+    expect(Reflect.get(service, 'socketRegistry')).toEqual(new Map());
     expect(loggerEvents).toEqual([
       'Failed to close Socket.IO server within 25ms; retaining managed Socket.IO state for shutdown retry.',
     ]);


### PR DESCRIPTION
## Summary

Close the Socket.IO lifecycle regression gaps around recoverable socket errors, Bun handshake request shape, shutdown retry bookkeeping, and docs parity.

Linked context: Closes #2431

## Changes

- Preserve active Socket.IO socket registry entries when a recoverable socket `error` event is emitted.
- Convert Bun Socket.IO handshake references into Web-standard `Request` instances before guard and handler contexts observe them.
- Add runtime regression coverage for Node-backed and Bun handshake request shapes, shutdown retry state retention, default pre-connect overflow policy, and event-driven async assertions.
- Document Socket.IO shutdown ownership and retry-state retention in the English and Korean intermediate Socket.IO chapter.
- Add a patch changeset for the consumer-visible `@fluojs/socket.io` behavior changes.

## Testing

- `pnpm --filter @fluojs/socket.io test`
- `pnpm --filter @fluojs/socket.io typecheck`
- `pnpm --filter @fluojs/socket.io... build`
- `pnpm docs:sync-check`
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main`
- `pnpm exec biome lint packages/socket.io/src/adapter.ts packages/socket.io/src/module.test.ts packages/socket.io/src/shutdown-lifecycle.test.ts`

Notes:
- TypeScript LSP diagnostics could not run because the TypeScript LSP server is not installed and installation was previously declined.
- Earlier full-repo `pnpm lint` was blocked by unrelated pre-existing lint failures in `packages/config/src/reload-module.test.ts`.
- Earlier full `pnpm verify:release-readiness` reached unrelated `packages/cli/src/cli.test.ts` sandbox failure after the Socket.IO-specific gates passed.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [ ] Changed public exports include a source-level summary.
- [ ] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No public exports were added or changed.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

The shutdown retry behavior is documented in the Socket.IO book chapter with EN/KO parity; runtime invariants are covered in `packages/socket.io/src/module.test.ts` and `packages/socket.io/src/shutdown-lifecycle.test.ts`.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by the applicable platform harness tests, such as `createPlatformConformanceHarness(...)` for platform component contracts or `createHttpAdapterPortabilityHarness(...)` for HTTP adapter portability contracts.

No platform contract docs or package README alignment/conformance claims changed.