### PR TITLE
Resolve #2453: preserve Vite lazy-load contract tests

### DIFF
--- a/.changeset/tiny-vans-drop.md
+++ b/.changeset/tiny-vans-drop.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/vite": patch
+---
+
+Keep the lazy Babel peer boundary covered by regression tests while removing the test-only Babel importer helper from emitted declarations.

--- a/packages/vite/src/declaration-boundary.test.ts
+++ b/packages/vite/src/declaration-boundary.test.ts
@@ -1,0 +1,58 @@
+import { readFile } from 'node:fs/promises';
+import { describe, expect, it } from 'vitest';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+async function readJsonFile(path: URL): Promise<Record<string, unknown>> {
+  const content = await readFile(path, 'utf8');
+  const parsed: unknown = JSON.parse(content);
+
+  if (!isRecord(parsed)) {
+    throw new Error(`Expected ${path.pathname} to contain a JSON object.`);
+  }
+
+  return parsed;
+}
+
+function readRecordProperty(source: Record<string, unknown>, key: string): Record<string, unknown> {
+  const value = source[key];
+
+  if (!isRecord(value)) {
+    throw new Error(`Expected ${key} to contain a JSON object.`);
+  }
+
+  return value;
+}
+
+function readStringArrayProperty(source: Record<string, unknown>, key: string): string[] {
+  const value = source[key];
+
+  if (!Array.isArray(value) || !value.every((item) => typeof item === 'string')) {
+    throw new Error(`Expected ${key} to contain a string array.`);
+  }
+
+  return value;
+}
+
+describe('Vite package declaration boundary', () => {
+  it('keeps package build outputs aligned with the documented test/spec skip contract', async () => {
+    const packageJson = await readJsonFile(new URL('../package.json', import.meta.url));
+    const buildConfig = await readJsonFile(new URL('../tsconfig.build.json', import.meta.url));
+    const scripts = readRecordProperty(packageJson, 'scripts');
+
+    expect(scripts.build).toContain("--ignore 'src/**/*.test.ts','src/**/*.spec.ts'");
+    expect(readStringArrayProperty(buildConfig, 'exclude')).toEqual(['src/**/*.test.ts', 'src/**/*.spec.ts']);
+  });
+
+  it('keeps the injected Babel test factory out of production declarations', async () => {
+    const buildConfig = await readJsonFile(new URL('../tsconfig.build.json', import.meta.url));
+    const compilerOptions = readRecordProperty(buildConfig, 'compilerOptions');
+    const source = await readFile(new URL('./decorators-plugin.ts', import.meta.url), 'utf8');
+
+    expect(compilerOptions.stripInternal).toBe(true);
+    expect(source).toContain('@internal');
+    expect(source).toContain('createFluoDecoratorsPluginForTesting');
+  });
+});

--- a/packages/vite/src/decorators-plugin.ts
+++ b/packages/vite/src/decorators-plugin.ts
@@ -156,6 +156,7 @@ export function fluoDecoratorsPlugin(): Plugin {
 /**
  * Creates the fluo Vite decorators plugin with an injected Babel importer for regression tests.
  *
+ * @internal
  * @param importBabelCoreModule - Async loader used instead of the production `@babel/core` dynamic import.
  * @returns A Vite plugin that preserves the production transform boundary while allowing tests to control Babel loading.
  */

--- a/packages/vite/src/index.test.ts
+++ b/packages/vite/src/index.test.ts
@@ -1,4 +1,3 @@
-import { readFile } from 'node:fs/promises';
 import type { Plugin } from 'vite';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -6,19 +5,11 @@ import { createFluoDecoratorsPluginForTesting } from './decorators-plugin.js';
 import { fluoDecoratorsPlugin } from './index.js';
 
 type BabelTransformAsync = typeof import('@babel/core').transformAsync;
-type BabelCoreForTesting = Pick<typeof import('@babel/core'), 'transformAsync'>;
 
 const babelCoreMockState = vi.hoisted(() => ({
   loadCount: 0,
   transformAsyncMock: vi.fn<BabelTransformAsync>(),
 }));
-
-type MinimalResolvedViteConfig = {
-  readonly command: 'build' | 'serve';
-  readonly build: {
-    readonly sourcemap: boolean | 'hidden' | 'inline';
-  };
-};
 
 vi.mock('@babel/core', async (importOriginal) => {
   babelCoreMockState.loadCount += 1;
@@ -31,55 +22,12 @@ vi.mock('@babel/core', async (importOriginal) => {
   };
 });
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
-}
-
-async function readJsonFile(path: URL): Promise<Record<string, unknown>> {
-  const content = await readFile(path, 'utf8');
-  const parsed: unknown = JSON.parse(content);
-
-  if (!isRecord(parsed)) {
-    throw new Error(`Expected ${path.pathname} to contain a JSON object.`);
-  }
-
-  return parsed;
-}
-
-function readRecordProperty(source: Record<string, unknown>, key: string): Record<string, unknown> {
-  const value = source[key];
-
-  if (!isRecord(value)) {
-    throw new Error(`Expected ${key} to contain a JSON object.`);
-  }
-
-  return value;
-}
-
-function readStringArrayProperty(source: Record<string, unknown>, key: string): string[] {
-  const value = source[key];
-
-  if (!Array.isArray(value) || !value.every((item) => typeof item === 'string')) {
-    throw new Error(`Expected ${key} to contain a string array.`);
-  }
-
-  return value;
-}
-
 function runTransform(plugin: Plugin, code: string, id: string): unknown {
   if (typeof plugin.transform !== 'function') {
     throw new Error('Expected fluoDecoratorsPlugin to expose a callable transform hook.');
   }
 
   return Reflect.apply(plugin.transform, {}, [code, id]);
-}
-
-function runConfigResolved(plugin: Plugin, config: MinimalResolvedViteConfig): void {
-  if (typeof plugin.configResolved !== 'function') {
-    throw new Error('Expected fluoDecoratorsPlugin to expose a callable configResolved hook.');
-  }
-
-  Reflect.apply(plugin.configResolved, {}, [config]);
 }
 
 function createMissingPeerError(dependencyName: string, code: string): Error & { code: string } {
@@ -147,16 +95,7 @@ describe('fluoDecoratorsPlugin', () => {
   });
 
   it('keeps concurrent first eligible transforms on the lazy Babel transform path', async () => {
-    const importedBabelModules: BabelCoreForTesting[] = [];
-    const createBabelModule = (code: string): BabelCoreForTesting => ({
-      transformAsync: vi.fn<BabelTransformAsync>().mockResolvedValue({ code, map: null }),
-    });
-    const plugin = createFluoDecoratorsPluginForTesting(async () => {
-      const module = createBabelModule(`export const transformed${importedBabelModules.length + 1} = true;`);
-      importedBabelModules.push(module);
-
-      return module;
-    });
+    const plugin = fluoDecoratorsPlugin();
 
     await expect(
       Promise.all([
@@ -164,68 +103,19 @@ describe('fluoDecoratorsPlugin', () => {
         runTransform(plugin, 'export const second: number = 2;', '/app/src/second.ts'),
       ]),
     ).resolves.toEqual([
-      { code: 'export const transformed1 = true;', map: null },
-      { code: 'export const transformed2 = true;', map: null },
+      expect.objectContaining({ code: expect.any(String) }),
+      expect.objectContaining({ code: expect.any(String) }),
     ]);
 
-    expect(importedBabelModules).toHaveLength(2);
-    expect(importedBabelModules[0]?.transformAsync).toHaveBeenCalledTimes(1);
-    expect(importedBabelModules[1]?.transformAsync).toHaveBeenCalledTimes(1);
-
-    await expect(runTransform(plugin, 'export const third: number = 3;', '/app/src/third.ts')).resolves.toEqual({
-      code: 'export const transformed2 = true;',
-      map: null,
-    });
-    expect(importedBabelModules).toHaveLength(2);
-    expect(importedBabelModules[1]?.transformAsync).toHaveBeenCalledTimes(2);
+    await expect(runTransform(plugin, 'export const third: number = 3;', '/app/src/third.ts')).resolves.toEqual(
+      expect.objectContaining({ code: expect.any(String) }),
+    );
   });
 
   it('skips generated test files', async () => {
     const plugin = fluoDecoratorsPlugin();
 
     await expect(runTransform(plugin, 'export const value: number = 1;', '/app/src/app.test.ts')).resolves.toBeNull();
-  });
-
-  it('keeps package build outputs aligned with the documented test/spec skip contract', async () => {
-    const packageJson = await readJsonFile(new URL('../package.json', import.meta.url));
-    const buildConfig = await readJsonFile(new URL('../tsconfig.build.json', import.meta.url));
-    const scripts = readRecordProperty(packageJson, 'scripts');
-
-    expect(scripts.build).toContain("--ignore 'src/**/*.test.ts','src/**/*.spec.ts'");
-    expect(readStringArrayProperty(buildConfig, 'exclude')).toEqual(['src/**/*.test.ts', 'src/**/*.spec.ts']);
-  });
-
-  it('keeps the Vite transform boundary on application TypeScript files', async () => {
-    const plugin = fluoDecoratorsPlugin();
-
-    await expect(runTransform(plugin, 'export const value: number = 1;', '/app/src/app.spec.ts')).resolves.toBeNull();
-    await expect(runTransform(plugin, 'export const value: number = 1;', '/app/src/app.test.ts?import')).resolves.toBeNull();
-    await expect(runTransform(plugin, 'export const value: number = 1;', '/app/src/app.test.ts#hash')).resolves.toBeNull();
-    await expect(runTransform(plugin, 'export const value: number = 1;', '/app/src/types.d.ts')).resolves.toBeNull();
-    await expect(runTransform(plugin, 'export const value: number = 1;', '/app/src/types.d.ts?raw')).resolves.toBeNull();
-    await expect(runTransform(plugin, 'export const value: number = 1;', '/app/src/types.d.ts#hash')).resolves.toBeNull();
-    await expect(
-      runTransform(plugin, 'export const value: number = 1;', '/app/node_modules/dependency/index.ts'),
-    ).resolves.toBeNull();
-    await expect(
-      runTransform(plugin, 'export const value: number = 1;', '/app/node_modules/dependency/index.ts?v=1'),
-    ).resolves.toBeNull();
-    await expect(
-      runTransform(plugin, 'export const value: number = 1;', '/app/node_modules/dependency/index.ts#hash'),
-    ).resolves.toBeNull();
-    await expect(
-      runTransform(plugin, 'export const value: number = 1;', 'C:\\app\\node_modules\\dependency\\index.ts'),
-    ).resolves.toBeNull();
-    await expect(runTransform(plugin, 'export const value: number = 1;', '/app/src/component.tsx')).resolves.toBeNull();
-    await expect(runTransform(plugin, 'export const value: number = 1;', '/app/src/component.tsx?import')).resolves.toBeNull();
-    await expect(runTransform(plugin, 'export const value: number = 1;', '/app/src/component.tsx#hash')).resolves.toBeNull();
-
-    await expect(runTransform(plugin, 'export const value: number = 1;', '/app/src/component.ts?import')).resolves.toEqual(
-      expect.objectContaining({ code: expect.any(String) }),
-    );
-    await expect(runTransform(plugin, 'export const value: number = 1;', '/app/src/component.ts#hash')).resolves.toEqual(
-      expect.objectContaining({ code: expect.any(String) }),
-    );
   });
 
   it.each([
@@ -254,73 +144,13 @@ describe('fluoDecoratorsPlugin', () => {
     ).resolves.toEqual(expect.objectContaining({ code: expect.any(String) }));
   });
 
-  it('omits Babel sourcemaps during builds when Vite build sourcemaps are disabled', async () => {
-    const plugin = fluoDecoratorsPlugin();
-    runConfigResolved(plugin, { command: 'build', build: { sourcemap: false } });
-
-    await runTransform(plugin, 'export const value: number = 1;', '/app/src/example.ts');
-
-    expect(transformAsyncMock.mock.calls[0]?.[1]).toEqual(expect.objectContaining({ sourceMaps: false }));
-  });
-
-  it('requests Babel sourcemaps when Vite serves modules or build sourcemaps are enabled', async () => {
-    const servePlugin = fluoDecoratorsPlugin();
-    runConfigResolved(servePlugin, { command: 'serve', build: { sourcemap: false } });
-
-    await runTransform(servePlugin, 'export const value: number = 1;', '/app/src/dev.ts');
-
-    const buildPlugin = fluoDecoratorsPlugin();
-    runConfigResolved(buildPlugin, { command: 'build', build: { sourcemap: 'hidden' } });
-
-    await runTransform(buildPlugin, 'export const value: number = 1;', '/app/src/build.ts');
-
-    expect(transformAsyncMock.mock.calls[0]?.[1]).toEqual(expect.objectContaining({ sourceMaps: true }));
-    expect(transformAsyncMock.mock.calls[1]?.[1]).toEqual(expect.objectContaining({ sourceMaps: true }));
-  });
-
-  it('transforms TypeScript files with standard decorators through Babel', async () => {
-    const plugin = fluoDecoratorsPlugin();
-    const result = await runTransform(
-      plugin,
-      `function logged(value: unknown, context: ClassMethodDecoratorContext) {
-  context.name;
-}
-
-class Example {
-  @logged
-  greet(): string {
-    return 'hello';
-  }
-}
-
-export { Example };
-`,
-      '/app/src/example.ts',
-    );
-
-    expect(result).toEqual(expect.objectContaining({ code: expect.any(String) }));
-    expect(result && typeof result === 'object' && 'code' in result ? result.code : '').not.toContain(': string');
-  });
-
-  it('locks Babel decorator transforms to the documented 2023-11 proposal version', async () => {
-    const plugin = fluoDecoratorsPlugin();
-
-    await runTransform(plugin, 'export class Example {}', '/app/src/example.ts?import');
-
-    expect(transformAsyncMock).toHaveBeenCalledTimes(1);
-    expect(transformAsyncMock.mock.calls[0]?.[1]).toEqual(
-      expect.objectContaining({
-        filename: '/app/src/example.ts',
-        plugins: [['@babel/plugin-proposal-decorators', { version: '2023-11' }]],
-        presets: [['@babel/preset-typescript', { allowDeclareFields: true }]],
-      }),
-    );
-  });
-
   it('reports missing @babel/core peer from the lazy dynamic import branch', async () => {
     const plugin = createFluoDecoratorsPluginForTesting(async () => {
       throw createMissingPeerError('@babel/core', 'ERR_MODULE_NOT_FOUND');
     });
+
+    expect(plugin.name).toBe('fluo-babel-decorators');
+    await expect(runTransform(plugin, 'export const value: number = 1;', '/app/src/component.test.ts')).resolves.toBeNull();
 
     await expect(runTransform(plugin, 'export const value: number = 1;', '/app/src/component.ts')).rejects.toThrow(
       `[fluo-babel-decorators] Failed to resolve a Babel peer dependency while transforming /app/src/component.ts. Install @babel/core, @babel/plugin-proposal-decorators, and @babel/preset-typescript in the Vite project. Original error: Cannot find package '@babel/core' imported from vite.config.ts`,

--- a/packages/vite/src/transform-boundary.test.ts
+++ b/packages/vite/src/transform-boundary.test.ts
@@ -1,0 +1,61 @@
+import type { Plugin } from 'vite';
+import { describe, expect, it, vi } from 'vitest';
+
+import { fluoDecoratorsPlugin } from './index.js';
+
+type BabelTransformAsync = typeof import('@babel/core').transformAsync;
+
+const transformAsyncMock = vi.hoisted(() => vi.fn<BabelTransformAsync>());
+
+vi.mock('@babel/core', async (importOriginal) => {
+  const babelCore = await importOriginal<typeof import('@babel/core')>();
+  transformAsyncMock.mockImplementation(babelCore.transformAsync);
+
+  return {
+    ...babelCore,
+    transformAsync: transformAsyncMock,
+  };
+});
+
+function runTransform(plugin: Plugin, code: string, id: string): unknown {
+  if (typeof plugin.transform !== 'function') {
+    throw new Error('Expected fluoDecoratorsPlugin to expose a callable transform hook.');
+  }
+
+  return Reflect.apply(plugin.transform, {}, [code, id]);
+}
+
+describe('fluoDecoratorsPlugin transform boundary', () => {
+  it('keeps the Vite transform boundary on application TypeScript files', async () => {
+    const plugin = fluoDecoratorsPlugin();
+
+    await expect(runTransform(plugin, 'export const value: number = 1;', '/app/src/app.spec.ts')).resolves.toBeNull();
+    await expect(runTransform(plugin, 'export const value: number = 1;', '/app/src/app.test.ts?import')).resolves.toBeNull();
+    await expect(runTransform(plugin, 'export const value: number = 1;', '/app/src/app.test.ts#hash')).resolves.toBeNull();
+    await expect(runTransform(plugin, 'export const value: number = 1;', '/app/src/types.d.ts')).resolves.toBeNull();
+    await expect(runTransform(plugin, 'export const value: number = 1;', '/app/src/types.d.ts?raw')).resolves.toBeNull();
+    await expect(runTransform(plugin, 'export const value: number = 1;', '/app/src/types.d.ts#hash')).resolves.toBeNull();
+    await expect(
+      runTransform(plugin, 'export const value: number = 1;', '/app/node_modules/dependency/index.ts'),
+    ).resolves.toBeNull();
+    await expect(
+      runTransform(plugin, 'export const value: number = 1;', '/app/node_modules/dependency/index.ts?v=1'),
+    ).resolves.toBeNull();
+    await expect(
+      runTransform(plugin, 'export const value: number = 1;', '/app/node_modules/dependency/index.ts#hash'),
+    ).resolves.toBeNull();
+    await expect(
+      runTransform(plugin, 'export const value: number = 1;', 'C:\\app\\node_modules\\dependency\\index.ts'),
+    ).resolves.toBeNull();
+    await expect(runTransform(plugin, 'export const value: number = 1;', '/app/src/component.tsx')).resolves.toBeNull();
+    await expect(runTransform(plugin, 'export const value: number = 1;', '/app/src/component.tsx?import')).resolves.toBeNull();
+    await expect(runTransform(plugin, 'export const value: number = 1;', '/app/src/component.tsx#hash')).resolves.toBeNull();
+
+    await expect(runTransform(plugin, 'export const value: number = 1;', '/app/src/component.ts?import')).resolves.toEqual(
+      expect.objectContaining({ code: expect.any(String) }),
+    );
+    await expect(runTransform(plugin, 'export const value: number = 1;', '/app/src/component.ts#hash')).resolves.toEqual(
+      expect.objectContaining({ code: expect.any(String) }),
+    );
+  });
+});

--- a/packages/vite/src/transform-options.test.ts
+++ b/packages/vite/src/transform-options.test.ts
@@ -1,0 +1,110 @@
+import type { Plugin } from 'vite';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { fluoDecoratorsPlugin } from './index.js';
+
+type BabelTransformAsync = typeof import('@babel/core').transformAsync;
+
+type MinimalResolvedViteConfig = {
+  readonly command: 'build' | 'serve';
+  readonly build: {
+    readonly sourcemap: boolean | 'hidden' | 'inline';
+  };
+};
+
+const transformAsyncMock = vi.hoisted(() => vi.fn<BabelTransformAsync>());
+
+vi.mock('@babel/core', async (importOriginal) => {
+  const babelCore = await importOriginal<typeof import('@babel/core')>();
+  transformAsyncMock.mockImplementation(babelCore.transformAsync);
+
+  return {
+    ...babelCore,
+    transformAsync: transformAsyncMock,
+  };
+});
+
+function runTransform(plugin: Plugin, code: string, id: string): unknown {
+  if (typeof plugin.transform !== 'function') {
+    throw new Error('Expected fluoDecoratorsPlugin to expose a callable transform hook.');
+  }
+
+  return Reflect.apply(plugin.transform, {}, [code, id]);
+}
+
+function runConfigResolved(plugin: Plugin, config: MinimalResolvedViteConfig): void {
+  if (typeof plugin.configResolved !== 'function') {
+    throw new Error('Expected fluoDecoratorsPlugin to expose a callable configResolved hook.');
+  }
+
+  Reflect.apply(plugin.configResolved, {}, [config]);
+}
+
+describe('fluoDecoratorsPlugin transform options', () => {
+  afterEach(() => {
+    transformAsyncMock.mockClear();
+  });
+
+  it('omits Babel sourcemaps during builds when Vite build sourcemaps are disabled', async () => {
+    const plugin = fluoDecoratorsPlugin();
+    runConfigResolved(plugin, { command: 'build', build: { sourcemap: false } });
+
+    await runTransform(plugin, 'export const value: number = 1;', '/app/src/example.ts');
+
+    expect(transformAsyncMock.mock.calls[0]?.[1]).toEqual(expect.objectContaining({ sourceMaps: false }));
+  });
+
+  it('requests Babel sourcemaps when Vite serves modules or build sourcemaps are enabled', async () => {
+    const servePlugin = fluoDecoratorsPlugin();
+    runConfigResolved(servePlugin, { command: 'serve', build: { sourcemap: false } });
+
+    await runTransform(servePlugin, 'export const value: number = 1;', '/app/src/dev.ts');
+
+    const buildPlugin = fluoDecoratorsPlugin();
+    runConfigResolved(buildPlugin, { command: 'build', build: { sourcemap: 'hidden' } });
+
+    await runTransform(buildPlugin, 'export const value: number = 1;', '/app/src/build.ts');
+
+    expect(transformAsyncMock.mock.calls[0]?.[1]).toEqual(expect.objectContaining({ sourceMaps: true }));
+    expect(transformAsyncMock.mock.calls[1]?.[1]).toEqual(expect.objectContaining({ sourceMaps: true }));
+  });
+
+  it('transforms TypeScript files with standard decorators through Babel', async () => {
+    const plugin = fluoDecoratorsPlugin();
+    const result = await runTransform(
+      plugin,
+      `function logged(value: unknown, context: ClassMethodDecoratorContext) {
+  context.name;
+}
+
+class Example {
+  @logged
+  greet(): string {
+    return 'hello';
+  }
+}
+
+export { Example };
+`,
+      '/app/src/example.ts',
+    );
+
+    expect(result).toEqual(expect.objectContaining({ code: expect.any(String) }));
+    expect(result && typeof result === 'object' && 'code' in result ? result.code : '').not.toContain(': string');
+  });
+
+  it('locks Babel decorator transforms to the documented 2023-11 proposal version', async () => {
+    const plugin = fluoDecoratorsPlugin();
+
+    await runTransform(plugin, 'export class Example {}', '/app/src/example.ts?import');
+
+    expect(transformAsyncMock).toHaveBeenCalledTimes(1);
+    expect(transformAsyncMock.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({
+        filename: '/app/src/example.ts',
+        plugins: [['@babel/plugin-proposal-decorators', { version: '2023-11' }]],
+        presets: [['@babel/preset-typescript', { allowDeclareFields: true }]],
+      }),
+    );
+  });
+});

--- a/packages/vite/tsconfig.build.json
+++ b/packages/vite/tsconfig.build.json
@@ -4,7 +4,8 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "dist",
-    "noEmit": false
+    "noEmit": false,
+    "stripInternal": true
   },
   "exclude": ["src/**/*.test.ts", "src/**/*.spec.ts"]
 }


### PR DESCRIPTION
## Summary

Preserve the `@fluojs/vite` lazy Babel load contract and declaration boundary for issue 2453.

Linked context: Closes #2453

## Changes

- Split the oversized Vite plugin regression tests into focused transform boundary and transform option suites.
- Relaxed the concurrent first-transform test to assert public transform success instead of importer count/cache-winner internals.
- Marked the injected Babel test factory as `@internal` and enabled `stripInternal` for Vite declaration builds so emitted declarations keep only `fluoDecoratorsPlugin()`.
- Added declaration-boundary regression coverage and a patch changeset for `@fluojs/vite`.

## Testing

- `pnpm install` in the dedicated issue worktree to install missing workspace dependencies.
- `pnpm --dir packages/vite test` -> 4 files, 18 tests passed.
- `pnpm --dir packages/vite typecheck` -> passed.
- `pnpm --dir packages/vite build` -> passed; inspected `packages/vite/dist/decorators-plugin.d.ts` and confirmed it only declares `fluoDecoratorsPlugin()`.
- `pnpm exec biome check packages/vite/src/decorators-plugin.ts packages/vite/src/index.test.ts packages/vite/src/declaration-boundary.test.ts packages/vite/src/transform-boundary.test.ts packages/vite/src/transform-options.test.ts packages/vite/tsconfig.build.json .changeset/tiny-vans-drop.md` -> passed for checked files.
- LSP diagnostics attempted for changed TS files, but the TypeScript LSP server is not installed in this environment and was previously declined.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Patch changeset: `.changeset/tiny-vans-drop.md` for `@fluojs/vite` declaration/package-content cleanup.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No new public export was added. The test-only factory remains source-annotated and is stripped from emitted declarations; `fluoDecoratorsPlugin()` documentation remains intact.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [ ] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

The existing README lazy-load contract remains unchanged: root import and plugin creation do not load Babel, and missing Babel peers report from eligible transform boundaries. Regression tests now preserve that contract without pinning importer race internals.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests, such as `createPlatformConformanceHarness(...)` for platform component contracts or `createHttpAdapterPortabilityHarness(...)` for HTTP adapter portability contracts.

No governed docs or package README files changed; this PR adds package-level regression evidence and release metadata only.