### PR TITLE
Resolve #2440: Harden queue scoped lifecycle and Redis ownership contracts

### DIFF
--- a/.changeset/bright-queues-drain.md
+++ b/.changeset/bright-queues-drain.md
@@ -2,4 +2,4 @@
 '@fluojs/queue': patch
 ---
 
-Drain pending queue dead-letter writes during worker startup rollback before releasing Redis lifecycle state.
+Drain pending queue dead-letter writes during worker startup rollback before releasing Redis lifecycle state, and harden scoped queue registrations with explicit unique scopes, scoped public token helpers, and module-graph Redis visibility checks.

--- a/.changeset/bright-queues-drain.md
+++ b/.changeset/bright-queues-drain.md
@@ -1,5 +1,5 @@
 ---
-'@fluojs/queue': patch
+'@fluojs/queue': major
 ---
 
 Drain pending queue dead-letter writes during worker startup rollback before releasing Redis lifecycle state, and harden scoped queue registrations with explicit unique scopes, scoped public token helpers, and module-graph Redis visibility checks.

--- a/.changeset/quiet-points-arrive.md
+++ b/.changeset/quiet-points-arrive.md
@@ -1,5 +1,5 @@
 ---
-"@fluojs/queue": patch
+"@fluojs/queue": major
 ---
 
 Harden scoped queue module discovery so non-global registrations stay isolated to the module tree that imported their `QueueModule.forRoot(...)` call, and require the Redis client provider to be reachable from that same graph.

--- a/.changeset/quiet-points-arrive.md
+++ b/.changeset/quiet-points-arrive.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/queue": patch
+---
+
+Harden scoped queue module discovery so non-global registrations stay isolated to the module tree that imported their `QueueModule.forRoot(...)` call, and require the Redis client provider to be reachable from that same graph.

--- a/packages/queue/README.ko.md
+++ b/packages/queue/README.ko.md
@@ -92,6 +92,31 @@ QueueModule.forRoot({ clientName: 'jobs' })
 
 `QueueModule.forRoot({ global: false })`를 사용하면 각 queue 등록은 해당 `QueueModule.forRoot(...)` 호출을 가져온 동일한 module tree에서 도달할 수 있는 worker만 탐색합니다. 서로 다른 scoped queue feature module은 서로 분리된 상태를 유지하며, Redis client provider도 같은 module tree 안에서 도달 가능해야 합니다.
 
+### 범위가 지정된 Queue 등록
+
+애플리케이션이 non-global queue 등록을 둘 이상 가져오면 명시적인 `scope`를 사용하세요. Scope 이름은 trim되며, 비어 있으면 안 되고, 컴파일된 module graph 안에서 고유해야 합니다. `QueueModule.forRoot({ global: false })`를 두 번 가져오는 duplicate default scoped registration이나 `QueueModule.forRoot({ global: false, scope: 'jobs' })`를 두 번 가져오는 duplicate explicit scope는 bootstrap 중 결정적인 오류로 실패합니다.
+
+```typescript
+import { Inject, Module } from '@fluojs/core';
+import { getQueueLifecycleServiceToken, getQueueToken, QueueModule, type Queue } from '@fluojs/queue';
+
+const EMAIL_QUEUE = getQueueToken('email');
+const EMAIL_QUEUE_LIFECYCLE = getQueueLifecycleServiceToken('email');
+
+@Inject(EMAIL_QUEUE)
+export class EmailPublisher {
+  constructor(private readonly queue: Queue) {}
+}
+
+@Module({
+  imports: [QueueModule.forRoot({ global: false, scope: 'email' })],
+  providers: [EmailPublisher, EmailWorker],
+})
+export class EmailQueueModule {}
+```
+
+애플리케이션에 기본 queue 등록이 하나뿐이고 compatibility `QUEUE` 토큰이나 `QueueLifecycleService` 클래스를 직접 주입할 때만 `scope`를 생략하세요. Scoped registration에서는 각 feature module이 기본 compatibility token 대신 자신의 queue instance를 resolve하도록 `getQueueToken(scope)` 또는 `getQueueLifecycleServiceToken(scope)`를 주입하세요.
+
 ### 부트스트랩 및 종료 수명 주기
 
 Queue는 애플리케이션 부트스트랩 중 worker를 탐색하고 Queue가 소유하는 BullMQ 리소스를 만들지만, BullMQ worker processor는 runtime이 전체 애플리케이션 bootstrap/readiness sequence 완료를 표시한 뒤에만 시작합니다. 다른 `onApplicationBootstrap()` hook에서 enqueue한 job은 Queue 서비스가 초기화된 뒤에는 받을 수 있으며, processor는 뒤에 실행되는 async bootstrap hook이나 애플리케이션 readiness보다 앞서 실행되지 않고 bootstrap-ready handoff 이후 실행됩니다. Queue status는 해당 BullMQ processor가 실제로 시작될 때까지 degraded readiness를 보고합니다. Processor 시작에 실패하면 lifecycle이 `failed`로 이동하고, status snapshot은 worker를 ready로 숨기지 않고 실패를 노출합니다.
@@ -127,6 +152,8 @@ Job은 JSON으로 직렬화 가능한 plain object여야 합니다. Queue는 enq
 - `QueueLifecycleService`: 작업을 큐에 추가하고 lifecycle/status snapshot을 생성(`enqueue(job)`, `createPlatformStatusSnapshot()`)하기 위한 기본 서비스입니다.
 - `@QueueWorker(JobClass, options?)`: 특정 작업을 처리할 핸들러를 지정하는 데코레이터입니다.
 - `QUEUE`: queue facade를 위한 호환성 주입 토큰입니다.
+- `getQueueToken(scope?)`: Queue facade token helper입니다. `scope`를 생략하면 기본 `QUEUE` token을 반환하고, 비어 있지 않은 scope는 해당 scoped registration의 facade token을 반환합니다.
+- `getQueueLifecycleServiceToken(scope?)`: Scoped queue registration을 위한 lifecycle service token helper입니다.
 - `createQueuePlatformStatusSnapshot(...)`: lifecycle/readiness diagnostics를 위한 status snapshot helper입니다.
 
 
@@ -147,6 +174,7 @@ Job은 JSON으로 직렬화 가능한 plain object여야 합니다. Queue는 enq
 `QueueModuleOptions` 수명 주기/status 설정:
 
 - `global`: queue module 등록을 global로 만들지 여부입니다. 기본값은 `true`이며, queue provider를 importing module graph 안에만 scope하고 싶으면 `false`를 지정합니다.
+- `scope`: 고유한 non-empty queue registration scope입니다. 하나의 앱에 non-global queue registration이 여러 개 있으면 필요합니다.
 - `workerShutdownTimeoutMs`: 종료 중 active worker processor를 기다리는 최대 시간입니다. 시간이 지나면 BullMQ worker를 force-close합니다. 기본값은 `30_000`입니다.
 - `defaultDeadLetterMaxEntries`: job별로 유지할 dead-letter record의 최대 개수이며, trimming을 끄려면 `false`를 지정합니다. 기본값은 `1_000`입니다.
 

--- a/packages/queue/README.ko.md
+++ b/packages/queue/README.ko.md
@@ -90,6 +90,8 @@ QueueModule.forRoot({ clientName: 'jobs' })
 
 `@fluojs/queue`는 애플리케이션 부트스트랩 중 해당 Redis 클라이언트를 조회한 뒤 BullMQ용으로 큐가 소유하는 duplicate 연결을 만듭니다. 공유 `@fluojs/redis` 클라이언트의 소유권은 `RedisModule`에 남아 있으며, Queue는 자신이 만든 BullMQ duplicate 연결만 닫습니다. 이 duplicate 연결은 BullMQ Worker가 요구하는 `maxRetriesPerRequest: null` 설정으로 구성되어 시작 동작이 BullMQ의 실제 런타임 제약과 일치합니다.
 
+`QueueModule.forRoot({ global: false })`를 사용하면 각 queue 등록은 해당 `QueueModule.forRoot(...)` 호출을 가져온 동일한 module tree에서 도달할 수 있는 worker만 탐색합니다. 서로 다른 scoped queue feature module은 서로 분리된 상태를 유지하며, Redis client provider도 같은 module tree 안에서 도달 가능해야 합니다.
+
 ### 부트스트랩 및 종료 수명 주기
 
 Queue는 애플리케이션 부트스트랩 중 worker를 탐색하고 Queue가 소유하는 BullMQ 리소스를 만들지만, BullMQ worker processor는 runtime이 전체 애플리케이션 bootstrap/readiness sequence 완료를 표시한 뒤에만 시작합니다. 다른 `onApplicationBootstrap()` hook에서 enqueue한 job은 Queue 서비스가 초기화된 뒤에는 받을 수 있으며, processor는 뒤에 실행되는 async bootstrap hook이나 애플리케이션 readiness보다 앞서 실행되지 않고 bootstrap-ready handoff 이후 실행됩니다. Queue status는 해당 BullMQ processor가 실제로 시작될 때까지 degraded readiness를 보고합니다. Processor 시작에 실패하면 lifecycle이 `failed`로 이동하고, status snapshot은 worker를 ready로 숨기지 않고 실패를 노출합니다.

--- a/packages/queue/README.md
+++ b/packages/queue/README.md
@@ -92,6 +92,31 @@ QueueModule.forRoot({ clientName: 'jobs' })
 
 When `QueueModule.forRoot({ global: false })` is used, each queue registration only discovers workers that are reachable from the same module tree that imported that specific `QueueModule.forRoot(...)` call. Separate scoped queue feature modules stay isolated from one another, and the Redis client provider must be reachable from that same module tree.
 
+### Scoped Queue Registrations
+
+Use an explicit `scope` when an application imports more than one non-global queue registration. Scope names are trimmed, must be non-empty, and must be unique per compiled module graph. Duplicate default scoped registrations such as two `QueueModule.forRoot({ global: false })` imports, or duplicate explicit scopes such as two `QueueModule.forRoot({ global: false, scope: 'jobs' })` imports, fail deterministically during bootstrap.
+
+```typescript
+import { Inject, Module } from '@fluojs/core';
+import { getQueueLifecycleServiceToken, getQueueToken, QueueModule, type Queue } from '@fluojs/queue';
+
+const EMAIL_QUEUE = getQueueToken('email');
+const EMAIL_QUEUE_LIFECYCLE = getQueueLifecycleServiceToken('email');
+
+@Inject(EMAIL_QUEUE)
+export class EmailPublisher {
+  constructor(private readonly queue: Queue) {}
+}
+
+@Module({
+  imports: [QueueModule.forRoot({ global: false, scope: 'email' })],
+  providers: [EmailPublisher, EmailWorker],
+})
+export class EmailQueueModule {}
+```
+
+Omit `scope` only when the application has a single default queue registration and injects the compatibility `QUEUE` token or `QueueLifecycleService` class directly. For scoped registrations, inject `getQueueToken(scope)` or `getQueueLifecycleServiceToken(scope)` so each feature module resolves its own queue instance instead of the default compatibility token.
+
 ### Bootstrap and Shutdown Lifecycle
 
 Queue discovers workers and creates queue-owned BullMQ resources during application bootstrap, but BullMQ worker processors are started only after the runtime marks the full application bootstrap/readiness sequence complete. Jobs enqueued by other `onApplicationBootstrap()` hooks can be accepted once the Queue service is initialized, and their processors run after the bootstrap-ready handoff instead of racing ahead of later async bootstrap hooks or application readiness. Queue status reports degraded readiness until those BullMQ processors have actually started; if a processor fails to start, the lifecycle moves to `failed` and status snapshots expose the failure instead of reporting the workers as ready.
@@ -127,6 +152,8 @@ Treat low-level provider assembly as an internal implementation detail: low-leve
 - `QueueLifecycleService`: Primary service for enqueuing jobs and creating lifecycle/status snapshots (`enqueue(job)`, `createPlatformStatusSnapshot()`).
 - `@QueueWorker(JobClass, options?)`: Decorator to mark a class as a job handler.
 - `QUEUE`: Compatibility injection token for the queue facade.
+- `getQueueToken(scope?)`: Queue facade token helper. Omitting `scope` returns the default `QUEUE` token; a non-empty scope returns that scoped registration's facade token.
+- `getQueueLifecycleServiceToken(scope?)`: Lifecycle service token helper for scoped queue registrations.
 - `createQueuePlatformStatusSnapshot(...)`: Status snapshot helper for lifecycle/readiness diagnostics.
 
 
@@ -147,6 +174,7 @@ Treat low-level provider assembly as an internal implementation detail: low-leve
 `QueueModuleOptions` lifecycle/status controls:
 
 - `global`: whether the queue module registration is global. Defaults to `true`; set `false` when queue providers should stay scoped to the importing module graph.
+- `scope`: unique non-empty queue registration scope. Required when multiple non-global queue registrations exist in one app.
 - `workerShutdownTimeoutMs`: maximum time to wait for active worker processors during shutdown before force-closing the BullMQ worker. Defaults to `30_000`.
 - `defaultDeadLetterMaxEntries`: maximum retained dead-letter records per job, or `false` to disable trimming. Defaults to `1_000`.
 

--- a/packages/queue/README.md
+++ b/packages/queue/README.md
@@ -90,6 +90,8 @@ QueueModule.forRoot({ clientName: 'jobs' })
 
 `@fluojs/queue` resolves that Redis client during application bootstrap, then creates queue-owned duplicate connections for BullMQ. The shared `@fluojs/redis` client remains owned by `RedisModule`; Queue closes only the duplicate BullMQ connections it creates. Those duplicate connections are configured with BullMQ's required `maxRetriesPerRequest: null` worker setting so startup behavior matches BullMQ's runtime constraints.
 
+When `QueueModule.forRoot({ global: false })` is used, each queue registration only discovers workers that are reachable from the same module tree that imported that specific `QueueModule.forRoot(...)` call. Separate scoped queue feature modules stay isolated from one another, and the Redis client provider must be reachable from that same module tree.
+
 ### Bootstrap and Shutdown Lifecycle
 
 Queue discovers workers and creates queue-owned BullMQ resources during application bootstrap, but BullMQ worker processors are started only after the runtime marks the full application bootstrap/readiness sequence complete. Jobs enqueued by other `onApplicationBootstrap()` hooks can be accepted once the Queue service is initialized, and their processors run after the bootstrap-ready handoff instead of racing ahead of later async bootstrap hooks or application readiness. Queue status reports degraded readiness until those BullMQ processors have actually started; if a processor fails to start, the lifecycle moves to `failed` and status snapshots expose the failure instead of reporting the workers as ready.

--- a/packages/queue/src/__snapshots__/public-surface.test.ts.snap
+++ b/packages/queue/src/__snapshots__/public-surface.test.ts.snap
@@ -7,5 +7,7 @@ exports[`@fluojs/queue root barrel public surface > keeps the documented root ex
   "QueueModule",
   "QueueWorker",
   "createQueuePlatformStatusSnapshot",
+  "getQueueLifecycleServiceToken",
+  "getQueueToken",
 ]
 `;

--- a/packages/queue/src/index.ts
+++ b/packages/queue/src/index.ts
@@ -2,7 +2,7 @@ export { QueueWorker } from './decorators.js';
 export { QueueModule } from './module.js';
 export { QueueLifecycleService } from './service.js';
 export * from './status.js';
-export { QUEUE } from './tokens.js';
+export { getQueueLifecycleServiceToken, getQueueToken, QUEUE } from './tokens.js';
 export type {
   Queue,
   QueueBackoffOptions,

--- a/packages/queue/src/module.test.ts
+++ b/packages/queue/src/module.test.ts
@@ -494,9 +494,11 @@ describe('@fluojs/queue', () => {
 
     const app = await bootstrapApplication({ rootModule: AppModule });
     const queueByClass = await app.container.resolve(QueueLifecycleService);
+    const queueByHelperToken = await app.container.resolve<QueueLifecycleService>(getQueueLifecycleServiceToken());
     const queueByToken = await app.container.resolve<Queue>(QUEUE);
 
     expect(queueByClass).toBeInstanceOf(QueueLifecycleService);
+    expect(queueByHelperToken).toBe(queueByClass);
     expect(typeof queueByToken.enqueue).toBe('function');
 
     await app.close();

--- a/packages/queue/src/module.test.ts
+++ b/packages/queue/src/module.test.ts
@@ -274,8 +274,14 @@ class MockRedisClient {
   failConnectOnDuplicate: number | undefined;
 
   readonly deadLetters = new Map<string, string[]>();
+  readonly disconnectCalls: string[] = [];
   readonly duplicateOptions: MockRedisDuplicateOptions[] = [];
   readonly duplicates: MockRedisConnection[] = [];
+  readonly quitCalls: string[] = [];
+
+  disconnect(): void {
+    this.disconnectCalls.push('shared');
+  }
 
   duplicate(options: MockRedisDuplicateOptions = {}): MockRedisConnection {
     this.duplicateSequence += 1;
@@ -339,6 +345,11 @@ class MockRedisClient {
     }
 
     this.deadLetters.set(key, entries.slice(startIndex, stopIndex + 1));
+    return 'OK';
+  }
+
+  async quit(): Promise<'OK'> {
+    this.quitCalls.push('shared');
     return 'OK';
   }
 }
@@ -567,6 +578,12 @@ describe('@fluojs/queue', () => {
       handled: string[] = [];
     }
 
+    class WorkerStoreModule {}
+    defineModule(WorkerStoreModule, {
+      exports: [WorkerStore],
+      providers: [WorkerStore],
+    });
+
     @Inject(WorkerStore)
     @QueueWorker(NamedJob)
     class NamedWorker {
@@ -665,6 +682,121 @@ describe('@fluojs/queue', () => {
     await app.close();
 
     expect(redis.duplicates.every((connection) => connection.status === 'end')).toBe(true);
+    expect(redis.quitCalls).toEqual([]);
+    expect(redis.disconnectCalls).toEqual([]);
+  });
+
+  it('keeps non-global queue registrations from discovering workers owned by another scoped queue module', async () => {
+    class FirstScopedJob {
+      constructor(public readonly id: string) {}
+    }
+
+    class SecondScopedJob {
+      constructor(public readonly id: string) {}
+    }
+
+    class WorkerStore {
+      handled: string[] = [];
+    }
+
+    class ScopedWorkerStoreModule {}
+    defineModule(ScopedWorkerStoreModule, {
+      exports: [WorkerStore],
+      providers: [WorkerStore],
+    });
+
+    @Inject(WorkerStore)
+    @QueueWorker(FirstScopedJob)
+    class FirstScopedWorker {
+      constructor(private readonly store: WorkerStore) {}
+
+      async handle(job: FirstScopedJob): Promise<void> {
+        this.store.handled.push(`first:${job.id}`);
+      }
+    }
+
+    @Inject(WorkerStore)
+    @QueueWorker(SecondScopedJob)
+    class SecondScopedWorker {
+      constructor(private readonly store: WorkerStore) {}
+
+      async handle(job: SecondScopedJob): Promise<void> {
+        this.store.handled.push(`second:${job.id}`);
+      }
+    }
+
+    class FirstQueueFeatureModule {}
+    defineModule(FirstQueueFeatureModule, {
+      imports: [QueueModule.forRoot({ global: false }), ScopedWorkerStoreModule],
+      providers: [FirstScopedWorker],
+    });
+
+    class SecondQueueFeatureModule {}
+    defineModule(SecondQueueFeatureModule, {
+      imports: [QueueModule.forRoot({ global: false }), ScopedWorkerStoreModule],
+      providers: [SecondScopedWorker],
+    });
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [FirstQueueFeatureModule, SecondQueueFeatureModule, ScopedWorkerStoreModule],
+    });
+
+    const redis = new MockRedisClient();
+    const app = await bootstrapApplication({
+      providers: [{ provide: REDIS_CLIENT, useValue: redis }],
+      rootModule: AppModule,
+    });
+
+    try {
+      const queue = await app.container.resolve<Queue>(QUEUE);
+      const service = await app.container.resolve(QueueLifecycleService);
+      const workerStore = await app.container.resolve(WorkerStore);
+      await waitForApplicationQueueWorkers(app);
+
+      await expect(queue.enqueue(new FirstScopedJob('1'))).rejects.toThrow(
+        'No @QueueWorker() registered for job type FirstScopedJob.',
+      );
+      await expect(queue.enqueue(new SecondScopedJob('2'))).resolves.toBe('1');
+      expect(workerStore.handled).toEqual(['second:2']);
+      expect(service.createPlatformStatusSnapshot().details).toMatchObject({
+        queuesReady: 1,
+        workersDiscovered: 1,
+        workersReady: 1,
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('requires scoped queue modules to import the Redis client provider explicitly', async () => {
+    class ScopedRedisJob {
+      constructor(public readonly id: string) {}
+    }
+
+    @QueueWorker(ScopedRedisJob)
+    class ScopedRedisWorker {
+      async handle(_job: ScopedRedisJob): Promise<void> {}
+    }
+
+    class RedisTestModule {}
+    defineModule(RedisTestModule, {
+      exports: [REDIS_CLIENT],
+      providers: [{ provide: REDIS_CLIENT, useValue: new MockRedisClient() }],
+    });
+
+    class QueueFeatureModule {}
+    defineModule(QueueFeatureModule, {
+      imports: [QueueModule.forRoot({ global: false })],
+      providers: [ScopedRedisWorker],
+    });
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [RedisTestModule, QueueFeatureModule],
+    });
+
+    await expect(bootstrapApplication({ rootModule: AppModule })).rejects.toThrow('cannot access token Symbol(fluo.redis.client)');
   });
 
   it('restricts non-global queue worker discovery to modules that can see the queue provider', async () => {
@@ -1164,6 +1296,7 @@ describe('@fluojs/queue', () => {
         global: true,
         workerShutdownTimeoutMs: 30_000,
       },
+      redis,
       container as never,
       [
         {
@@ -1435,6 +1568,7 @@ describe('@fluojs/queue', () => {
         global: true,
         workerShutdownTimeoutMs: 30_000,
       },
+      redis,
       container as never,
       [
         {
@@ -1569,6 +1703,7 @@ describe('@fluojs/queue', () => {
         global: true,
         workerShutdownTimeoutMs: 30_000,
       },
+      redis,
       container as never,
       [
         {
@@ -1643,6 +1778,7 @@ describe('@fluojs/queue', () => {
         global: true,
         workerShutdownTimeoutMs: 30_000,
       },
+      redis,
       container as never,
       [
         {

--- a/packages/queue/src/module.test.ts
+++ b/packages/queue/src/module.test.ts
@@ -1,6 +1,6 @@
 import { Inject, Scope } from '@fluojs/core';
 import { defineControllerMetadata } from '@fluojs/core/internal';
-import { getRedisClientToken, REDIS_CLIENT } from '@fluojs/redis';
+import { getRedisClientToken, REDIS_CLIENT, RedisModule } from '@fluojs/redis';
 import { type ApplicationLogger, bootstrapApplication, defineModule } from '@fluojs/runtime';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -769,34 +769,66 @@ describe('@fluojs/queue', () => {
     }
   });
 
-  it('requires scoped queue modules to import the Redis client provider explicitly', async () => {
+  it('resolves a named Redis client through sibling Redis and Queue module imports', async () => {
     class ScopedRedisJob {
       constructor(public readonly id: string) {}
     }
 
-    @QueueWorker(ScopedRedisJob)
-    class ScopedRedisWorker {
-      async handle(_job: ScopedRedisJob): Promise<void> {}
+    class ScopedRedisWorkerStore {
+      handled: string[] = [];
     }
 
-    class RedisTestModule {}
-    defineModule(RedisTestModule, {
-      exports: [REDIS_CLIENT],
-      providers: [{ provide: REDIS_CLIENT, useValue: new MockRedisClient() }],
+    @Inject(ScopedRedisWorkerStore)
+    @QueueWorker(ScopedRedisJob)
+    class ScopedRedisWorker {
+      constructor(private readonly store: ScopedRedisWorkerStore) {}
+
+      async handle(job: ScopedRedisJob): Promise<void> {
+        this.store.handled.push(job.id);
+      }
+    }
+
+    @Inject(QUEUE)
+    class ScopedRedisUserService {
+      constructor(private readonly queue: Queue) {}
+
+      async enqueue(id: string): Promise<string> {
+        return this.queue.enqueue(new ScopedRedisJob(id));
+      }
+    }
+
+    class RedisFeatureModule {}
+    defineModule(RedisFeatureModule, {
+      imports: [RedisModule.forRoot({ name: 'jobs' })],
     });
 
     class QueueFeatureModule {}
     defineModule(QueueFeatureModule, {
-      imports: [QueueModule.forRoot({ global: false })],
-      providers: [ScopedRedisWorker],
+      imports: [QueueModule.forRoot({ clientName: 'jobs', global: false })],
+      providers: [ScopedRedisWorker, ScopedRedisUserService, ScopedRedisWorkerStore],
     });
 
     class AppModule {}
     defineModule(AppModule, {
-      imports: [RedisTestModule, QueueFeatureModule],
+      imports: [RedisFeatureModule, QueueFeatureModule],
     });
 
-    await expect(bootstrapApplication({ rootModule: AppModule })).rejects.toThrow('cannot access token Symbol(fluo.redis.client)');
+    const redis = new MockRedisClient();
+    const app = await bootstrapApplication({
+      providers: [{ provide: getRedisClientToken('jobs'), useValue: redis }],
+      rootModule: AppModule,
+    });
+
+    try {
+      const service = await app.container.resolve(ScopedRedisUserService);
+      const store = await app.container.resolve(ScopedRedisWorkerStore);
+      await waitForApplicationQueueWorkers(app);
+
+      await expect(service.enqueue('named-1')).resolves.toBe('1');
+      expect(store.handled).toEqual(['named-1']);
+    } finally {
+      await app.close();
+    }
   });
 
   it('restricts non-global queue worker discovery to modules that can see the queue provider', async () => {

--- a/packages/queue/src/module.test.ts
+++ b/packages/queue/src/module.test.ts
@@ -266,7 +266,7 @@ import { QueueWorker } from './decorators.js';
 import { getQueueWorkerMetadata } from './metadata.js';
 import { QueueModule } from './module.js';
 import { QueueLifecycleService } from './service.js';
-import { QUEUE } from './tokens.js';
+import { getQueueLifecycleServiceToken, getQueueToken, QUEUE } from './tokens.js';
 import type { Queue } from './types.js';
 
 class MockRedisClient {
@@ -686,7 +686,59 @@ describe('@fluojs/queue', () => {
     expect(redis.disconnectCalls).toEqual([]);
   });
 
-  it('keeps non-global queue registrations from discovering workers owned by another scoped queue module', async () => {
+  it('rejects duplicate default scoped queue registrations with a deterministic error', async () => {
+    class FirstQueueFeatureModule {}
+    defineModule(FirstQueueFeatureModule, {
+      imports: [QueueModule.forRoot({ global: false })],
+    });
+
+    class SecondQueueFeatureModule {}
+    defineModule(SecondQueueFeatureModule, {
+      imports: [QueueModule.forRoot({ global: false })],
+    });
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [FirstQueueFeatureModule, SecondQueueFeatureModule],
+    });
+
+    const redis = new MockRedisClient();
+
+    await expect(
+      bootstrapApplication({
+        providers: [{ provide: REDIS_CLIENT, useValue: redis }],
+        rootModule: AppModule,
+      }),
+    ).rejects.toThrow('Duplicate @fluojs/queue scope "default" registered. Provide a unique QueueModule.forRoot({ scope }) value for each scoped queue registration.');
+  });
+
+  it('rejects duplicate explicit scoped queue registrations with a deterministic error', async () => {
+    class FirstQueueFeatureModule {}
+    defineModule(FirstQueueFeatureModule, {
+      imports: [QueueModule.forRoot({ global: false, scope: 'jobs' })],
+    });
+
+    class SecondQueueFeatureModule {}
+    defineModule(SecondQueueFeatureModule, {
+      imports: [QueueModule.forRoot({ global: false, scope: 'jobs' })],
+    });
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [FirstQueueFeatureModule, SecondQueueFeatureModule],
+    });
+
+    const redis = new MockRedisClient();
+
+    await expect(
+      bootstrapApplication({
+        providers: [{ provide: REDIS_CLIENT, useValue: redis }],
+        rootModule: AppModule,
+      }),
+    ).rejects.toThrow('Duplicate @fluojs/queue scope "jobs" registered. Provide a unique QueueModule.forRoot({ scope }) value for each scoped queue registration.');
+  });
+
+  it('keeps distinct explicit queue scopes isolated through public scoped token helpers', async () => {
     class FirstScopedJob {
       constructor(public readonly id: string) {}
     }
@@ -725,16 +777,34 @@ describe('@fluojs/queue', () => {
       }
     }
 
+    @Inject(getQueueToken('first'))
+    class FirstScopedUserService {
+      constructor(private readonly queue: Queue) {}
+
+      async enqueue(id: string): Promise<string> {
+        return this.queue.enqueue(new FirstScopedJob(id));
+      }
+    }
+
+    @Inject(getQueueToken('second'))
+    class SecondScopedUserService {
+      constructor(private readonly queue: Queue) {}
+
+      async enqueue(id: string): Promise<string> {
+        return this.queue.enqueue(new SecondScopedJob(id));
+      }
+    }
+
     class FirstQueueFeatureModule {}
     defineModule(FirstQueueFeatureModule, {
-      imports: [QueueModule.forRoot({ global: false }), ScopedWorkerStoreModule],
-      providers: [FirstScopedWorker],
+      imports: [QueueModule.forRoot({ global: false, scope: 'first' }), ScopedWorkerStoreModule],
+      providers: [FirstScopedWorker, FirstScopedUserService],
     });
 
     class SecondQueueFeatureModule {}
     defineModule(SecondQueueFeatureModule, {
-      imports: [QueueModule.forRoot({ global: false }), ScopedWorkerStoreModule],
-      providers: [SecondScopedWorker],
+      imports: [QueueModule.forRoot({ global: false, scope: 'second' }), ScopedWorkerStoreModule],
+      providers: [SecondScopedWorker, SecondScopedUserService],
     });
 
     class AppModule {}
@@ -749,17 +819,33 @@ describe('@fluojs/queue', () => {
     });
 
     try {
-      const queue = await app.container.resolve<Queue>(QUEUE);
-      const service = await app.container.resolve(QueueLifecycleService);
+      const firstQueue = await app.container.resolve<Queue>(getQueueToken('first'));
+      const firstService = await app.container.resolve<QueueLifecycleService>(getQueueLifecycleServiceToken('first'));
+      const secondQueue = await app.container.resolve<Queue>(getQueueToken('second'));
+      const secondService = await app.container.resolve<QueueLifecycleService>(getQueueLifecycleServiceToken('second'));
+      const firstUserService = await app.container.resolve(FirstScopedUserService);
+      const secondUserService = await app.container.resolve(SecondScopedUserService);
       const workerStore = await app.container.resolve(WorkerStore);
-      await waitForApplicationQueueWorkers(app);
+      await waitForQueueWorkers(firstService);
+      await waitForQueueWorkers(secondService);
 
-      await expect(queue.enqueue(new FirstScopedJob('1'))).rejects.toThrow(
+      await expect(firstQueue.enqueue(new FirstScopedJob('1'))).resolves.toBe('1');
+      await expect(firstQueue.enqueue(new SecondScopedJob('2'))).rejects.toThrow(
+        'No @QueueWorker() registered for job type SecondScopedJob.',
+      );
+      await expect(secondQueue.enqueue(new SecondScopedJob('3'))).resolves.toBe('2');
+      await expect(secondQueue.enqueue(new FirstScopedJob('4'))).rejects.toThrow(
         'No @QueueWorker() registered for job type FirstScopedJob.',
       );
-      await expect(queue.enqueue(new SecondScopedJob('2'))).resolves.toBe('1');
-      expect(workerStore.handled).toEqual(['second:2']);
-      expect(service.createPlatformStatusSnapshot().details).toMatchObject({
+      await expect(firstUserService.enqueue('5')).resolves.toBe('3');
+      await expect(secondUserService.enqueue('6')).resolves.toBe('4');
+      expect(workerStore.handled).toEqual(['first:1', 'second:3', 'first:5', 'second:6']);
+      expect(firstService.createPlatformStatusSnapshot().details).toMatchObject({
+        queuesReady: 1,
+        workersDiscovered: 1,
+        workersReady: 1,
+      });
+      expect(secondService.createPlatformStatusSnapshot().details).toMatchObject({
         queuesReady: 1,
         workersDiscovered: 1,
         workersReady: 1,
@@ -767,6 +853,14 @@ describe('@fluojs/queue', () => {
     } finally {
       await app.close();
     }
+  });
+
+  it('rejects blank explicit queue scopes during module registration', () => {
+    expect(() => QueueModule.forRoot({ global: false, scope: '   ' })).toThrow(
+      'Queue scope must be a non-empty string when provided.',
+    );
+    expect(() => getQueueToken('')).toThrow('Queue scope must be a non-empty string when provided.');
+    expect(() => getQueueLifecycleServiceToken('  ')).toThrow('Queue scope must be a non-empty string when provided.');
   });
 
   it('resolves a named Redis client through sibling Redis and Queue module imports', async () => {
@@ -788,7 +882,7 @@ describe('@fluojs/queue', () => {
       }
     }
 
-    @Inject(QUEUE)
+    @Inject(getQueueToken('jobs'))
     class ScopedRedisUserService {
       constructor(private readonly queue: Queue) {}
 
@@ -797,20 +891,10 @@ describe('@fluojs/queue', () => {
       }
     }
 
-    class RedisFeatureModule {}
-    defineModule(RedisFeatureModule, {
-      imports: [RedisModule.forRoot({ name: 'jobs' })],
-    });
-
-    class QueueFeatureModule {}
-    defineModule(QueueFeatureModule, {
-      imports: [QueueModule.forRoot({ clientName: 'jobs', global: false })],
-      providers: [ScopedRedisWorker, ScopedRedisUserService, ScopedRedisWorkerStore],
-    });
-
     class AppModule {}
     defineModule(AppModule, {
-      imports: [RedisFeatureModule, QueueFeatureModule],
+      imports: [RedisModule.forRoot({ name: 'jobs' }), QueueModule.forRoot({ clientName: 'jobs', global: false, scope: 'jobs' })],
+      providers: [ScopedRedisWorker, ScopedRedisUserService, ScopedRedisWorkerStore],
     });
 
     const redis = new MockRedisClient();
@@ -821,14 +905,48 @@ describe('@fluojs/queue', () => {
 
     try {
       const service = await app.container.resolve(ScopedRedisUserService);
+      const queueLifecycle = await app.container.resolve<QueueLifecycleService>(getQueueLifecycleServiceToken('jobs'));
       const store = await app.container.resolve(ScopedRedisWorkerStore);
-      await waitForApplicationQueueWorkers(app);
+      await waitForQueueWorkers(queueLifecycle);
 
       await expect(service.enqueue('named-1')).resolves.toBe('1');
       expect(store.handled).toEqual(['named-1']);
     } finally {
       await app.close();
     }
+  });
+
+  it('does not resolve hidden Redis providers outside the queue module graph', async () => {
+    class HiddenRedisJob {
+      constructor(public readonly id: string) {}
+    }
+
+    @QueueWorker(HiddenRedisJob)
+    class HiddenRedisWorker {
+      async handle(_job: HiddenRedisJob): Promise<void> {}
+    }
+
+    const hiddenRedisToken = getRedisClientToken('hidden');
+
+    class HiddenRedisModule {}
+    defineModule(HiddenRedisModule, {
+      providers: [{ provide: hiddenRedisToken, useValue: new MockRedisClient() }],
+    });
+
+    class QueueFeatureModule {}
+    defineModule(QueueFeatureModule, {
+      imports: [QueueModule.forRoot({ clientName: 'hidden', global: false, scope: 'hidden-redis' })],
+      providers: [HiddenRedisWorker],
+    });
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [HiddenRedisModule, QueueFeatureModule],
+    });
+
+    await expect(bootstrapApplication({ rootModule: AppModule })).rejects.toThrow(
+      '@fluojs/queue cannot access Redis client token Symbol(fluo.redis.client:hidden) from queue scope "hidden-redis". Import and export the matching RedisModule.forRoot(...) registration through the same module graph.',
+    );
   });
 
   it('restricts non-global queue worker discovery to modules that can see the queue provider', async () => {

--- a/packages/queue/src/module.ts
+++ b/packages/queue/src/module.ts
@@ -1,10 +1,44 @@
 import type { Provider } from '@fluojs/di';
-import { defineModule, type ModuleType } from '@fluojs/runtime';
+import type { Container } from '@fluojs/di';
+import { getRedisClientToken } from '@fluojs/redis';
+import { defineModule, type ApplicationLogger, type CompiledModule, type ModuleType } from '@fluojs/runtime';
+import {
+  APPLICATION_LOGGER,
+  BOOTSTRAP_READY_SIGNAL,
+  COMPILED_MODULES,
+  RUNTIME_CONTAINER,
+} from '@fluojs/runtime/internal';
+import type { BootstrapReadySignal } from '@fluojs/runtime/internal';
 
 import { normalizePositiveInteger, normalizePositiveIntegerOrFalse, normalizeRateLimiter } from './helpers.js';
 import { QueueLifecycleService } from './service.js';
-import { QUEUE, QUEUE_OPTIONS } from './tokens.js';
+import { QUEUE, QUEUE_MODULE_CONTEXT, QUEUE_OPTIONS } from './tokens.js';
+import type { QueueModuleContext } from './tokens.js';
 import type { NormalizedQueueModuleOptions, QueueModuleOptions } from './types.js';
+
+interface QueueModuleRedisClient {
+  duplicate(options?: { maxRetriesPerRequest: null }): QueueModuleRedisConnection;
+  ltrim(key: string, start: number, stop: number): Promise<unknown>;
+  rpush(key: string, value: string): Promise<unknown>;
+}
+
+interface QueueModuleRedisConnection {
+  connect(): Promise<unknown>;
+  disconnect(): void;
+  quit(): Promise<unknown>;
+  maxRetriesPerRequest?: number | null;
+  status?: string;
+}
+
+type QueueLifecycleServiceFactoryDeps = [
+  NormalizedQueueModuleOptions,
+  QueueModuleRedisClient,
+  Container,
+  readonly CompiledModule[],
+  ApplicationLogger,
+  BootstrapReadySignal,
+  QueueModuleContext,
+];
 
 function normalizeQueueModuleOptions(options: QueueModuleOptions = {}): NormalizedQueueModuleOptions {
   const defaultRateLimiter = normalizeRateLimiter(options.defaultRateLimiter);
@@ -26,13 +60,35 @@ function normalizeQueueModuleOptions(options: QueueModuleOptions = {}): Normaliz
   };
 }
 
-function createQueueProviders(options: QueueModuleOptions = {}): Provider[] {
+function createQueueProviders(options: QueueModuleOptions = {}, moduleType: ModuleType): Provider[] {
+  const redisToken = getRedisClientToken(options.clientName);
+
   return [
     {
       provide: QUEUE_OPTIONS,
       useValue: normalizeQueueModuleOptions(options),
     },
-    QueueLifecycleService,
+    {
+      provide: QUEUE_MODULE_CONTEXT,
+      useValue: { moduleType } satisfies QueueModuleContext,
+    },
+    {
+      inject: [
+        QUEUE_OPTIONS,
+        redisToken,
+        RUNTIME_CONTAINER,
+        COMPILED_MODULES,
+        APPLICATION_LOGGER,
+        BOOTSTRAP_READY_SIGNAL,
+        QUEUE_MODULE_CONTEXT,
+      ],
+      provide: QueueLifecycleService,
+      useFactory: (...deps: unknown[]) => {
+        const typedDeps = deps as QueueLifecycleServiceFactoryDeps;
+
+        return new QueueLifecycleService(...typedDeps);
+      },
+    },
     {
       inject: [QueueLifecycleService],
       provide: QUEUE,
@@ -74,7 +130,7 @@ export class QueueModule {
     return defineModule(QueueModuleDefinition, {
       exports: [QueueLifecycleService, QUEUE],
       global: options.global ?? true,
-      providers: createQueueProviders(options),
+      providers: createQueueProviders(options, QueueModuleDefinition),
     });
   }
 }

--- a/packages/queue/src/module.ts
+++ b/packages/queue/src/module.ts
@@ -12,7 +12,7 @@ import type { BootstrapReadySignal } from '@fluojs/runtime/internal';
 
 import { normalizePositiveInteger, normalizePositiveIntegerOrFalse, normalizeRateLimiter } from './helpers.js';
 import { QueueLifecycleService } from './service.js';
-import { QUEUE, QUEUE_MODULE_CONTEXT, QUEUE_OPTIONS } from './tokens.js';
+import { QUEUE, QUEUE_MODULE_CONTEXT, QUEUE_OPTIONS, QUEUE_REDIS_CLIENT } from './tokens.js';
 import type { QueueModuleContext } from './tokens.js';
 import type { NormalizedQueueModuleOptions, QueueModuleOptions } from './types.js';
 
@@ -28,6 +28,16 @@ interface QueueModuleRedisConnection {
   quit(): Promise<unknown>;
   maxRetriesPerRequest?: number | null;
   status?: string;
+}
+
+function hasQueueRedisClient(value: unknown): value is QueueModuleRedisClient {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const client = value as { duplicate?: unknown; ltrim?: unknown; rpush?: unknown };
+
+  return typeof client.duplicate === 'function' && typeof client.rpush === 'function' && typeof client.ltrim === 'function';
 }
 
 type QueueLifecycleServiceFactoryDeps = [
@@ -61,8 +71,6 @@ function normalizeQueueModuleOptions(options: QueueModuleOptions = {}): Normaliz
 }
 
 function createQueueProviders(options: QueueModuleOptions = {}, moduleType: ModuleType): Provider[] {
-  const redisToken = getRedisClientToken(options.clientName);
-
   return [
     {
       provide: QUEUE_OPTIONS,
@@ -73,9 +81,29 @@ function createQueueProviders(options: QueueModuleOptions = {}, moduleType: Modu
       useValue: { moduleType } satisfies QueueModuleContext,
     },
     {
+      inject: [QUEUE_OPTIONS, RUNTIME_CONTAINER],
+      provide: QUEUE_REDIS_CLIENT,
+      useFactory: async (...deps: unknown[]) => {
+        const [normalizedOptions, runtimeContainer] = deps as [NormalizedQueueModuleOptions, Container];
+        const redisToken = getRedisClientToken(normalizedOptions.clientName);
+
+        if (!runtimeContainer.has(redisToken)) {
+          throw new Error('@fluojs/queue requires a registered Redis client with duplicate(), rpush(), and ltrim() methods.');
+        }
+
+        const redisClient = await runtimeContainer.resolve(redisToken);
+
+        if (!hasQueueRedisClient(redisClient)) {
+          throw new Error('@fluojs/queue requires a Redis client with duplicate(), rpush(), and ltrim() methods.');
+        }
+
+        return redisClient;
+      },
+    },
+    {
       inject: [
         QUEUE_OPTIONS,
-        redisToken,
+        QUEUE_REDIS_CLIENT,
         RUNTIME_CONTAINER,
         COMPILED_MODULES,
         APPLICATION_LOGGER,

--- a/packages/queue/src/module.ts
+++ b/packages/queue/src/module.ts
@@ -201,10 +201,10 @@ function createQueueProviders(normalizedOptions: NormalizedQueueModuleOptions, m
  */
 export class QueueModule {
   /**
-   * Registers queue providers globally using canonical `forRoot(...)` semantics.
+   * Registers queue providers using canonical `forRoot(...)` semantics.
    *
    * @param options Queue runtime defaults used by discovered workers and enqueued jobs.
-   * @returns A module definition that exports `QueueLifecycleService` and the compatibility token `QUEUE`.
+   * @returns A module definition that exports default queue tokens when `scope` is omitted, or scoped queue tokens when `scope` is set.
    *
    * @example
    * ```ts

--- a/packages/queue/src/module.ts
+++ b/packages/queue/src/module.ts
@@ -1,3 +1,4 @@
+import type { Token } from '@fluojs/core';
 import type { Provider } from '@fluojs/di';
 import type { Container } from '@fluojs/di';
 import { getRedisClientToken } from '@fluojs/redis';
@@ -12,7 +13,15 @@ import type { BootstrapReadySignal } from '@fluojs/runtime/internal';
 
 import { normalizePositiveInteger, normalizePositiveIntegerOrFalse, normalizeRateLimiter } from './helpers.js';
 import { QueueLifecycleService } from './service.js';
-import { QUEUE, QUEUE_MODULE_CONTEXT, QUEUE_OPTIONS, QUEUE_REDIS_CLIENT } from './tokens.js';
+import {
+  getQueueLifecycleServiceToken,
+  getQueueModuleContextToken,
+  getQueueOptionsToken,
+  getQueueRedisClientToken as getQueueScopedRedisClientToken,
+  getQueueToken,
+  normalizeQueueScope,
+  QUEUE,
+} from './tokens.js';
 import type { QueueModuleContext } from './tokens.js';
 import type { NormalizedQueueModuleOptions, QueueModuleOptions } from './types.js';
 
@@ -50,11 +59,21 @@ type QueueLifecycleServiceFactoryDeps = [
   QueueModuleContext,
 ];
 
+interface QueueProviderTokens {
+  readonly lifecycleServiceToken: Token;
+  readonly moduleContextToken: Token;
+  readonly optionsToken: Token;
+  readonly queueRedisClientToken: Token;
+  readonly queueToken: Token;
+}
+
 function normalizeQueueModuleOptions(options: QueueModuleOptions = {}): NormalizedQueueModuleOptions {
   const defaultRateLimiter = normalizeRateLimiter(options.defaultRateLimiter);
+  const scope = normalizeQueueScope(options.scope);
 
   return {
     clientName: options.clientName,
+    ...(scope ? { scope } : {}),
     defaultAttempts: normalizePositiveInteger(options.defaultAttempts, 1),
     defaultBackoff: options.defaultBackoff
       ? {
@@ -70,22 +89,63 @@ function normalizeQueueModuleOptions(options: QueueModuleOptions = {}): Normaliz
   };
 }
 
-function createQueueProviders(options: QueueModuleOptions = {}, moduleType: ModuleType): Provider[] {
-  return [
+function getQueueProviderTokens(scope?: string): QueueProviderTokens {
+  return {
+    lifecycleServiceToken: getQueueLifecycleServiceToken(scope),
+    moduleContextToken: getQueueModuleContextToken(scope),
+    optionsToken: getQueueOptionsToken(scope),
+    queueRedisClientToken: getQueueScopedRedisClientToken(scope),
+    queueToken: getQueueToken(scope),
+  };
+}
+
+function moduleCanAccessQueueRegistration(compiledModule: CompiledModule, moduleType: ModuleType): boolean {
+  return compiledModule.type === moduleType || (compiledModule.definition.imports ?? []).includes(moduleType);
+}
+
+function canAccessRedisClient(
+  compiledModules: readonly CompiledModule[],
+  moduleContext: QueueModuleContext,
+  redisToken: Token,
+): boolean {
+  return compiledModules.some(
+    (compiledModule) =>
+      moduleCanAccessQueueRegistration(compiledModule, moduleContext.moduleType) && compiledModule.accessibleTokens.has(redisToken),
+  );
+}
+
+function formatQueueScope(scope: string | undefined): string {
+  return scope ?? 'default';
+}
+
+function createQueueProviders(normalizedOptions: NormalizedQueueModuleOptions, moduleType: ModuleType): Provider[] {
+  const tokens = getQueueProviderTokens(normalizedOptions.scope);
+  const providers: Provider[] = [
     {
-      provide: QUEUE_OPTIONS,
-      useValue: normalizeQueueModuleOptions(options),
+      provide: tokens.optionsToken,
+      useValue: normalizedOptions,
     },
     {
-      provide: QUEUE_MODULE_CONTEXT,
-      useValue: { moduleType } satisfies QueueModuleContext,
+      provide: tokens.moduleContextToken,
+      useValue: { moduleType, scope: formatQueueScope(normalizedOptions.scope) } satisfies QueueModuleContext,
     },
     {
-      inject: [QUEUE_OPTIONS, RUNTIME_CONTAINER],
-      provide: QUEUE_REDIS_CLIENT,
+      inject: [tokens.optionsToken, RUNTIME_CONTAINER, COMPILED_MODULES, tokens.moduleContextToken],
+      provide: tokens.queueRedisClientToken,
       useFactory: async (...deps: unknown[]) => {
-        const [normalizedOptions, runtimeContainer] = deps as [NormalizedQueueModuleOptions, Container];
-        const redisToken = getRedisClientToken(normalizedOptions.clientName);
+        const [resolvedOptions, runtimeContainer, compiledModules, moduleContext] = deps as [
+          NormalizedQueueModuleOptions,
+          Container,
+          readonly CompiledModule[],
+          QueueModuleContext,
+        ];
+        const redisToken = getRedisClientToken(resolvedOptions.clientName);
+
+        if (!canAccessRedisClient(compiledModules, moduleContext, redisToken)) {
+          throw new Error(
+            `@fluojs/queue cannot access Redis client token ${String(redisToken)} from queue scope "${moduleContext.scope}". Import and export the matching RedisModule.forRoot(...) registration through the same module graph.`,
+          );
+        }
 
         if (!runtimeContainer.has(redisToken)) {
           throw new Error('@fluojs/queue requires a registered Redis client with duplicate(), rpush(), and ltrim() methods.');
@@ -102,15 +162,15 @@ function createQueueProviders(options: QueueModuleOptions = {}, moduleType: Modu
     },
     {
       inject: [
-        QUEUE_OPTIONS,
-        QUEUE_REDIS_CLIENT,
+        tokens.optionsToken,
+        tokens.queueRedisClientToken,
         RUNTIME_CONTAINER,
         COMPILED_MODULES,
         APPLICATION_LOGGER,
         BOOTSTRAP_READY_SIGNAL,
-        QUEUE_MODULE_CONTEXT,
+        tokens.moduleContextToken,
       ],
-      provide: QueueLifecycleService,
+      provide: tokens.lifecycleServiceToken,
       useFactory: (...deps: unknown[]) => {
         const typedDeps = deps as QueueLifecycleServiceFactoryDeps;
 
@@ -118,13 +178,22 @@ function createQueueProviders(options: QueueModuleOptions = {}, moduleType: Modu
       },
     },
     {
-      inject: [QueueLifecycleService],
-      provide: QUEUE,
+      inject: [tokens.lifecycleServiceToken],
+      provide: tokens.queueToken,
       useFactory: (service: unknown) => ({
         enqueue: (job: object) => (service as QueueLifecycleService).enqueue(job),
       }),
     },
   ];
+
+  if (normalizedOptions.scope === undefined) {
+    providers.push({
+      provide: QueueLifecycleService,
+      useExisting: tokens.lifecycleServiceToken,
+    });
+  }
+
+  return providers;
 }
 
 /**
@@ -153,12 +222,16 @@ export class QueueModule {
    * ```
    */
   static forRoot(options: QueueModuleOptions = {}): ModuleType {
+    const normalizedOptions = normalizeQueueModuleOptions(options);
+    const tokens = getQueueProviderTokens(normalizedOptions.scope);
     class QueueModuleDefinition {}
 
     return defineModule(QueueModuleDefinition, {
-      exports: [QueueLifecycleService, QUEUE],
-      global: options.global ?? true,
-      providers: createQueueProviders(options, QueueModuleDefinition),
+      exports: normalizedOptions.scope === undefined
+        ? [QueueLifecycleService, QUEUE]
+        : [tokens.lifecycleServiceToken, tokens.queueToken],
+      global: normalizedOptions.global,
+      providers: createQueueProviders(normalizedOptions, QueueModuleDefinition),
     });
   }
 }

--- a/packages/queue/src/module.ts
+++ b/packages/queue/src/module.ts
@@ -228,7 +228,7 @@ export class QueueModule {
 
     return defineModule(QueueModuleDefinition, {
       exports: normalizedOptions.scope === undefined
-        ? [QueueLifecycleService, QUEUE]
+        ? [QueueLifecycleService, tokens.lifecycleServiceToken, QUEUE]
         : [tokens.lifecycleServiceToken, tokens.queueToken],
       global: normalizedOptions.global,
       providers: createQueueProviders(normalizedOptions, QueueModuleDefinition),

--- a/packages/queue/src/public-surface.test.ts
+++ b/packages/queue/src/public-surface.test.ts
@@ -12,6 +12,8 @@ describe('@fluojs/queue root barrel public surface', () => {
     expect(queue).not.toHaveProperty('createQueueProviders');
     expect(queue).toHaveProperty('QueueLifecycleService');
     expect(queue).toHaveProperty('QUEUE');
+    expect(queue).toHaveProperty('getQueueToken');
+    expect(queue).toHaveProperty('getQueueLifecycleServiceToken');
     expect(queue).toHaveProperty('QueueWorker');
     expect(queue).toHaveProperty('createQueuePlatformStatusSnapshot');
     expect(queue).not.toHaveProperty('QUEUE_OPTIONS');
@@ -27,6 +29,8 @@ describe('@fluojs/queue root barrel public surface', () => {
     );
     expect(readme).toContain('low-level provider assembly as an internal implementation detail');
     expect(readme).toContain('low-level provider helpers are not part of the documented root-barrel contract.');
+    expect(readme).toContain('`getQueueToken(scope)` or `getQueueLifecycleServiceToken(scope)`');
+    expect(readme).toContain('Duplicate default scoped registrations such as two `QueueModule.forRoot({ global: false })` imports');
     expect(readme).toContain('`QueueLifecycleService.createPlatformStatusSnapshot()` uses the same public snapshot contract');
     expect(readme).toContain('worker-start failures report not-ready/unhealthy with `workerStartFailures`');
     expect(koreanReadme).toContain(
@@ -34,6 +38,8 @@ describe('@fluojs/queue root barrel public surface', () => {
     );
     expect(koreanReadme).toContain('저수준 provider 조합을 루트 barrel API의 일부가 아니라 내부 구현 세부사항으로 취급해야 합니다.');
     expect(koreanReadme).toContain('저수준 provider helper는 문서화된 루트 barrel 계약에 포함되지 않습니다.');
+    expect(koreanReadme).toContain('`getQueueToken(scope)` 또는 `getQueueLifecycleServiceToken(scope)`');
+    expect(koreanReadme).toContain('`QueueModule.forRoot({ global: false })`를 두 번 가져오는 duplicate default scoped registration');
     expect(koreanReadme).toContain('`QueueLifecycleService.createPlatformStatusSnapshot()`은 `createQueuePlatformStatusSnapshot(...)`과 같은 공개 snapshot 계약');
     expect(koreanReadme).toContain('worker-start failure는 `workerStartFailures`와 `lastWorkerStartFailure` details를 포함해 not-ready/unhealthy');
   });

--- a/packages/queue/src/service.ts
+++ b/packages/queue/src/service.ts
@@ -19,7 +19,7 @@ import {
   type QueueLifecycleState,
   type QueuePlatformStatusSnapshot,
 } from './status.js';
-import { QUEUE } from './tokens.js';
+import { getQueueLifecycleServiceToken, getQueueToken, QUEUE } from './tokens.js';
 import type { QueueModuleContext } from './tokens.js';
 import { discoverQueueWorkerDescriptors } from './worker-discovery.js';
 import type {
@@ -138,6 +138,34 @@ function toBullBackoff(backoff: QueueBackoffOptions | undefined): JobsOptions['b
   };
 }
 
+function isQueueModuleContext(value: unknown): value is QueueModuleContext {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const context = value as { moduleType?: unknown; scope?: unknown };
+
+  return typeof context.moduleType === 'function' && typeof context.scope === 'string';
+}
+
+function collectQueueModuleScopeCount(compiledModules: readonly CompiledModule[], scope: string): number {
+  let count = 0;
+
+  for (const compiledModule of compiledModules) {
+    for (const provider of compiledModule.definition.providers ?? []) {
+      if (typeof provider !== 'object' || provider === null || !('useValue' in provider)) {
+        continue;
+      }
+
+      if (isQueueModuleContext(provider.useValue) && provider.useValue.scope === scope) {
+        count += 1;
+      }
+    }
+  }
+
+  return count;
+}
+
 async function closeConnection(connection: QueueOwnedConnection): Promise<void> {
   if (connection.status === 'end') {
     return;
@@ -183,10 +211,11 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
     private readonly compiledModules: readonly CompiledModule[],
     private readonly logger: ApplicationLogger,
     private readonly bootstrapReadySignal: BootstrapReadySignal = IMMEDIATE_BOOTSTRAP_READY_SIGNAL,
-    private readonly moduleContext: QueueModuleContext = { moduleType: QueueLifecycleService },
+    private readonly moduleContext: QueueModuleContext = { moduleType: QueueLifecycleService, scope: 'default' },
   ) {
     this.compiledModulesByType = new Map(this.compiledModules.map((compiledModule) => [compiledModule.type, compiledModule]));
     this.deadLetterManager = new QueueDeadLetterManager(this.options, this.logger, () => this.getRedisClient());
+    this.assertUniqueQueueScope();
   }
 
   async onApplicationBootstrap(): Promise<void> {
@@ -335,7 +364,22 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
   }
 
   private exportsQueueRegistration(compiledModule: CompiledModule): boolean {
-    return compiledModule.exportedTokens.has(QueueLifecycleService) || compiledModule.exportedTokens.has(QUEUE);
+    return (
+      compiledModule.exportedTokens.has(QueueLifecycleService) ||
+      compiledModule.exportedTokens.has(QUEUE) ||
+      compiledModule.exportedTokens.has(getQueueLifecycleServiceToken(this.options.scope)) ||
+      compiledModule.exportedTokens.has(getQueueToken(this.options.scope))
+    );
+  }
+
+  private assertUniqueQueueScope(): void {
+    const scopeCount = collectQueueModuleScopeCount(this.compiledModules, this.moduleContext.scope);
+
+    if (scopeCount > 1) {
+      throw new Error(
+        `Duplicate @fluojs/queue scope "${this.moduleContext.scope}" registered. Provide a unique QueueModule.forRoot({ scope }) value for each scoped queue registration.`,
+      );
+    }
   }
 
   private async handleStartupFailure(): Promise<void> {

--- a/packages/queue/src/service.ts
+++ b/packages/queue/src/service.ts
@@ -1,21 +1,15 @@
-import { Inject } from '@fluojs/core';
 import { cloneWithFallback } from '@fluojs/core/internal';
 import type { Container } from '@fluojs/di';
-import { getRedisClientToken, getRedisComponentId } from '@fluojs/redis';
+import { getRedisComponentId } from '@fluojs/redis';
 import type {
   ApplicationLogger,
   CompiledModule,
+  ModuleType,
   OnApplicationBootstrap,
   OnApplicationShutdown,
   OnModuleDestroy,
 } from '@fluojs/runtime';
-import {
-  APPLICATION_LOGGER,
-  BOOTSTRAP_READY_SIGNAL,
-  COMPILED_MODULES,
-  RUNTIME_CONTAINER,
-  type BootstrapReadySignal,
-} from '@fluojs/runtime/internal';
+import { type BootstrapReadySignal } from '@fluojs/runtime/internal';
 import { Queue as BullQueue, Worker as BullWorker, type ConnectionOptions, type JobsOptions, type Job as BullJob } from 'bullmq';
 
 import { QueueDeadLetterManager, type QueueRedisDeadLetterClient } from './dead-letter-manager.js';
@@ -25,7 +19,8 @@ import {
   type QueueLifecycleState,
   type QueuePlatformStatusSnapshot,
 } from './status.js';
-import { QUEUE, QUEUE_OPTIONS } from './tokens.js';
+import { QUEUE } from './tokens.js';
+import type { QueueModuleContext } from './tokens.js';
 import { discoverQueueWorkerDescriptors } from './worker-discovery.js';
 import type {
   NormalizedQueueModuleOptions,
@@ -165,7 +160,6 @@ async function closeConnection(connection: QueueOwnedConnection): Promise<void> 
  * The service discovers `@QueueWorker()` providers during bootstrap, creates the
  * BullMQ queues/workers they require, and shuts them down with the application.
  */
-@Inject(QUEUE_OPTIONS, RUNTIME_CONTAINER, COMPILED_MODULES, APPLICATION_LOGGER, BOOTSTRAP_READY_SIGNAL)
 export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnApplicationShutdown, OnModuleDestroy {
   private readonly descriptorsByJobType = new Map<QueueJobType, QueueWorkerDescriptor>();
   private readonly queuesByJobName = new Map<string, QueueInstance>();
@@ -176,19 +170,22 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
   private readonly runningWorkerJobNames = new Set<string>();
   private readonly failedWorkerJobNames = new Set<string>();
   private readonly workerStartFailures: WorkerStartFailure[] = [];
+  private readonly compiledModulesByType: ReadonlyMap<ModuleType, CompiledModule>;
   private lifecycleState: QueueLifecycleState = 'idle';
-  private redisClient: QueueRedisClient | undefined;
   private startPromise: Promise<void> | undefined;
   private shutdownPromise: Promise<void> | undefined;
   private startupFailureRollbackPromise: Promise<void> | undefined;
 
   constructor(
     private readonly options: NormalizedQueueModuleOptions,
+    private readonly redisClient: QueueRedisClient,
     private readonly runtimeContainer: Container,
     private readonly compiledModules: readonly CompiledModule[],
     private readonly logger: ApplicationLogger,
     private readonly bootstrapReadySignal: BootstrapReadySignal = IMMEDIATE_BOOTSTRAP_READY_SIGNAL,
+    private readonly moduleContext: QueueModuleContext = { moduleType: QueueLifecycleService },
   ) {
+    this.compiledModulesByType = new Map(this.compiledModules.map((compiledModule) => [compiledModule.type, compiledModule]));
     this.deadLetterManager = new QueueDeadLetterManager(this.options, this.logger, () => this.getRedisClient());
   }
 
@@ -285,8 +282,7 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
   }
 
   private async startLifecycle(): Promise<void> {
-    const redis = await this.resolveRedisClient();
-    this.redisClient = redis;
+    const redis = this.resolveRedisClient();
     this.descriptorsByJobType.clear();
 
     for (const [jobType, descriptor] of discoverQueueWorkerDescriptors(
@@ -310,7 +306,36 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
       return true;
     }
 
-    return compiledModule.accessibleTokens.has(QueueLifecycleService) || compiledModule.accessibleTokens.has(QUEUE);
+    return this.canReachQueueRegistration(compiledModule);
+  }
+
+  private canReachQueueRegistration(compiledModule: CompiledModule, visited = new Set<ModuleType>()): boolean {
+    if (visited.has(compiledModule.type)) {
+      return false;
+    }
+
+    visited.add(compiledModule.type);
+
+    for (const importedModuleType of compiledModule.definition.imports ?? []) {
+      if (importedModuleType === this.moduleContext.moduleType) {
+        return true;
+      }
+
+      const importedModule = this.compiledModulesByType.get(importedModuleType);
+      if (!importedModule || !this.exportsQueueRegistration(importedModule)) {
+        continue;
+      }
+
+      if (this.canReachQueueRegistration(importedModule, visited)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  private exportsQueueRegistration(compiledModule: CompiledModule): boolean {
+    return compiledModule.exportedTokens.has(QueueLifecycleService) || compiledModule.exportedTokens.has(QUEUE);
   }
 
   private async handleStartupFailure(): Promise<void> {
@@ -319,31 +344,18 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
     if (this.lifecycleState === 'starting') {
       this.lifecycleState = 'idle';
     }
-    this.redisClient = undefined;
     this.startPromise = undefined;
   }
 
-  private async resolveRedisClient(): Promise<QueueRedisClient> {
-    const redisToken = getRedisClientToken(this.options.clientName);
-
-    if (!this.runtimeContainer.has(redisToken)) {
-      throw new Error('@fluojs/queue requires a registered Redis client with duplicate(), rpush(), and ltrim() methods.');
-    }
-
-    const redisClient = await this.runtimeContainer.resolve(redisToken);
-
-    if (!hasQueueRedisClient(redisClient)) {
+  private resolveRedisClient(): QueueRedisClient {
+    if (!hasQueueRedisClient(this.redisClient)) {
       throw new Error('@fluojs/queue requires a Redis client with duplicate(), rpush(), and ltrim() methods.');
     }
 
-    return redisClient;
+    return this.redisClient;
   }
 
   private getRedisClient(): QueueRedisClient {
-    if (!this.redisClient) {
-      throw new Error('@fluojs/queue Redis client is not initialized.');
-    }
-
     return this.redisClient;
   }
 
@@ -572,7 +584,6 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
       this.startupFailureRollbackPromise = (async () => {
         await this.closeInitializedResources();
         await this.deadLetterManager.drainPendingWrites();
-        this.redisClient = undefined;
       })()
         .catch((rollbackError: unknown) => {
           this.logger.error(
@@ -682,7 +693,6 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
       await this.closeInitializedResources();
       await this.deadLetterManager.drainPendingWrites();
       this.lifecycleState = 'stopped';
-      this.redisClient = undefined;
       this.startPromise = undefined;
     })();
 

--- a/packages/queue/src/tokens.ts
+++ b/packages/queue/src/tokens.ts
@@ -1,8 +1,14 @@
 import type { Token } from '@fluojs/core';
+import type { ModuleType } from '@fluojs/runtime';
 
-import type { Queue, NormalizedQueueModuleOptions } from './types.js';
+import type { NormalizedQueueModuleOptions, Queue } from './types.js';
+
+export interface QueueModuleContext {
+  readonly moduleType: ModuleType;
+}
 
 /** Compatibility injection token for the queue facade returned by {@link QueueModule.forRoot}. */
 export const QUEUE: Token<Queue> = Symbol.for('fluo.queue');
 /** Injection token for normalized module defaults consumed by {@link QueueLifecycleService}. */
 export const QUEUE_OPTIONS: Token<NormalizedQueueModuleOptions> = Symbol.for('fluo.queue.options');
+export const QUEUE_MODULE_CONTEXT: Token<QueueModuleContext> = Symbol.for('fluo.queue.module-context');

--- a/packages/queue/src/tokens.ts
+++ b/packages/queue/src/tokens.ts
@@ -1,15 +1,141 @@
 import type { Token } from '@fluojs/core';
 import type { ModuleType } from '@fluojs/runtime';
 
+import type { QueueLifecycleService } from './service.js';
 import type { NormalizedQueueModuleOptions, Queue } from './types.js';
 
+/** Runtime metadata that binds one queue registration to its compiled module graph. */
 export interface QueueModuleContext {
   readonly moduleType: ModuleType;
+  readonly scope: string;
 }
 
+const scopedQueueTokens = new Map<string, Token<Queue>>();
+const scopedQueueLifecycleServiceTokens = new Map<string, Token<QueueLifecycleService>>();
+const scopedQueueOptionsTokens = new Map<string, Token<NormalizedQueueModuleOptions>>();
+const scopedQueueRedisClientTokens = new Map<string, Token<unknown>>();
+const scopedQueueModuleContextTokens = new Map<string, Token<QueueModuleContext>>();
+
+/**
+ * Normalize an optional queue registration scope.
+ *
+ * @param scope Optional scope name supplied to {@link QueueModule.forRoot}.
+ * @returns A trimmed non-empty scope name, or `undefined` for the default registration.
+ * @throws When a provided scope contains only whitespace.
+ */
+export function normalizeQueueScope(scope?: string): string | undefined {
+  if (scope === undefined) {
+    return undefined;
+  }
+
+  const normalized = scope.trim();
+
+  if (normalized.length === 0) {
+    throw new Error('Queue scope must be a non-empty string when provided.');
+  }
+
+  return normalized;
+}
+
+function getScopedToken<T>(tokens: Map<string, Token<T>>, scope: string, description: string): Token<T> {
+  const existing = tokens.get(scope);
+
+  if (existing) {
+    return existing;
+  }
+
+  const created = Symbol(`${description}:${scope}`) as Token<T>;
+  tokens.set(scope, created);
+  return created;
+}
+
+/** Queue-owned Redis client token consumed by the default queue registration. */
 export const QUEUE_REDIS_CLIENT: Token<unknown> = Symbol.for('fluo.queue.redis-client');
 /** Compatibility injection token for the queue facade returned by {@link QueueModule.forRoot}. */
 export const QUEUE: Token<Queue> = Symbol.for('fluo.queue');
 /** Injection token for normalized module defaults consumed by {@link QueueLifecycleService}. */
 export const QUEUE_OPTIONS: Token<NormalizedQueueModuleOptions> = Symbol.for('fluo.queue.options');
+/** Runtime module-context token consumed by the default queue registration. */
 export const QUEUE_MODULE_CONTEXT: Token<QueueModuleContext> = Symbol.for('fluo.queue.module-context');
+
+/**
+ * Return the queue facade token for a default or explicitly scoped registration.
+ *
+ * @param scope Optional queue registration scope.
+ * @returns The compatibility {@link QUEUE} token when omitted, or a stable token for the scoped queue facade.
+ */
+export function getQueueToken(scope?: string): Token<Queue> {
+  const normalizedScope = normalizeQueueScope(scope);
+
+  if (normalizedScope === undefined) {
+    return QUEUE;
+  }
+
+  return getScopedToken(scopedQueueTokens, normalizedScope, 'fluo.queue');
+}
+
+/**
+ * Return the lifecycle service token for a default or explicitly scoped queue registration.
+ *
+ * @param scope Optional queue registration scope.
+ * @returns The default lifecycle-service token when omitted, or a stable token for the scoped lifecycle service.
+ */
+export function getQueueLifecycleServiceToken(scope?: string): Token<QueueLifecycleService> {
+  const normalizedScope = normalizeQueueScope(scope);
+
+  if (normalizedScope === undefined) {
+    return QueueLifecycleServiceToken;
+  }
+
+  return getScopedToken(scopedQueueLifecycleServiceTokens, normalizedScope, 'fluo.queue.lifecycle-service');
+}
+
+/**
+ * Return the normalized options token for a default or explicitly scoped queue registration.
+ *
+ * @param scope Optional queue registration scope.
+ * @returns The default options token when omitted, or a stable token for scoped normalized options.
+ */
+export function getQueueOptionsToken(scope?: string): Token<NormalizedQueueModuleOptions> {
+  const normalizedScope = normalizeQueueScope(scope);
+
+  if (normalizedScope === undefined) {
+    return QUEUE_OPTIONS;
+  }
+
+  return getScopedToken(scopedQueueOptionsTokens, normalizedScope, 'fluo.queue.options');
+}
+
+/**
+ * Return the queue-owned Redis client token for a default or explicitly scoped registration.
+ *
+ * @param scope Optional queue registration scope.
+ * @returns The default Redis client token when omitted, or a stable token for the scoped Redis dependency.
+ */
+export function getQueueRedisClientToken(scope?: string): Token<unknown> {
+  const normalizedScope = normalizeQueueScope(scope);
+
+  if (normalizedScope === undefined) {
+    return QUEUE_REDIS_CLIENT;
+  }
+
+  return getScopedToken(scopedQueueRedisClientTokens, normalizedScope, 'fluo.queue.redis-client');
+}
+
+/**
+ * Return the module-context token for a default or explicitly scoped queue registration.
+ *
+ * @param scope Optional queue registration scope.
+ * @returns The default module-context token when omitted, or a stable token for scoped queue context.
+ */
+export function getQueueModuleContextToken(scope?: string): Token<QueueModuleContext> {
+  const normalizedScope = normalizeQueueScope(scope);
+
+  if (normalizedScope === undefined) {
+    return QUEUE_MODULE_CONTEXT;
+  }
+
+  return getScopedToken(scopedQueueModuleContextTokens, normalizedScope, 'fluo.queue.module-context');
+}
+
+const QueueLifecycleServiceToken: Token<QueueLifecycleService> = Symbol.for('fluo.queue.lifecycle-service.default');

--- a/packages/queue/src/tokens.ts
+++ b/packages/queue/src/tokens.ts
@@ -7,6 +7,7 @@ export interface QueueModuleContext {
   readonly moduleType: ModuleType;
 }
 
+export const QUEUE_REDIS_CLIENT: Token<unknown> = Symbol.for('fluo.queue.redis-client');
 /** Compatibility injection token for the queue facade returned by {@link QueueModule.forRoot}. */
 export const QUEUE: Token<Queue> = Symbol.for('fluo.queue');
 /** Injection token for normalized module defaults consumed by {@link QueueLifecycleService}. */

--- a/packages/queue/src/types.ts
+++ b/packages/queue/src/types.ts
@@ -37,6 +37,8 @@ export interface QueueWorkerOptions {
 /** Module-wide defaults used when individual workers omit execution settings. */
 export interface QueueModuleOptions {
   clientName?: string;
+  /** Unique registration scope for non-global queue modules that need isolated providers. */
+  scope?: string;
   /** Whether queue providers should be visible globally. Defaults to `true`. */
   global?: boolean;
   defaultAttempts?: number;
@@ -51,6 +53,7 @@ export interface QueueModuleOptions {
 /** Normalized queue options resolved once during module registration. */
 export interface NormalizedQueueModuleOptions {
   clientName?: string;
+  scope?: string;
   defaultAttempts: number;
   defaultBackoff?: QueueBackoffOptions;
   defaultConcurrency: number;


### PR DESCRIPTION
## Summary

Hardens queue scoped lifecycle discovery so non-global queue registrations stay isolated to the module tree that imported their own `QueueModule.forRoot(...)` call, and makes the Redis client dependency explicit in the queue module graph.

Linked context: https://github.com/fluojs/fluo/issues/2440

## Changes

- Added module-context reachability filtering in `QueueLifecycleService` so scoped queue modules only discover reachable workers.
- Switched queue Redis resolution from runtime-container lookup to an explicit module injection dependency.
- Added regression coverage for scoped queue isolation and Redis provider visibility.
- Documented the scoped queue isolation contract in `packages/queue/README.md` and `packages/queue/README.ko.md`.
- Added a `patch` Changeset for the public `@fluojs/queue` behavior change.

## Testing

- `pnpm --dir packages/queue test -- src/module.test.ts`
- `pnpm --dir packages/queue typecheck`
- `pnpm --dir packages/queue build`

Notes: the scoped-queue regression test emits expected duplicate-provider warnings when two non-global `QueueModule.forRoot(...)` registrations coexist, but the suite passes.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.

## Public export documentation

- [x] No new public exports were added.
- [x] Existing public package docs were updated to match the new scoped queue contract.

## Behavioral contract

- [x] Non-global queue registrations stay isolated to the module tree that imported their own `QueueModule.forRoot(...)` call.
- [x] Queue now requires the Redis client provider to be reachable through the same module graph.
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] Queue README English/Korean parity was updated together.
- [x] No platform governance docs or CI enforcement files needed changes.

Closes #2440
