### PR TITLE
Resolve #2420: add Fastify contract regression coverage

### DIFF
--- a/packages/platform-fastify/src/adapter.test.ts
+++ b/packages/platform-fastify/src/adapter.test.ts
@@ -845,20 +845,22 @@ describe('@fluojs/platform-fastify', () => {
       signal: abortController.signal,
     });
 
-    await expect(Promise.race([
-      observedMultipartRequest.promise,
-      new Promise<void>((_resolve, reject) => {
-        setTimeout(() => {
-          reject(new Error('Multipart request never reached Fastify preHandler hook.'));
-        }, 2_000);
-      }),
-    ])).resolves.toBeUndefined();
+    try {
+      await expect(Promise.race([
+        observedMultipartRequest.promise,
+        new Promise<void>((_resolve, reject) => {
+          setTimeout(() => {
+            reject(new Error('Multipart request never reached Fastify preHandler hook.'));
+          }, 2_000);
+        }),
+      ])).resolves.toBeUndefined();
 
-    abortController.abort();
-    await multipartRequest.catch(() => undefined);
-    expect(observedMultipartRawBodyStates).toEqual([false]);
-
-    await app.close();
+      expect(observedMultipartRawBodyStates).toEqual([false]);
+    } finally {
+      abortController.abort();
+      await multipartRequest.catch(() => undefined);
+      await app.close();
+    }
   });
 
   it('treats multipart content-type values case-insensitively before raw-body capture', async () => {
@@ -921,20 +923,22 @@ describe('@fluojs/platform-fastify', () => {
       signal: abortController.signal,
     });
 
-    await expect(Promise.race([
-      observedMultipartRequest.promise,
-      new Promise<void>((_resolve, reject) => {
-        setTimeout(() => {
-          reject(new Error('Mixed-case multipart request never reached Fastify preHandler hook.'));
-        }, 2_000);
-      }),
-    ])).resolves.toBeUndefined();
+    try {
+      await expect(Promise.race([
+        observedMultipartRequest.promise,
+        new Promise<void>((_resolve, reject) => {
+          setTimeout(() => {
+            reject(new Error('Mixed-case multipart request never reached Fastify preHandler hook.'));
+          }, 2_000);
+        }),
+      ])).resolves.toBeUndefined();
 
-    abortController.abort();
-    await multipartRequest.catch(() => undefined);
-    expect(observedMultipartRawBodyStates).toEqual([false]);
-
-    await app.close();
+      expect(observedMultipartRawBodyStates).toEqual([false]);
+    } finally {
+      abortController.abort();
+      await multipartRequest.catch(() => undefined);
+      await app.close();
+    }
   });
 
   it('supports SSE streaming', async () => {
@@ -1328,23 +1332,25 @@ describe('@fluojs/platform-fastify', () => {
 
     await app.listen();
 
-    const form = new FormData();
-    form.set('name', 'Ada');
-    form.set('payload', new Blob(['hello'], { type: 'text/plain' }), 'payload.txt');
+    try {
+      const form = new FormData();
+      form.set('name', 'Ada');
+      form.set('payload', new Blob(['hello'], { type: 'text/plain' }), 'payload.txt');
 
-    const response = await fetch(`http://127.0.0.1:${String(port)}/uploads`, {
-      body: form,
-      method: 'POST',
-    });
+      const response = await fetch(`http://127.0.0.1:${String(port)}/uploads`, {
+        body: form,
+        method: 'POST',
+      });
 
-    expect(response.status).toBe(201);
-    await expect(response.json()).resolves.toEqual({
-      body: { name: 'Ada' },
-      fileCount: 1,
-      hasRawBody: false,
-    });
-
-    await app.close();
+      expect(response.status).toBe(201);
+      await expect(response.json()).resolves.toEqual({
+        body: { name: 'Ada' },
+        fileCount: 1,
+        hasRawBody: false,
+      });
+    } finally {
+      await app.close();
+    }
   });
 
   it('rejects multipart payloads once the cumulative body size exceeds multipart.maxTotalSize', async () => {
@@ -1376,23 +1382,73 @@ describe('@fluojs/platform-fastify', () => {
 
     await app.listen();
 
-    const form = new FormData();
-    form.set('name', 'Ada');
-    form.set('payload', new Blob(['1234567890'], { type: 'text/plain' }), 'payload.txt');
+    try {
+      const form = new FormData();
+      form.set('name', 'Ada');
+      form.set('payload', new Blob(['1234567890'], { type: 'text/plain' }), 'payload.txt');
 
-    const response = await fetch(`http://127.0.0.1:${String(port)}/uploads`, {
-      body: form,
-      method: 'POST',
+      const response = await fetch(`http://127.0.0.1:${String(port)}/uploads`, {
+        body: form,
+        method: 'POST',
+      });
+
+      expect(response.status).toBe(413);
+      await expect(response.json()).resolves.toMatchObject({
+        error: {
+          code: 'PAYLOAD_TOO_LARGE',
+        },
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('honors direct createFastifyAdapter multipart options', async () => {
+    @Controller('/uploads')
+    class UploadController {
+      @Post('/')
+      upload(_input: undefined, context: RequestContext) {
+        return {
+          body: context.request.body,
+          fileCount: context.request.files?.length ?? 0,
+        };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [UploadController],
     });
 
-    expect(response.status).toBe(413);
-    await expect(response.json()).resolves.toMatchObject({
-      error: {
-        code: 'PAYLOAD_TOO_LARGE',
-      },
+    const port = await findAvailablePort();
+    const app = await fluoFactory.create(AppModule, {
+      adapter: createFastifyAdapter({ port }, {
+        maxFileSize: 1024,
+        maxTotalSize: 10,
+      }),
     });
 
-    await app.close();
+    await app.listen();
+
+    try {
+      const form = new FormData();
+      form.set('name', 'Ada');
+      form.set('payload', new Blob(['1234567890'], { type: 'text/plain' }), 'payload.txt');
+
+      const response = await fetch(`http://127.0.0.1:${String(port)}/uploads`, {
+        body: form,
+        method: 'POST',
+      });
+
+      expect(response.status).toBe(413);
+      await expect(response.json()).resolves.toMatchObject({
+        error: {
+          code: 'PAYLOAD_TOO_LARGE',
+        },
+      });
+    } finally {
+      await app.close();
+    }
   });
 
   it('defaults multipart.maxTotalSize to maxBodySize when no explicit multipart total is provided', async () => {
@@ -1698,19 +1754,65 @@ describe('@fluojs/platform-fastify', () => {
 
     await app.listen();
 
-    const [prefixedApp, prefixedHealth, health] = await Promise.all([
-      fetch(`http://127.0.0.1:${String(port)}/api/app/info`),
-      fetch(`http://127.0.0.1:${String(port)}/api/health`),
-      fetch(`http://127.0.0.1:${String(port)}/health`),
-    ]);
+    try {
+      const [prefixedApp, prefixedHealth, health] = await Promise.all([
+        fetch(`http://127.0.0.1:${String(port)}/api/app/info`),
+        fetch(`http://127.0.0.1:${String(port)}/api/health`),
+        fetch(`http://127.0.0.1:${String(port)}/health`),
+      ]);
 
-    expect(prefixedApp.status).toBe(200);
-    await expect(prefixedApp.json()).resolves.toEqual({ ok: true, route: 'app-info' });
-    expect(prefixedHealth.status).toBe(200);
-    await expect(prefixedHealth.json()).resolves.toEqual({ status: 'ok' });
-    expect(health.status).toBe(404);
+      expect(prefixedApp.status).toBe(200);
+      await expect(prefixedApp.json()).resolves.toEqual({ ok: true, route: 'app-info' });
+      expect(prefixedHealth.status).toBe(200);
+      await expect(prefixedHealth.json()).resolves.toEqual({ status: 'ok' });
+      expect(health.status).toBe(404);
+    } finally {
+      await app.close();
+    }
+  });
 
-    await app.close();
+  it('excludes configured paths from the global prefix', async () => {
+    const HealthModule = createHealthModule();
+
+    @Controller('/app')
+    class AppController {
+      @Get('/info')
+      getInfo() {
+        return { ok: true, route: 'app-info' };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [AppController],
+      imports: [HealthModule],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapFastifyApplication(AppModule, {
+      cors: false,
+      globalPrefix: '/api',
+      globalPrefixExclude: ['/health'],
+      port,
+    });
+
+    await app.listen();
+
+    try {
+      const [prefixedApp, prefixedHealth, health] = await Promise.all([
+        fetch(`http://127.0.0.1:${String(port)}/api/app/info`),
+        fetch(`http://127.0.0.1:${String(port)}/api/health`),
+        fetch(`http://127.0.0.1:${String(port)}/health`),
+      ]);
+
+      expect(prefixedApp.status).toBe(200);
+      await expect(prefixedApp.json()).resolves.toEqual({ ok: true, route: 'app-info' });
+      expect(prefixedHealth.status).toBe(404);
+      expect(health.status).toBe(200);
+      await expect(health.json()).resolves.toEqual({ status: 'ok' });
+    } finally {
+      await app.close();
+    }
   });
 
   it('hands safe native Fastify routes to the dispatcher without rematching', async () => {
@@ -2056,24 +2158,33 @@ describe('@fluojs/platform-fastify', () => {
     });
 
     const port = await findAvailablePort();
-    const app = await runFastifyApplication(AppModule, {
-      cors: false,
-      host: '127.0.0.1',
-      https: {
-        cert: TEST_TLS_CERTIFICATE,
-        key: TEST_TLS_PRIVATE_KEY,
-      },
-      port,
-    });
+    let app: Application | undefined;
 
-    const response = await requestHttps(`https://127.0.0.1:${String(port)}/health`);
+    try {
+      app = await runFastifyApplication(AppModule, {
+        cors: false,
+        host: '127.0.0.1',
+        https: {
+          cert: TEST_TLS_CERTIFICATE,
+          key: TEST_TLS_PRIVATE_KEY,
+        },
+        port,
+      });
 
-    expect(response.statusCode).toBe(200);
-    expect(JSON.parse(response.body)).toEqual({ ok: true });
-    expect(log.mock.calls.some(([message]) => String(message).includes(`Listening on https://127.0.0.1:${String(port)}`))).toBe(true);
+      const response = await requestHttps(`https://127.0.0.1:${String(port)}/health`);
 
-    await app.close();
-    log.mockRestore();
+      expect(response.statusCode).toBe(200);
+      expect(JSON.parse(response.body)).toEqual({ ok: true });
+      expect(log.mock.calls.some(([message]) => String(message).includes(`Listening on https://127.0.0.1:${String(port)}`))).toBe(true);
+    } finally {
+      try {
+        if (app) {
+          await app.close();
+        }
+      } finally {
+        log.mockRestore();
+      }
+    }
   });
 
   it('keeps dispatcher until fastify close settles even when close() times out', async () => {


### PR DESCRIPTION
## Summary

Add the missing Fastify adapter contract regression coverage requested by the package audit.

Linked context: Closes #2420

## Changes

- Added a `globalPrefixExclude` regression test that proves excluded health routes stay unprefixed while ordinary app routes keep the global prefix.
- Added direct `createFastifyAdapter(options, multipartOptions?)` multipart limit coverage for `multipart.maxTotalSize`.
- Wrapped the targeted real-app Fastify integration paths in `try/finally` cleanup so failed assertions do not leak running apps, in-flight multipart requests, or console spies.

## Testing

- `pnpm install` — installed dependencies in the fresh dedicated worktree.
- `pnpm --filter @fluojs/platform-fastify... build` — passed; generated dependency package declarations needed for workspace type resolution.
- `pnpm exec biome lint "packages/platform-fastify/src/adapter.test.ts"` — passed.
- `pnpm --filter @fluojs/platform-fastify typecheck` — passed after dependency build.
- `pnpm --filter @fluojs/platform-fastify test` — passed, 58 tests.
- Changed-file LSP diagnostics were attempted, but the TypeScript LSP server is unavailable in this environment; `tsc` and Biome covered the changed file.

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

Test-only regression coverage for existing documented Fastify adapter contracts; no `.changeset/*.md` required.

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [ ] Changed public exports include a source-level summary.
- [ ] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [ ] Source `@example` blocks and README scenario examples still play complementary roles.

Not applicable: no public exports or README examples changed.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [ ] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

No new runtime behavior is introduced; this PR makes existing README-documented Fastify prefix and multipart contracts executable and hardens cleanup around those integration paths.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests, such as `createPlatformConformanceHarness(...)` for platform component contracts or `createHttpAdapterPortabilityHarness(...)` for HTTP adapter portability contracts.

No platform docs changed; the package-local Fastify adapter test suite now backs the existing package README claims for `globalPrefixExclude` and direct multipart factory options.
