### PR TITLE
Resolve #2423: align Deno adapter public API docs and coverage

### DIFF
--- a/.changeset/platform-deno-constructor-semantics.md
+++ b/.changeset/platform-deno-constructor-semantics.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/platform-deno": patch
+---
+
+Align direct Deno adapter construction with the public factory by sharing option normalization, host alias precedence, and numeric option validation, and document the lifecycle/API surface with matching regression coverage.

--- a/packages/platform-deno/README.ko.md
+++ b/packages/platform-deno/README.ko.md
@@ -57,19 +57,32 @@ const app = await fluoFactory.create(AppModule, { adapter });
 
 await app.listen();
 
-const response = await adapter.handle(new Request('http://localhost:3000/health'));
+try {
+  const response = await adapter.handle(new Request('http://localhost:3000/health'));
+  console.log(await response.json());
+} finally {
+  await app.close();
+}
 ```
+
+### 직접 어댑터 생성
+애플리케이션 코드는 보통 `createDenoAdapter(options)`, `bootstrapDenoApplication(...)`, `runDenoApplication(...)`을 사용해 adapter setup 경계를 명확히 유지하는 편을 권장합니다. 커스텀 orchestration이나 테스트에서는 `new DenoHttpApplicationAdapter(options)`를 직접 사용할 수 있으며, constructor는 factory와 같은 public `DenoAdapterOptions`를 받아 기본 port를 적용하고, portable `host` alias보다 `hostname`을 우선하며, 잘못된 `port` 또는 `maxBodySize` 값은 setup 시점에 거절합니다.
 
 ### Opt-in Deno WebSocket 바인딩
 어댑터는 애플리케이션이 `@fluojs/websockets/deno` 바인딩을 import하고 설정한 뒤에 Deno의 네이티브 `Deno.upgradeWebSocket`을 지원합니다. 해당 바인딩이 없으면 websocket upgrade 요청은 암묵적으로 upgrade되지 않고 일반 HTTP dispatch 경로를 계속 따릅니다.
 
 ```typescript
 import { Module } from '@fluojs/core';
-import { WebSocketGateway } from '@fluojs/websockets';
-import { DenoWebSocketModule } from '@fluojs/websockets/deno';
+import { DenoWebSocketModule, OnMessage, WebSocketGateway } from '@fluojs/websockets/deno';
+import type { DenoServerWebSocket } from '@fluojs/websockets/deno';
 
 @WebSocketGateway({ path: '/ws' })
-export class MyGateway {}
+export class MyGateway {
+  @OnMessage('ping')
+  handlePing(_payload: unknown, socket: DenoServerWebSocket) {
+    socket.send(JSON.stringify({ event: 'pong', data: 'hello from deno' }));
+  }
+}
 
 @Module({
   imports: [DenoWebSocketModule.forRoot()],
@@ -99,17 +112,23 @@ Advanced option에는 test 또는 non-hosted runtime을 위한 injectable `serve
 
 ## Conformance 커버리지
 
-`packages/platform-deno/src/adapter.test.ts`는 문서화된 Deno 계약을 검증하는 package-local regression 대상입니다. 이 파일은 shared Web dispatch delegation, HTTPS startup forwarding, `Deno.serve(...)` bind target과 startup log에 대한 `host` alias 및 `hostname` 우선순위, 중복 `listen(...)` no-op dispatcher 보존, 기본 `SIGINT`/`SIGTERM` signal listener 등록, `shutdownSignals: false`, partial signal-registration failure 이후 listener rollback, websocket upgrade binding 및 no-binding HTTP fallback, websocket listen 전 bootstrap gating, global Deno serve/upgrade fallback seam, listen 전 `500` 처리, shutdown 중 `503` 처리, serve-signal abort 전 in-flight request drain, bounded 10초 close timeout을 검증합니다.
+`packages/platform-deno/src/adapter.test.ts`는 문서화된 Deno 계약을 검증하는 package-local regression 대상입니다. 이 파일은 shared Web dispatch delegation, `listen(dispatcher)` 이후 direct `adapter.handle(...)` success-path dispatch, 직접 constructor/factory option normalization, HTTPS startup forwarding, `Deno.serve(...)` bind target과 startup log에 대한 `host` alias 및 `hostname` 우선순위, 중복 `listen(...)` no-op dispatcher 보존, 기본 `SIGINT`/`SIGTERM` signal listener 등록, `shutdownSignals: false`, partial signal-registration failure 이후 listener rollback, websocket upgrade binding 및 no-binding HTTP fallback, websocket listen 전 bootstrap gating, global Deno serve/upgrade fallback seam, listen 전 `500` 처리, shutdown 중 `503` 처리, serve-signal abort 전 in-flight request drain, bounded 10초 close timeout을 검증합니다.
 
 공유 edge portability suite인 `packages/testing/src/portability/web-runtime-adapter-portability.test.ts`는 Deno를 Bun 및 Cloudflare Workers와 함께 실행해 malformed cookie 보존, query decoding, JSON/text raw-body capture, multipart raw-body 제외, SSE framing을 검증합니다. 패키지 테스트의 README parity assertion은 이 edge-runtime 커버리지 문서가 한국어 mirror와 계속 동기화되도록 확인합니다.
 
 ## 공개 API 개요
 
-- `createDenoAdapter(options)`: Deno HTTP 어댑터를 위한 팩토리입니다.
+- `createDenoAdapter(options)`: Deno HTTP 어댑터를 위한 팩토리이며, 직접 생성과 같은 validation 및 normalization을 공유합니다.
 - `bootstrapDenoApplication(module, options)`: 커스텀 오케스트레이션을 위한 고급 부트스트랩입니다.
 - `runDenoApplication(module, options)`: Deno를 위한 권장 빠른 시작 헬퍼입니다.
-- `DenoHttpApplicationAdapter`: `handle(...)`, `getListenTarget()`, `getRealtimeCapability()`, `getServer()`, `configureWebSocketBinding(...)`를 제공하는 핵심 adapter 구현체입니다.
-- `handle(request)`: 수동 `Request` to `Response` 디스패처입니다.
+- `DenoHttpApplicationAdapter(options)`: 핵심 adapter 구현체입니다. Direct `new DenoHttpApplicationAdapter(options)`는 `createDenoAdapter(options)`와 같은 기본 port, `host` alias 처리, `hostname` 우선순위, 숫자 option validation을 적용합니다.
+- `listen(dispatcher)`: fluo HTTP dispatcher를 bind하고 `Deno.serve`를 시작합니다. 중복 호출은 원래 dispatcher를 보존하는 no-op입니다.
+- `close()`: 새 유입을 중단하고 active request를 최대 10초 drain한 뒤, shutdown이 끝나지 않으면 Deno serve signal을 abort합니다.
+- `handle(request)`: 수동 `Request` to `Response` 디스패처입니다. `listen(dispatcher)`가 runtime dispatcher를 bind한 뒤에는 성공 경로를 실행하고, bind 전에는 JSON `500`, shutdown 중에는 JSON `503`을 반환합니다.
+- `getListenTarget()`: Deno `hostname` 또는 portable `host` alias를 사용해 bind target과 public URL을 보고합니다.
+- `getRealtimeCapability()`: runtime integration을 위한 fetch-style Deno websocket upgrade capability를 보고합니다.
+- `getServer()`: adapter가 listen 중일 때 active `Deno.serve` controller를 반환합니다.
+- `configureWebSocketBinding(...)`: `listen(dispatcher)`가 server를 시작하기 전에 `@fluojs/websockets/deno` binding을 설치합니다.
 - `https: { cert, key }`: `Deno.serve`로 전달되고 보고되는 listen URL에 반영되는 HTTPS 시작 옵션입니다.
 - Option 및 seam type: `DenoServeOptions`, `DenoServeController`, `DenoServerWebSocket`, websocket binding interface, bootstrap/run option, listen-target helper.
 

--- a/packages/platform-deno/README.md
+++ b/packages/platform-deno/README.md
@@ -57,19 +57,32 @@ const app = await fluoFactory.create(AppModule, { adapter });
 
 await app.listen();
 
-const response = await adapter.handle(new Request('http://localhost:3000/health'));
+try {
+  const response = await adapter.handle(new Request('http://localhost:3000/health'));
+  console.log(await response.json());
+} finally {
+  await app.close();
+}
 ```
+
+### Direct Adapter Construction
+Application code should usually prefer `createDenoAdapter(options)`, `bootstrapDenoApplication(...)`, or `runDenoApplication(...)` so adapter setup stays explicit. Custom orchestration and tests may use `new DenoHttpApplicationAdapter(options)` directly; the constructor accepts the same public `DenoAdapterOptions` as the factory, applies the default port, preserves `hostname` over the portable `host` alias, and rejects invalid `port` or `maxBodySize` values during setup.
 
 ### Opt-in Deno WebSocket Binding
 The adapter supports Deno's native `Deno.upgradeWebSocket` after the application imports and configures the `@fluojs/websockets/deno` binding. Without that binding, websocket upgrade requests continue through normal HTTP dispatch instead of being upgraded implicitly.
 
 ```typescript
 import { Module } from '@fluojs/core';
-import { WebSocketGateway } from '@fluojs/websockets';
-import { DenoWebSocketModule } from '@fluojs/websockets/deno';
+import { DenoWebSocketModule, OnMessage, WebSocketGateway } from '@fluojs/websockets/deno';
+import type { DenoServerWebSocket } from '@fluojs/websockets/deno';
 
 @WebSocketGateway({ path: '/ws' })
-export class MyGateway {}
+export class MyGateway {
+  @OnMessage('ping')
+  handlePing(_payload: unknown, socket: DenoServerWebSocket) {
+    socket.send(JSON.stringify({ event: 'pong', data: 'hello from deno' }));
+  }
+}
 
 @Module({
   imports: [DenoWebSocketModule.forRoot()],
@@ -99,17 +112,23 @@ Advanced options include injectable `serve` and `upgradeWebSocket` seams for tes
 
 ## Conformance Coverage
 
-`packages/platform-deno/src/adapter.test.ts` is the package-local regression target for the documented Deno contract. It covers shared Web dispatch delegation, HTTPS startup forwarding, `host` alias and `hostname` precedence for the `Deno.serve(...)` bind target and startup log, duplicate `listen(...)` no-op dispatcher preservation, default `SIGINT`/`SIGTERM` signal listener registration, `shutdownSignals: false`, listener rollback after partial signal-registration failure, websocket upgrade binding and no-binding HTTP fallback, websocket pre-listen bootstrap gating, global Deno serve/upgrade fallback seams, pre-listen `500` handling, shutdown `503` handling, in-flight request drain before serve-signal abort, and the bounded 10-second close timeout.
+`packages/platform-deno/src/adapter.test.ts` is the package-local regression target for the documented Deno contract. It covers shared Web dispatch delegation, direct `adapter.handle(...)` success-path dispatch after `listen(dispatcher)`, direct constructor/factory option normalization, HTTPS startup forwarding, `host` alias and `hostname` precedence for the `Deno.serve(...)` bind target and startup log, duplicate `listen(...)` no-op dispatcher preservation, default `SIGINT`/`SIGTERM` signal listener registration, `shutdownSignals: false`, listener rollback after partial signal-registration failure, websocket upgrade binding and no-binding HTTP fallback, websocket pre-listen bootstrap gating, global Deno serve/upgrade fallback seams, pre-listen `500` handling, shutdown `503` handling, in-flight request drain before serve-signal abort, and the bounded 10-second close timeout.
 
 The shared edge portability suite in `packages/testing/src/portability/web-runtime-adapter-portability.test.ts` exercises Deno beside Bun and Cloudflare Workers for malformed cookie preservation, query decoding, JSON/text raw-body capture, multipart raw-body exclusion, and SSE framing. The README parity assertion in the package test keeps these documented edge-runtime coverage claims synchronized with the Korean mirror.
 
 ## Public API Overview
 
-- `createDenoAdapter(options)`: Factory for the Deno HTTP adapter.
+- `createDenoAdapter(options)`: Factory for the Deno HTTP adapter; it shares validation and normalization with direct construction.
 - `bootstrapDenoApplication(module, options)`: Advanced bootstrap for custom orchestration.
 - `runDenoApplication(module, options)`: Recommended quick-start helper for Deno.
-- `DenoHttpApplicationAdapter`: Core adapter implementation with `handle(...)`, `getListenTarget()`, `getRealtimeCapability()`, `getServer()`, and `configureWebSocketBinding(...)`.
-- `handle(request)`: Manual `Request` to `Response` dispatcher.
+- `DenoHttpApplicationAdapter(options)`: Core adapter implementation. Direct `new DenoHttpApplicationAdapter(options)` applies the same default port, `host` alias handling, `hostname` precedence, and numeric option validation as `createDenoAdapter(options)`.
+- `listen(dispatcher)`: Binds the fluo HTTP dispatcher and starts `Deno.serve`; duplicate calls are no-ops while preserving the original dispatcher.
+- `close()`: Stops ingress, drains active requests for up to 10 seconds, and aborts the Deno serve signal if shutdown does not settle.
+- `handle(request)`: Manual `Request` to `Response` dispatcher. It succeeds after `listen(dispatcher)` binds the runtime dispatcher, returns JSON `500` before binding, and returns JSON `503` while shutdown is in progress.
+- `getListenTarget()`: Reports the bind target and public URL using Deno `hostname` or the portable `host` alias.
+- `getRealtimeCapability()`: Reports the fetch-style Deno websocket upgrade capability for runtime integration.
+- `getServer()`: Returns the active `Deno.serve` controller while the adapter is listening.
+- `configureWebSocketBinding(...)`: Installs the `@fluojs/websockets/deno` binding before `listen(dispatcher)` starts the server.
 - `https: { cert, key }`: HTTPS startup options forwarded to `Deno.serve` and reflected in the reported listen URL.
 - Option and seam types: `DenoServeOptions`, `DenoServeController`, `DenoServerWebSocket`, websocket binding interfaces, bootstrap/run options, and listen-target helpers.
 

--- a/packages/platform-deno/src/adapter.test.ts
+++ b/packages/platform-deno/src/adapter.test.ts
@@ -33,6 +33,8 @@ import {
   runDenoApplication,
 } from './adapter.js';
 
+// allow: SIZE_OK — Package-local Deno adapter contract regressions share serve, dispatch, signal, websocket, and README fixtures.
+
 const TEST_TLS_PRIVATE_KEY = `-----BEGIN PRIVATE KEY-----
 MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDBbj6DdMPNvDMr
 yNUM0dreceSBINfH+VDV750R3X57mdoqebUgjKOXjbjR7JRkloJ4PEgAic+840rq
@@ -375,6 +377,8 @@ describe('@fluojs/platform-deno', () => {
   it('rejects invalid explicit numeric adapter options during setup', () => {
     expect(() => createDenoAdapter({ maxBodySize: -1 })).toThrow(/maxBodySize/i);
     expect(() => createDenoAdapter({ port: 1.5 })).toThrow(/port/i);
+    expect(() => new DenoHttpApplicationAdapter({ maxBodySize: -1 })).toThrow(/maxBodySize/i);
+    expect(() => new DenoHttpApplicationAdapter({ port: 1.5 })).toThrow(/port/i);
   });
 
   it('uses the transport-neutral application logger by default for terminal Deno startup helpers', async () => {
@@ -409,14 +413,30 @@ describe('@fluojs/platform-deno', () => {
   it('keeps edge runtime README conformance coverage aligned across English and Korean docs', () => {
     const englishReadme = readFileSync(new URL('../README.md', import.meta.url), 'utf8');
     const koreanReadme = readFileSync(new URL('../README.ko.md', import.meta.url), 'utf8');
+    const sharedReadmeClaims = [
+      'Deno.serve',
+      'SIGINT',
+      'SIGTERM',
+      '10',
+      'packages/platform-deno/src/adapter.test.ts',
+      'packages/testing/src/portability/web-runtime-adapter-portability.test.ts',
+      'new DenoHttpApplicationAdapter',
+      'createDenoAdapter(options)',
+      'DenoWebSocketModule, OnMessage, WebSocketGateway',
+      'DenoServerWebSocket',
+      'listen(dispatcher)',
+      'close()',
+      'handle(request)',
+      'getListenTarget()',
+      'getRealtimeCapability()',
+      'getServer()',
+      'configureWebSocketBinding(...)',
+    ] as const;
 
     for (const readme of [englishReadme, koreanReadme]) {
-      expect(readme).toContain('Deno.serve');
-      expect(readme).toContain('SIGINT');
-      expect(readme).toContain('SIGTERM');
-      expect(readme).toContain('10');
-      expect(readme).toContain('packages/platform-deno/src/adapter.test.ts');
-      expect(readme).toContain('packages/testing/src/portability/web-runtime-adapter-portability.test.ts');
+      for (const claim of sharedReadmeClaims) {
+        expect(readme).toContain(claim);
+      }
     }
   });
 
@@ -443,45 +463,78 @@ describe('@fluojs/platform-deno', () => {
     });
 
     const server = createServeStub();
-    const app = await bootstrapDenoApplication(AppModule, {
-      port: 4567,
-      rawBody: true,
-      serve: server.serve,
-    });
+    let app: Application | undefined;
 
-    await app.listen();
+    try {
+      app = await bootstrapDenoApplication(AppModule, {
+        port: 4567,
+        rawBody: true,
+        serve: server.serve,
+      });
 
-    expect(server.options).toMatchObject({
-      hostname: '0.0.0.0',
-      port: 4567,
-    });
-    expect(server.options?.signal?.aborted).toBe(false);
+      await app.listen();
 
-    const response = await server.handler?.(new Request('https://runtime.test/hooks/stripe?tag=one&tag=two', {
-      body: JSON.stringify({ provider: 'stripe' }),
-      headers: {
-        cookie: 'session=abc%20123; bad=%E0%A4%A',
-        'content-type': 'application/json',
-      },
-      method: 'POST',
-    }));
+      expect(server.options).toMatchObject({
+        hostname: '0.0.0.0',
+        port: 4567,
+      });
+      expect(server.options?.signal?.aborted).toBe(false);
 
-    expect(response).toBeInstanceOf(Response);
-    expect(response?.status).toBe(201);
-    await expect(response?.json()).resolves.toEqual({
-      cookies: { bad: '%E0%A4%A', session: 'abc 123' },
-      method: 'POST',
-      parsed: { provider: 'stripe' },
-      path: '/hooks/stripe',
-      query: { tag: ['one', 'two'] },
-      raw: '{"provider":"stripe"}',
-      url: '/hooks/stripe?tag=one&tag=two',
-    });
+      const response = await server.handler?.(new Request('https://runtime.test/hooks/stripe?tag=one&tag=two', {
+        body: JSON.stringify({ provider: 'stripe' }),
+        headers: {
+          cookie: 'session=abc%20123; bad=%E0%A4%A',
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      }));
 
-    await app.close();
+      expect(response).toBeInstanceOf(Response);
+      expect(response?.status).toBe(201);
+      await expect(response?.json()).resolves.toEqual({
+        cookies: { bad: '%E0%A4%A', session: 'abc 123' },
+        method: 'POST',
+        parsed: { provider: 'stripe' },
+        path: '/hooks/stripe',
+        query: { tag: ['one', 'two'] },
+        raw: '{"provider":"stripe"}',
+        url: '/hooks/stripe?tag=one&tag=two',
+      });
+    } finally {
+      await app?.close();
+    }
 
     expect(server.shutdown).toHaveBeenCalledTimes(1);
     expect(server.options?.signal?.aborted).toBe(true);
+  });
+
+  it('dispatches successful requests through adapter.handle after listen binds the dispatcher', async () => {
+    const server = createServeStub();
+    const adapter = createDenoAdapter({
+      serve: server.serve,
+    });
+
+    try {
+      await adapter.listen({
+        async dispatch(request: FrameworkRequest, response: FrameworkResponse) {
+          response.setStatus(202);
+          await response.send({
+            method: request.method,
+            path: request.path,
+          });
+        },
+      });
+
+      const response = await adapter.handle(new Request('https://runtime.test/manual-dispatch'));
+
+      expect(response.status).toBe(202);
+      await expect(response.json()).resolves.toEqual({
+        method: 'GET',
+        path: '/manual-dispatch',
+      });
+    } finally {
+      await adapter.close();
+    }
   });
 
   it('supports SSE streaming over the shared Web response bridge', async () => {
@@ -505,25 +558,29 @@ describe('@fluojs/platform-deno', () => {
     });
 
     const server = createServeStub();
-    const app = await bootstrapDenoApplication(AppModule, {
-      serve: server.serve,
-    });
+    let app: Application | undefined;
 
-    await app.listen();
+    try {
+      app = await bootstrapDenoApplication(AppModule, {
+        serve: server.serve,
+      });
 
-    const response = await server.handler?.(new Request('https://runtime.test/events', {
-      headers: {
-        accept: 'text/event-stream',
-      },
-    }));
-    const body = await response?.text();
+      await app.listen();
 
-    expect(response?.status).toBe(200);
-    expect(response?.headers.get('content-type')).toContain('text/event-stream');
-    expect(body).toContain('event: ready');
-    expect(body).toContain('data: {"ready":true}');
+      const response = await server.handler?.(new Request('https://runtime.test/events', {
+        headers: {
+          accept: 'text/event-stream',
+        },
+      }));
+      const body = await response?.text();
 
-    await app.close();
+      expect(response?.status).toBe(200);
+      expect(response?.headers.get('content-type')).toContain('text/event-stream');
+      expect(body).toContain('event: ready');
+      expect(body).toContain('data: {"ready":true}');
+    } finally {
+      await app?.close();
+    }
   });
 
   it('logs the listen target through the run helper', async () => {
@@ -651,6 +708,17 @@ describe('@fluojs/platform-deno', () => {
     expect(adapter.getListenTarget()).toEqual({
       bindTarget: '127.0.0.1:3000',
       url: 'http://127.0.0.1:3000',
+    });
+  });
+
+  it('normalizes direct constructor options through the same public factory semantics', () => {
+    const adapter = new DenoHttpApplicationAdapter({
+      host: '0.0.0.0',
+    });
+
+    expect(adapter.getListenTarget()).toEqual({
+      bindTarget: '0.0.0.0:3000',
+      url: 'http://localhost:3000',
     });
   });
 

--- a/packages/platform-deno/src/adapter.ts
+++ b/packages/platform-deno/src/adapter.ts
@@ -127,7 +127,11 @@ declare global {
 
 /**
  * Deno-backed HTTP adapter that preserves request draining and websocket binding seams.
+ *
+ * Direct construction accepts the same public options as `createDenoAdapter(...)` and applies the
+ * same default port, `host` alias, `hostname` precedence, and numeric option validation.
  */
+// allow: SIZE_OK — Deno serve, websocket, signal, and shutdown state form one adapter lifecycle state machine.
 export class DenoHttpApplicationAdapter implements HttpApplicationAdapter {
   private abortController?: AbortController;
   private closeInFlight?: Promise<void>;
@@ -140,12 +144,19 @@ export class DenoHttpApplicationAdapter implements HttpApplicationAdapter {
   private readonly options: Required<Pick<DenoAdapterOptions, 'hostname' | 'port'>> & DenoAdapterOptions;
   private readonly webRequestResponseFactory;
 
-  constructor(options: Required<Pick<DenoAdapterOptions, 'hostname' | 'port'>> & DenoAdapterOptions) {
-    this.options = options;
+  /**
+   * Create a Deno adapter with the same normalization rules as `createDenoAdapter(...)`.
+   *
+   * @param options Transport, parsing, and websocket-host configuration for the Deno runtime.
+   */
+  constructor(options: DenoAdapterOptions = {}) {
+    const resolvedOptions = normalizeDenoAdapterOptions(options);
+
+    this.options = resolvedOptions;
     this.webRequestResponseFactory = createWebRequestResponseFactory({
-      maxBodySize: options.maxBodySize,
-      multipart: options.multipart,
-      rawBody: options.rawBody,
+      maxBodySize: resolvedOptions.maxBodySize,
+      multipart: resolvedOptions.multipart,
+      rawBody: resolvedOptions.rawBody,
     });
   }
 
@@ -322,13 +333,19 @@ export class DenoHttpApplicationAdapter implements HttpApplicationAdapter {
  * @returns A Deno-backed `HttpApplicationAdapter`.
  */
 export function createDenoAdapter(options: DenoAdapterOptions = {}): DenoHttpApplicationAdapter {
+  return new DenoHttpApplicationAdapter(options);
+}
+
+function normalizeDenoAdapterOptions(
+  options: DenoAdapterOptions,
+): Required<Pick<DenoAdapterOptions, 'hostname' | 'port'>> & DenoAdapterOptions {
   validateNonNegativeIntegerOption('maxBodySize', options.maxBodySize);
 
-  return new DenoHttpApplicationAdapter({
+  return {
     ...options,
     hostname: options.hostname ?? options.host ?? DEFAULT_HOSTNAME,
     port: resolveDenoPort(options.port),
-  });
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

Align `@fluojs/platform-deno` public API documentation, direct constructor semantics, and regression coverage for the Deno HTTP adapter.

Linked context: Closes #2423

## Changes

- Shared `DenoHttpApplicationAdapter` direct-constructor option normalization with `createDenoAdapter(options)`, including default port, `host` alias, `hostname` precedence, and numeric option validation.
- Updated `packages/platform-deno/README.md` and `README.ko.md` for direct construction semantics, public lifecycle methods, `adapter.handle(...)`, cleanup `finally` examples, and Deno WebSocket subpath imports.
- Added regression coverage for direct constructor validation/defaults, `adapter.handle(...)` success dispatch after `listen(dispatcher)`, README parity assertions, and app cleanup `finally` paths.
- Added a patch Changeset for the public constructor behavior fix.

## Testing

- `pnpm install`
- Red check before implementation/docs: `pnpm --filter @fluojs/platform-deno test` failed for direct constructor validation/normalization and README parity expectations.
- `pnpm --filter @fluojs/platform-deno... build` — passed.
- `pnpm --filter @fluojs/platform-deno build` — passed.
- `pnpm --filter @fluojs/platform-deno typecheck` — passed.
- `pnpm --filter @fluojs/platform-deno test` — passed, 39 tests.
- `pnpm exec biome check packages/platform-deno/src/adapter.ts packages/platform-deno/src/adapter.test.ts packages/platform-deno/README.md packages/platform-deno/README.ko.md .changeset/platform-deno-constructor-semantics.md` — passed.
- `pnpm verify:public-export-tsdoc` — passed.
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main` — passed.
- `pnpm verify:platform-consistency-governance` — passed.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Patch release rationale: direct `new DenoHttpApplicationAdapter(options)` is a public class construction path. It now matches the factory's validation/default/host-normalization semantics instead of bypassing them.

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests, such as `createPlatformConformanceHarness(...)` for platform component contracts or `createHttpAdapterPortabilityHarness(...)` for HTTP adapter portability contracts.
