### PR TITLE
Resolve #2425: close HTTP regression coverage gaps

### DIFF
--- a/packages/http/src/decorators.test.ts
+++ b/packages/http/src/decorators.test.ts
@@ -342,6 +342,28 @@ describe('http decorators', () => {
 
       return InvalidMixedSegmentController;
     }).toThrow(InvalidRoutePathError);
+
+    expect(() => {
+      class InvalidQuestionRouteController {
+        @Get('/files?')
+        getFile() {
+          return { ok: true };
+        }
+      }
+
+      return InvalidQuestionRouteController;
+    }).toThrow(InvalidRoutePathError);
+
+    expect(() => {
+      class InvalidRegexRouteController {
+        @Get('/(.*)')
+        getFile() {
+          return { ok: true };
+        }
+      }
+
+      return InvalidRegexRouteController;
+    }).toThrow(InvalidRoutePathError);
   });
 
   it('preserves binding and validator metadata for PickType, OmitType, and IntersectionType', () => {

--- a/packages/http/src/dispatch/dispatcher.test.ts
+++ b/packages/http/src/dispatch/dispatcher.test.ts
@@ -1116,6 +1116,63 @@ describe('dispatcher runtime', () => {
     expect(response.simpleJsonBody).toBeUndefined();
   });
 
+  it('short-circuits already-aborted signal requests before handler execution', async () => {
+    const controller = new AbortController();
+    const handler = vi.fn(() => ({ ok: true }));
+
+    controller.abort();
+
+    @Controller('/already-aborted-signal')
+    class AlreadyAbortedSignalController {
+      @Get('/')
+      getValue() {
+        return handler();
+      }
+    }
+
+    const root = new Container().register(AlreadyAbortedSignalController);
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: AlreadyAbortedSignalController }]),
+      rootContainer: root,
+    });
+    const request = createRequest('/already-aborted-signal');
+    request.signal = controller.signal;
+    const response = createFastPathResponse();
+
+    await dispatcher.dispatch(request, response);
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(response.committed).toBe(false);
+    expect(response.simpleJsonBody).toBeUndefined();
+  });
+
+  it('short-circuits already-aborted probe requests before handler execution', async () => {
+    const handler = vi.fn(() => ({ ok: true }));
+
+    @Controller('/already-aborted-probe')
+    class AlreadyAbortedProbeController {
+      @Get('/')
+      getValue() {
+        return handler();
+      }
+    }
+
+    const root = new Container().register(AlreadyAbortedProbeController);
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: AlreadyAbortedProbeController }]),
+      rootContainer: root,
+    });
+    const request = createRequest('/already-aborted-probe');
+    request.isAborted = () => true;
+    const response = createFastPathResponse();
+
+    await dispatcher.dispatch(request, response);
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(response.committed).toBe(false);
+    expect(response.simpleJsonBody).toBeUndefined();
+  });
+
   it('preserves adapter abort probes on cloned dispatch requests', async () => {
     let aborted = false;
 

--- a/packages/http/src/middleware/rate-limit.test.ts
+++ b/packages/http/src/middleware/rate-limit.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createMemoryRateLimitStore, createRateLimitMiddleware } from './rate-limit.js';
 import type { MiddlewareContext } from '../types.js';
@@ -54,6 +54,10 @@ describe('createRateLimitMiddleware', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-03-17T00:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('returns 429 with Retry-After after the limit is exceeded', async () => {


### PR DESCRIPTION
## Summary

Close the `@fluojs/http` regression coverage gaps identified in the package audit for issue #2425.

Linked context: Closes #2425

## Changes

- Added dispatcher regression coverage for requests that are already aborted before handler execution through both `FrameworkRequest.signal` and `FrameworkRequest.isAborted()`.
- Added decorator regression coverage for the documented unsupported `?` and `/(.*)` route syntaxes.
- Added rate-limit test cleanup so fake timers are restored after each test.

## Testing

- `pnpm install`
- `pnpm test -- src/dispatch/dispatcher.test.ts src/decorators.test.ts src/middleware/rate-limit.test.ts` from `packages/http` (Vitest ran the package suite: 15 files, 217 tests passed)
- `pnpm --filter @fluojs/core build && pnpm --filter @fluojs/di build && pnpm --filter @fluojs/validation build && pnpm --filter @fluojs/http typecheck`
- `pnpm --filter @fluojs/http build`
- `pnpm exec biome lint packages/http/src/dispatch/dispatcher.test.ts packages/http/src/decorators.test.ts packages/http/src/middleware/rate-limit.test.ts`
- `GIT_MASTER=1 git diff --check`

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

No changeset: test-only regression coverage and suite hygiene; no runtime behavior, API surface, package contents, or release metadata changed.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No public exports changed.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

The PR only locks existing README-documented behavior: abort short-circuiting and unsupported route syntaxes.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests, such as `createPlatformConformanceHarness(...)` for platform component contracts or `createHttpAdapterPortabilityHarness(...)` for HTTP adapter portability contracts.

No governance docs or platform adapter contracts changed; this is package-local regression coverage only.
