### PR TITLE
test(discord): cover bootstrap and payload regressions

### DIFF
--- a/packages/discord/README.ko.md
+++ b/packages/discord/README.ko.md
@@ -176,7 +176,7 @@ Behavioral contract 메모:
 
 - 하나의 notification dispatch는 정확히 하나의 Discord thread 경로로 매핑됩니다. `payload.threadId` 또는 `recipients`의 단일 항목을 사용해야 합니다.
 - `payload.threadId`가 없으면 `DiscordService.sendNotification(...)`는 첫 번째 `recipients` 항목을 사용하고, 그것도 없으면 `defaultThreadId`로 폴백합니다.
-- notification metadata는 payload metadata, dispatch metadata, template/subject marker를 합쳐 구성됩니다. `template`은 renderer가 구성된 경우에만 렌더링됩니다.
+- notification metadata는 payload metadata, dispatch metadata, template/subject marker를 합쳐 구성됩니다. 중복 key에서는 dispatch metadata가 payload metadata를 덮어쓰고, 최종 `subject` / `template` marker가 둘 모두를 덮어씁니다. `template`은 renderer가 구성된 경우에만 렌더링됩니다.
 - 여러 Discord thread로 fan-out이 필요한 notification workflow라면 thread별 concrete Discord message를 만들어 `DiscordService.sendMany(...)`로 보내거나 별도 notification dispatch를 실행해야 합니다. 하나의 notification dispatch는 multi-recipient fan-out을 암묵적으로 확장하지 않습니다.
 
 ### 명시적 fetch 주입을 사용하는 webhook-first 전달

--- a/packages/discord/README.md
+++ b/packages/discord/README.md
@@ -176,7 +176,7 @@ Behavioral contract notes:
 
 - One notification dispatch maps to exactly one Discord thread route. Use `payload.threadId` or a single entry in `recipients`.
 - If `payload.threadId` is omitted, `DiscordService.sendNotification(...)` uses the first `recipients` entry or falls back to `defaultThreadId`.
-- Notification metadata is merged from payload metadata, dispatch metadata, and template/subject markers. `template` is rendered only when a renderer is configured.
+- Notification metadata is merged from payload metadata, dispatch metadata, and template/subject markers. On duplicate keys, dispatch metadata overrides payload metadata, and final `subject` / `template` markers override both. `template` is rendered only when a renderer is configured.
 - If a notification workflow needs fan-out across multiple Discord threads, create one concrete Discord message per thread with `DiscordService.sendMany(...)` or issue separate notification dispatches; a single notification dispatch never expands multi-recipient fan-out implicitly.
 
 ### Webhook-first delivery with explicit fetch injection

--- a/packages/discord/src/module.test.ts
+++ b/packages/discord/src/module.test.ts
@@ -352,6 +352,49 @@ describe('DiscordModule', () => {
     expect(transportState.closeCalls).toBe(1);
   });
 
+  it('skips bootstrap verification when verifyOnModuleInit is true but the transport has no verifier', async () => {
+    const sent: NormalizedDiscordMessage[] = [];
+    const transport = {
+      async send(message: NormalizedDiscordMessage) {
+        sent.push(message);
+
+        return {
+          messageId: 'no-verify-1',
+          ok: true,
+          response: 'ok',
+          statusCode: 200,
+          threadId: message.threadId,
+          warnings: [],
+        };
+      },
+    } satisfies DiscordTransport;
+    const container = new Container();
+    const moduleType = DiscordModule.forRoot({
+      defaultThreadId: 'thread-no-verify',
+      transport,
+      verifyOnModuleInit: true,
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(DiscordService);
+    await service.onModuleInit();
+
+    const result = await service.send({ content: 'Capability-based verification' });
+
+    expect(result).toMatchObject({
+      messageId: 'no-verify-1',
+      ok: true,
+      threadId: 'thread-no-verify',
+    });
+    expect('verify' in transport).toBe(false);
+    expect(sent).toEqual([
+      expect.objectContaining({
+        content: 'Capability-based verification',
+        threadId: 'thread-no-verify',
+      }),
+    ]);
+  });
+
   it('resolves async options once and exposes the compatibility facade and channel token', async () => {
     const DISCORD_CONFIG = Symbol('discord-config');
     const factoryCalls: string[] = [];
@@ -495,8 +538,54 @@ describe('DiscordModule', () => {
     expect(transportState.sent[0]?.embeds).toHaveLength(1);
   });
 
+  it('merges notification metadata with dispatch and subject-template marker precedence', async () => {
+    const container = new Container();
+    const moduleType = DiscordModule.forRoot({
+      renderer: {
+        async render() {
+          return { content: 'Rendered deployment notice' };
+        },
+      },
+      transport: createRecordingTransportFactory({ responsePrefix: 'metadata' }),
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(DiscordService);
+    await service.onModuleInit();
+
+    const result = await service.sendNotification({
+      channel: 'discord',
+      metadata: {
+        dispatchOnly: 'dispatch',
+        shared: 'dispatch',
+        subject: 'dispatch-subject',
+        template: 'dispatch-template',
+      },
+      payload: {
+        metadata: {
+          payloadOnly: 'payload',
+          shared: 'payload',
+          subject: 'payload-subject',
+          template: 'payload-template',
+        },
+      },
+      subject: 'Release subject',
+      template: 'release-template',
+    });
+
+    expect(result.messageId).toBe('metadata-1');
+    expect(transportState.sent[0]?.metadata).toEqual({
+      dispatchOnly: 'dispatch',
+      payloadOnly: 'payload',
+      shared: 'dispatch',
+      subject: 'Release subject',
+      template: 'release-template',
+    });
+  });
+
   it('creates a webhook-first transport with an explicit fetch-compatible boundary', async () => {
     const calls: Array<{ body?: string; input: string; method?: string }> = [];
+    const rawResponseBody = '{ "channel_id": "chan-1", "guild_id": "guild-1", "id": "msg-1" }';
     const fetchLike: DiscordFetchLike = async (input, init) => {
       calls.push({ body: init?.body, input, method: init?.method });
 
@@ -504,7 +593,7 @@ describe('DiscordModule', () => {
         ok: true,
         status: 200,
         async text() {
-          return JSON.stringify({ channel_id: 'chan-1', guild_id: 'guild-1', id: 'msg-1' });
+          return rawResponseBody;
         },
       };
     };
@@ -525,6 +614,7 @@ describe('DiscordModule', () => {
     );
 
     expect(result).toMatchObject({ messageId: 'msg-1', ok: true, statusCode: 200, threadId: 'thread-ops' });
+    expect(result.response).toBe(rawResponseBody);
     expect(calls).toEqual([
       {
         body: JSON.stringify({ content: 'Webhook path' }),
@@ -815,6 +905,7 @@ describe('DiscordModule', () => {
     vi.useFakeTimers();
 
     try {
+      const rawResponseBody = '{ "channel_id": "chan-1", "guild_id": "guild-1", "id": "msg-1" }';
       const fetchLike = vi
         .fn<DiscordFetchLike>()
         .mockResolvedValueOnce({
@@ -836,7 +927,7 @@ describe('DiscordModule', () => {
           ok: true,
           status: 200,
           async text() {
-            return JSON.stringify({ channel_id: 'chan-1', guild_id: 'guild-1', id: 'msg-1' });
+            return rawResponseBody;
           },
         });
       const transport = createDiscordWebhookTransport({
@@ -847,7 +938,10 @@ describe('DiscordModule', () => {
       const pending = transport.send({ attachments: [], components: [], content: 'Retry path', embeds: [], threadId: 'thread-ops' }, {});
       await vi.runAllTimersAsync();
 
-      await expect(pending).resolves.toMatchObject({ messageId: 'msg-1', ok: true, statusCode: 200, threadId: 'thread-ops' });
+      const result = await pending;
+
+      expect(result).toMatchObject({ messageId: 'msg-1', ok: true, statusCode: 200, threadId: 'thread-ops' });
+      expect(result.response).toBe(rawResponseBody);
       expect(fetchLike).toHaveBeenCalledTimes(3);
     } finally {
       vi.useRealTimers();


### PR DESCRIPTION
## Summary

Adds Discord package regression coverage for the audit gaps tracked in #2448 and documents the metadata precedence contract exercised by those regressions.

Linked context: Resolves #2448

## Changes

- Covers `verifyOnModuleInit: true` when the configured transport has no `verify()` capability.
- Asserts notification metadata merge precedence across payload metadata, dispatch metadata, and subject/template markers.
- Documents the metadata duplicate-key precedence in `packages/discord/README.md` and `packages/discord/README.ko.md`.
- Asserts successful `DiscordSendResult.response` preserves the raw upstream Discord webhook response body, including retry success.

## Testing

- `pnpm --filter @fluojs/discord test -- src/module.test.ts`
- `pnpm --filter @fluojs/discord test`
- `pnpm --filter @fluojs/discord typecheck`
- `pnpm --filter @fluojs/discord... build`
- `GIT_MASTER=1 git diff --check origin/main...HEAD`

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

Regression coverage plus README contract clarification only; no public API, runtime behavior, package contents, or release metadata changed.

## Public export documentation

- [ ] Changed public exports include a source-level summary.
- [ ] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [ ] Source `@example` blocks and README scenario examples still play complementary roles.

No public exports changed.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [ ] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

Existing Discord notification metadata precedence is now documented in the affected package README pair and covered by package-local regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by the applicable platform harness tests, such as `createPlatformConformanceHarness(...)` for platform component contracts or `createHttpAdapterPortabilityHarness(...)` for HTTP adapter portability contracts.

No platform contract docs changed; the affected package README and Korean mirror were updated together.