### PR TITLE
Resolve #2433: harden Drizzle status handle contract

### DIFF
--- a/.changeset/harden-drizzle-status-handle.md
+++ b/.changeset/harden-drizzle-status-handle.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/drizzle": patch
+---
+
+Align the public Drizzle handle provider type with its documented platform status snapshot contract and add regression coverage for Drizzle transaction target resolution and facade forwarding.

--- a/packages/drizzle/src/module.test.ts
+++ b/packages/drizzle/src/module.test.ts
@@ -1,7 +1,7 @@
 import { Global, Inject, Module } from '@fluojs/core';
 import { bootstrapApplication, defineModule } from '@fluojs/runtime';
 import { describe, expect, it, vi } from 'vitest';
-
+import type { DrizzleHandleProvider } from './index.js';
 import {
   createDrizzlePlatformStatusSnapshot,
   DRIZZLE_DATABASE,
@@ -642,13 +642,15 @@ describe('@fluojs/drizzle', () => {
     const syncApp = await bootstrapApplication({
       rootModule: StrictSyncAppModule,
     });
-    const syncDrizzle = await syncApp.container.resolve(DrizzleDatabase<typeof database>);
+    try {
+      const syncDrizzle = await syncApp.container.resolve(DrizzleDatabase<typeof database>);
 
-    await expect(syncDrizzle.transaction(async () => 'ok')).rejects.toThrow(
-      'Transaction not supported: Drizzle database does not implement transaction.',
-    );
-
-    await syncApp.close();
+      await expect(syncDrizzle.transaction(async () => 'ok')).rejects.toThrow(
+        'Transaction not supported: Drizzle database does not implement transaction.',
+      );
+    } finally {
+      await syncApp.close();
+    }
 
     const StrictAsyncModule = DrizzleModule.forRootAsync({
       useFactory: () => ({
@@ -666,13 +668,15 @@ describe('@fluojs/drizzle', () => {
     const asyncApp = await bootstrapApplication({
       rootModule: StrictAsyncAppModule,
     });
-    const asyncDrizzle = await asyncApp.container.resolve(DrizzleDatabase<typeof database>);
+    try {
+      const asyncDrizzle = await asyncApp.container.resolve(DrizzleDatabase<typeof database>);
 
-    await expect(asyncDrizzle.requestTransaction(async () => 'ok')).rejects.toThrow(
-      'Transaction not supported: Drizzle database does not implement transaction.',
-    );
-
-    await asyncApp.close();
+      await expect(asyncDrizzle.requestTransaction(async () => 'ok')).rejects.toThrow(
+        'Transaction not supported: Drizzle database does not implement transaction.',
+      );
+    } finally {
+      await asyncApp.close();
+    }
   });
 
   it('defaults strictTransactions to false for sync and async module entrypoints', async () => {
@@ -1184,6 +1188,33 @@ describe('@fluojs/drizzle', () => {
     expect(snapshot().details.lifecycleState).toBe('stopped');
   });
 
+  it('forwards facade query methods to the root handle outside transactions and ambient handle inside transactions', async () => {
+    const events: string[] = [];
+    const transactionDatabase = {
+      query() {
+        events.push('tx:query');
+        return 'tx-result';
+      },
+    };
+    const database = {
+      query() {
+        events.push('root:query');
+        return 'root-result';
+      },
+      async transaction<T>(callback: (value: typeof transactionDatabase) => Promise<T>): Promise<T> {
+        events.push('transaction:start');
+        const result = await callback(transactionDatabase);
+        events.push('transaction:end');
+        return result;
+      },
+    };
+    const facade = DrizzleDatabase.createFacade<typeof database, typeof transactionDatabase>(database);
+
+    expect(facade.query()).toBe('root-result');
+    await expect(facade.transaction(async () => facade.query())).resolves.toBe('tx-result');
+    expect(events).toEqual(['root:query', 'transaction:start', 'tx:query', 'transaction:end']);
+  });
+
   it('reports live createPlatformStatusSnapshot lifecycle transitions through the module facade', async () => {
     const database = {};
     const disposeStarted = createDeferred();
@@ -1402,14 +1433,16 @@ describe('DrizzleModule.forRootAsync', () => {
 
     const app = await bootstrapApplication({ rootModule: AppModule });
     const drizzle = await app.container.resolve(DrizzleDatabase);
-    const handleProvider = await app.container.resolve(DRIZZLE_HANDLE_PROVIDER);
+    try {
+      const handleProvider = await app.container.resolve<DrizzleHandleProvider<typeof database, typeof transactionDatabase>>(
+        DRIZZLE_HANDLE_PROVIDER,
+      );
 
-    expect(handleProvider).toBe(drizzle);
-    expect((handleProvider as DrizzleDatabase<typeof database, typeof transactionDatabase>).createPlatformStatusSnapshot()).toEqual(
-      drizzle.createPlatformStatusSnapshot(),
-    );
-
-    await app.close();
+      expect(handleProvider).toBe(drizzle);
+      expect(handleProvider.createPlatformStatusSnapshot()).toEqual(drizzle.createPlatformStatusSnapshot());
+    } finally {
+      await app.close();
+    }
   });
 
   it('factory returning a promise resolves the database correctly', async () => {
@@ -1424,11 +1457,13 @@ describe('DrizzleModule.forRootAsync', () => {
     defineModule(AppModule, { imports: [drizzleModule] });
 
     const app = await bootstrapApplication({ rootModule: AppModule });
-    const db = await app.container.resolve(DrizzleDatabase);
+    try {
+      const db = await app.container.resolve(DrizzleDatabase);
 
-    expect(db).toBeInstanceOf(DrizzleDatabase);
-
-    await app.close();
+      expect(db).toBeInstanceOf(DrizzleDatabase);
+    } finally {
+      await app.close();
+    }
   });
 
   it('resolves async options independently for each application container', async () => {

--- a/packages/drizzle/src/transaction-decorator.red.test.ts
+++ b/packages/drizzle/src/transaction-decorator.red.test.ts
@@ -184,16 +184,18 @@ describe('@fluojs/drizzle Transaction decorator contract (RED - pending Task 8 i
     });
 
     const app = await bootstrapApplication({ rootModule: AppModule });
-    const service = await app.container.resolve(UserService);
+    try {
+      const service = await app.container.resolve(UserService);
 
-    await expect(service.outer('grace@example.com')).resolves.toEqual({
-      email: 'grace@example.com',
-      id: 'tx-user',
-    });
+      await expect(service.outer('grace@example.com')).resolves.toEqual({
+        email: 'grace@example.com',
+        id: 'tx-user',
+      });
 
-    expect(events).toEqual(['transaction:start', 'tx:insert:users', 'tx:values:grace@example.com', 'transaction:end']);
-
-    await app.close();
+      expect(events).toEqual(['transaction:start', 'tx:insert:users', 'tx:values:grace@example.com', 'transaction:end']);
+    } finally {
+      await app.close();
+    }
   });
 
   it('rejects nested @Transaction() calls with options while a context is already active', async () => {
@@ -268,13 +270,15 @@ describe('@fluojs/drizzle Transaction decorator contract (RED - pending Task 8 i
     });
 
     const app = await bootstrapApplication({ rootModule: AppModule });
-    const service = await app.container.resolve(UserService);
+    try {
+      const service = await app.container.resolve(UserService);
 
-    await expect(service.outer('linus@example.com')).rejects.toThrow();
+      await expect(service.outer('linus@example.com')).rejects.toThrow();
 
-    expect(events).toEqual(['transaction:start']);
-
-    await app.close();
+      expect(events).toEqual(['transaction:start']);
+    } finally {
+      await app.close();
+    }
   });
 
   it('forwards @Transaction(...) options to the outer transaction boundary', async () => {
@@ -308,12 +312,14 @@ describe('@fluojs/drizzle Transaction decorator contract (RED - pending Task 8 i
     });
 
     const app = await bootstrapApplication({ rootModule: AppModule });
-    const service = await app.container.resolve(UserService);
+    try {
+      const service = await app.container.resolve(UserService);
 
-    await expect(service.create()).resolves.toBe(transactionDatabase);
-    expect(optionsCalls).toEqual([{ isolationLevel: 'Serializable' }]);
-
-    await app.close();
+      await expect(service.create()).resolves.toBe(transactionDatabase);
+      expect(optionsCalls).toEqual([{ isolationLevel: 'Serializable' }]);
+    } finally {
+      await app.close();
+    }
   });
 });
 
@@ -367,8 +373,23 @@ describe('@fluojs/drizzle Transaction decorator — named/accessor contract', ()
       }
     }
 
+    class SelfFallbackService {
+      async transaction<T>(callback: () => Promise<T>): Promise<T> {
+        events.push('self:transaction:start');
+        const result = await callback();
+        events.push('self:transaction:end');
+        return result;
+      }
+
+      @Transaction()
+      async run() {
+        events.push('self-fallback:work');
+      }
+    }
+
     await new DbFirstService().run();
     await new DirectBeforeNestedService().run();
+    await new SelfFallbackService().run();
 
     expect(events).toEqual([
       'primary:transaction:start',
@@ -377,6 +398,9 @@ describe('@fluojs/drizzle Transaction decorator — named/accessor contract', ()
       'direct:transaction:start',
       'direct-before-nested:work',
       'direct:transaction:end',
+      'self:transaction:start',
+      'self-fallback:work',
+      'self:transaction:end',
     ]);
   });
 

--- a/packages/drizzle/src/types.ts
+++ b/packages/drizzle/src/types.ts
@@ -1,4 +1,5 @@
 import type { MaybePromise } from '@fluojs/core';
+import type { PersistencePlatformStatusSnapshot } from '@fluojs/runtime';
 
 type DrizzleTransactionCallback<TTransactionDatabase, TResult> = (database: TTransactionDatabase) => Promise<TResult>;
 
@@ -48,6 +49,8 @@ export interface DrizzleModuleOptions<TDatabase extends DrizzleDatabaseLike<TTra
  * @typeParam TTransactionOptions Options forwarded to `database.transaction(...)`.
  */
 export interface DrizzleHandleProvider<TDatabase extends DrizzleDatabaseLike<TTransactionDatabase, TTransactionOptions>, TTransactionDatabase = TDatabase, TTransactionOptions = unknown> {
+  /** Produces the platform diagnostics snapshot for health and readiness integrations. */
+  createPlatformStatusSnapshot(): PersistencePlatformStatusSnapshot;
   /** Returns the ambient transaction database when present, or the root Drizzle handle otherwise. */
   current(): TDatabase | TTransactionDatabase;
   /**

--- a/packages/drizzle/src/vertical-slice.test.ts
+++ b/packages/drizzle/src/vertical-slice.test.ts
@@ -1,18 +1,17 @@
-import { describe, expect, it } from 'vitest';
-
 import { Inject } from '@fluojs/core';
-import { bootstrapApplication, defineModule } from '@fluojs/runtime';
 import {
   Controller,
-  FromBody,
-  Post,
-  RequestDto,
-  HttpCode,
   type FrameworkRequest,
   type FrameworkResponse,
+  FromBody,
+  HttpCode,
+  Post,
+  RequestDto,
 } from '@fluojs/http';
+import { bootstrapApplication, defineModule } from '@fluojs/runtime';
+import { describe, expect, it } from 'vitest';
 
-import { DrizzleModule, DrizzleDatabase, Transaction, type DrizzleDatabaseFacade } from './index.js';
+import { DrizzleDatabase, type DrizzleDatabaseFacade, DrizzleModule, Transaction } from './index.js';
 
 function createResponse(events?: string[]): FrameworkResponse & { body?: unknown } {
   return {
@@ -253,16 +252,18 @@ describe('@fluojs/drizzle service boundary primary flow', () => {
     });
 
     const app = await bootstrapApplication({ rootModule: AppModule });
-    const response = createResponse(events);
+    try {
+      const response = createResponse(events);
 
-    await app.dispatch(
-      createRequest('/controller-compat/users', 'POST', { email: 'grace@example.com', name: 'Grace' }),
-      response,
-    );
+      await app.dispatch(
+        createRequest('/controller-compat/users', 'POST', { email: 'grace@example.com', name: 'Grace' }),
+        response,
+      );
 
-    expect(response.body).toEqual({ email: 'grace@example.com', id: 'controller-tx-user', name: 'Grace' });
-    expect(events).toEqual(['transaction:start', 'tx:insert:grace@example.com', 'transaction:commit', 'response:send']);
-
-    await app.close();
+      expect(response.body).toEqual({ email: 'grace@example.com', id: 'controller-tx-user', name: 'Grace' });
+      expect(events).toEqual(['transaction:start', 'tx:insert:grace@example.com', 'transaction:commit', 'response:send']);
+    } finally {
+      await app.close();
+    }
   });
 });


### PR DESCRIPTION
## Summary

Align the public `@fluojs/drizzle` status handle contract with the README-documented diagnostics surface and harden related transaction/facade regression coverage.

Linked context: Closes #2433

## Changes

- Added `createPlatformStatusSnapshot()` to the exported `DrizzleHandleProvider` interface.
- Added regression coverage for `DrizzleDatabaseFacade` forwarding to the root handle outside transactions and the ambient handle inside transactions.
- Added regression coverage for `@Transaction()` falling back to the decorated instance itself when no `this.db`, direct property, or nested `.db` candidate exists.
- Wrapped targeted app-backed Drizzle tests in `finally` cleanup so assertion failures still close the app.
- Added a patch changeset for the public `@fluojs/drizzle` type-surface alignment.

## Testing

- `pnpm install` in the dedicated worktree to prepare workspace dependencies.
- `pnpm exec biome check packages/drizzle/src/types.ts packages/drizzle/src/module.test.ts packages/drizzle/src/vertical-slice.test.ts packages/drizzle/src/transaction-decorator.red.test.ts` passed.
- Built workspace dependency packages required for Drizzle verification: `@fluojs/core`, `@fluojs/di`, `@fluojs/validation`, `@fluojs/http`, and `@fluojs/runtime`.
- `pnpm --dir packages/drizzle build` passed.
- `pnpm --dir packages/drizzle typecheck` passed.
- `pnpm --dir packages/drizzle test` passed: 5 test files, 52 tests.
- `lsp_diagnostics` could not run because the TypeScript LSP server is not installed and the prior install prompt was declined; package build/typecheck covered changed TypeScript files.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

`DrizzleHandleProvider.createPlatformStatusSnapshot()` is documented with source TSDoc; it has no parameters and returns the shared `PersistencePlatformStatusSnapshot` type.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

The README already documented the status snapshot and transaction target/facade behavior; this PR aligns the public type and executable tests with that existing contract.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests, such as `createPlatformConformanceHarness(...)` for platform component contracts or `createHttpAdapterPortabilityHarness(...)` for HTTP adapter portability contracts.

No governance docs changed. Package README EN/KO already described the relevant Drizzle contracts, and this PR adds package-level regression evidence instead of changing SSOT docs.