### PR TITLE
test(email): cover notification docs and visibility gaps

### DIFF
--- a/packages/email/README.ko.md
+++ b/packages/email/README.ko.md
@@ -235,7 +235,7 @@ export class AppModule {}
 지원하는 notification payload 필드:
 
 - `to`, `cc`, `bcc`, `from`, `replyTo`
-- `text`, `html`, `attachments`, `headers`
+- `text`, `html`, `attachments`, `headers`, `metadata`
 - 모듈에 renderer가 구성된 경우 `templateData`
 
 Behavioral contract 메모:

--- a/packages/email/README.md
+++ b/packages/email/README.md
@@ -235,7 +235,7 @@ export class AppModule {}
 Supported notification payload fields:
 
 - `to`, `cc`, `bcc`, `from`, `replyTo`
-- `text`, `html`, `attachments`, `headers`
+- `text`, `html`, `attachments`, `headers`, `metadata`
 - `templateData` when a renderer is configured on the module
 
 Behavioral contract notes:

--- a/packages/email/src/module.test.ts
+++ b/packages/email/src/module.test.ts
@@ -370,6 +370,15 @@ describe('EmailModule', () => {
         transport: createRecordingTransportFactory(),
       }),
     );
+    const asyncDefaultMetadata = getModuleMetadata(
+      EmailModule.forRootAsync({
+        inject: [],
+        useFactory: () => ({
+          defaultFrom: 'async-global@example.com',
+          transport: createRecordingTransportFactory({ messagePrefix: 'async-global' }),
+        }),
+      }),
+    );
     const asyncMetadata = getModuleMetadata(
       EmailModule.forRootAsync({
         global: false,
@@ -382,6 +391,7 @@ describe('EmailModule', () => {
     );
 
     expect(syncMetadata?.global).toBe(true);
+    expect(asyncDefaultMetadata?.global).toBe(true);
     expect(asyncMetadata?.global).toBe(false);
   });
 
@@ -841,6 +851,32 @@ describe('EmailModule', () => {
           },
           '2026-04-27T00:00:00.000Z',
         ),
+      ),
+    ).rejects.toMatchObject({
+      message: 'Email transport reported an incomplete delivery (accepted=0, pending=0, rejected=0).',
+      name: 'EmailDeliveryError',
+    });
+  });
+
+  it('fails direct notification channel sends when the transport accepts zero recipients', async () => {
+    const container = new Container();
+    const moduleType = EmailModule.forRoot({
+      defaultFrom: 'noreply@example.com',
+      transport: new ZeroAcceptedTransport(),
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const channel = await container.resolve(EmailChannel);
+
+    await expect(
+      channel.send(
+        {
+          channel: 'email',
+          payload: { text: 'Hello' },
+          recipients: ['user@example.com'],
+          subject: 'Subject',
+        },
+        {},
       ),
     ).rejects.toMatchObject({
       message: 'Email transport reported an incomplete delivery (accepted=0, pending=0, rejected=0).',


### PR DESCRIPTION
## Summary

Closes the `@fluojs/email` documentation and regression gaps tracked in #2446.

Linked context: Resolves #2446

## Changes

- Documents `metadata` in the supported email notification payload fields in both package README files.
- Adds direct `EmailChannel.send(...)` regression coverage for zero accepted recipients.
- Adds explicit `EmailModule.forRootAsync(...)` default global visibility regression coverage.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm --filter @fluojs/email test -- src/module.test.ts`
- `pnpm --filter @fluojs/email test`
- `pnpm --filter @fluojs/email... build`
- `pnpm --filter @fluojs/email typecheck`
- `pnpm docs:sync-check`
- `GIT_MASTER=1 git diff --check origin/main...HEAD`

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

Docs-only and test-only alignment for existing `@fluojs/email` behavior. No public API, runtime behavior, package manifest, package contents, or release metadata changes.

## Public export documentation

- [ ] Changed public exports include a source-level summary.
- [ ] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [ ] Source `@example` blocks and README scenario examples still play complementary roles.

No public exports changed.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [ ] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

This PR documents existing email notification payload metadata behavior and adds direct regressions for existing delivery and async module visibility contracts.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by the applicable platform harness tests, such as `createPlatformConformanceHarness(...)` for platform component contracts or `createHttpAdapterPortabilityHarness(...)` for HTTP adapter portability contracts.

No platform contract docs changed; the affected package README and Korean mirror were updated together.