### PR TITLE
Resolve #2495: cover React page lifecycle pipeline

### DIFF
--- a/packages/react/src/lifecycle-binding.test.ts
+++ b/packages/react/src/lifecycle-binding.test.ts
@@ -1,0 +1,246 @@
+import { Module } from '@fluojs/core';
+import { appendDtoFieldValidationRule } from '@fluojs/core/request-pipeline';
+import {
+  Controller,
+  Convert,
+  FromBody,
+  FromCookie,
+  FromHeader,
+  FromPath,
+  FromQuery,
+  Get,
+  RequestDto,
+  type FrameworkRequest,
+  type FrameworkResponse,
+} from '@fluojs/http';
+import { bootstrapApplication } from '@fluojs/runtime';
+import { describe, expect, it } from 'vitest';
+
+import { Path, Router } from './decorators.js';
+import { ReactModule } from './module.js';
+
+type TestResponse = FrameworkResponse & { body?: unknown };
+
+function createRequest(path: string, overrides: Partial<FrameworkRequest> = {}): FrameworkRequest {
+  return {
+    body: undefined,
+    cookies: {},
+    headers: {},
+    method: 'GET',
+    params: {},
+    path,
+    query: {},
+    raw: {},
+    url: path,
+    ...overrides,
+  };
+}
+
+function createResponse(): TestResponse {
+  return {
+    committed: false,
+    headers: {},
+    redirect(status: number, location: string) {
+      this.setStatus(status);
+      this.setHeader('Location', location);
+      this.committed = true;
+    },
+    send(body: unknown) {
+      this.body = body;
+      this.committed = true;
+    },
+    setHeader(name: string, value: string | string[]) {
+      this.headers[name] = value;
+    },
+    setStatus(code: number) {
+      this.statusCode = code;
+      this.statusSet = true;
+    },
+  };
+}
+
+function requireQueryValue(prototype: object, propertyKey: string): void {
+  appendDtoFieldValidationRule(prototype, propertyKey, {
+    code: 'VALUE_REQUIRED',
+    kind: 'minLength',
+    message: 'value is required',
+    value: 1,
+  });
+}
+
+describe('React page HTTP lifecycle binding', () => {
+  it('binds request DTO values from path, query, header, cookie, and body fields', async () => {
+    class PageRequest {
+      @FromPath('slug')
+      slug = '';
+
+      @FromQuery('tab')
+      tab = '';
+
+      @FromHeader('x-page-mode')
+      mode = '';
+
+      @FromCookie('session')
+      session = '';
+
+      @FromBody('draft')
+      draft = '';
+    }
+
+    @Router('/pages')
+    class PageRouter {
+      @Path('/:slug')
+      @RequestDto(PageRequest)
+      show(input: PageRequest) {
+        return input;
+      }
+    }
+
+    @Module({
+      imports: [ReactModule.forRoot({ controllers: [PageRouter] })],
+    })
+    class AppModule {}
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+
+    try {
+      // Given: a React page route is registered through ReactModule and declares HTTP DTO bindings.
+      const response = createResponse();
+
+      // When: the dispatcher receives a GET page request with all request sources populated.
+      await app.dispatch(
+        createRequest('/pages/intro', {
+          body: { draft: 'enabled' },
+          cookies: { session: 'cookie-123' },
+          headers: { 'x-page-mode': 'preview' },
+          query: { tab: 'settings' },
+        }),
+        response,
+      );
+
+      // Then: the same HTTP binder materializes the React page DTO.
+      expect(response.statusCode).toBe(200);
+      expect(response.body).toEqual({
+        draft: 'enabled',
+        mode: 'preview',
+        session: 'cookie-123',
+        slug: 'intro',
+        tab: 'settings',
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('applies field-level converters before invoking React page handlers', async () => {
+    class TrimConverter {
+      convert(value: unknown) {
+        return typeof value === 'string' ? value.trim() : value;
+      }
+    }
+
+    class SearchRequest {
+      @Convert(TrimConverter)
+      @FromQuery('q')
+      query = '';
+    }
+
+    @Router('/search')
+    class SearchRouter {
+      @Path('/')
+      @RequestDto(SearchRequest)
+      index(input: SearchRequest) {
+        return input;
+      }
+    }
+
+    @Module({ imports: [ReactModule.forRoot({ controllers: [SearchRouter] })] })
+    class AppModule {}
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+
+    try {
+      // Given: a React page route uses an HTTP field converter.
+      const response = createResponse();
+
+      // When: the request carries an untrimmed query value.
+      await app.dispatch(createRequest('/search', { query: { q: '  fluo  ' } }), response);
+
+      // Then: converter output is passed to the page handler.
+      expect(response.statusCode).toBe(200);
+      expect(response.body).toEqual({ query: 'fluo' });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('returns the same validation error envelope as an ordinary HTTP controller', async () => {
+    class RequiredQueryRequest {
+      @FromQuery('value')
+      value = '';
+    }
+
+    requireQueryValue(RequiredQueryRequest.prototype, 'value');
+
+    @Controller('/api')
+    class ApiController {
+      @Get('/required')
+      @RequestDto(RequiredQueryRequest)
+      required(input: RequiredQueryRequest) {
+        return input;
+      }
+    }
+
+    @Router('/page')
+    class PageRouter {
+      @Path('/required')
+      @RequestDto(RequiredQueryRequest)
+      required(input: RequiredQueryRequest) {
+        return input;
+      }
+    }
+
+    @Module({
+      controllers: [ApiController],
+      imports: [ReactModule.forRoot({ controllers: [PageRouter] })],
+    })
+    class AppModule {}
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+
+    try {
+      // Given: an ordinary controller and a React page share the same validated request DTO.
+      const apiResponse = createResponse();
+      const pageResponse = createResponse();
+      const invalidRequest = { headers: { 'x-request-id': 'req-validation-400' }, query: { value: '' } };
+
+      // When: both routes receive invalid query data.
+      await app.dispatch(createRequest('/api/required', invalidRequest), apiResponse);
+      await app.dispatch(createRequest('/page/required', invalidRequest), pageResponse);
+
+      // Then: React page validation preserves ordinary HTTP error semantics exactly.
+      expect(apiResponse.statusCode).toBe(400);
+      expect(pageResponse.statusCode).toBe(400);
+      expect(pageResponse.body).toEqual(apiResponse.body);
+      expect(pageResponse.body).toEqual({
+        error: {
+          code: 'BAD_REQUEST',
+          details: [
+            {
+              code: 'VALUE_REQUIRED',
+              field: 'value',
+              message: 'value is required',
+              source: 'query',
+            },
+          ],
+          message: 'Validation failed.',
+          meta: undefined,
+          requestId: 'req-validation-400',
+          status: 400,
+        },
+      });
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/packages/react/src/lifecycle-pipeline.test.ts
+++ b/packages/react/src/lifecycle-pipeline.test.ts
@@ -156,6 +156,7 @@ describe('React page HTTP lifecycle pipeline', () => {
   it('keeps request-scoped React page providers isolated across concurrent requests', async () => {
     const firstRequestGate = createDeferred();
     const firstHandlerStarted = createDeferred();
+    const secondHandlerStarted = createDeferred();
 
     class ScopedPageRequest {
       @FromPath('label')
@@ -180,6 +181,10 @@ describe('React page HTTP lifecycle pipeline', () => {
       async show(input: ScopedPageRequest) {
         this.store.labels.push(input.label);
 
+        if (input.label === 'second') {
+          secondHandlerStarted.resolve();
+        }
+
         if (input.label === 'first') {
           firstHandlerStarted.resolve();
           await firstRequestGate.promise;
@@ -203,6 +208,7 @@ describe('React page HTTP lifecycle pipeline', () => {
       await firstHandlerStarted.promise;
       const secondResponse = createResponse();
       const secondDispatch = app.dispatch(createRequest('/scope/second'), secondResponse);
+      await secondHandlerStarted.promise;
 
       // When: both in-flight dispatches settle.
       firstRequestGate.resolve();

--- a/packages/react/src/lifecycle-pipeline.test.ts
+++ b/packages/react/src/lifecycle-pipeline.test.ts
@@ -1,0 +1,291 @@
+import { Inject, Module, Scope } from '@fluojs/core';
+import {
+  Controller,
+  FromPath,
+  Get,
+  InvalidRoutePathError,
+  RequestDto,
+  RouteConflictError,
+  UseGuards,
+  UseInterceptors,
+  Version,
+  type CallHandler,
+  type FrameworkRequest,
+  type FrameworkResponse,
+  type Guard,
+  type GuardContext,
+  type Interceptor,
+  type InterceptorContext,
+  type Middleware,
+  type MiddlewareContext,
+  type Next,
+} from '@fluojs/http';
+import { bootstrapApplication } from '@fluojs/runtime';
+import { describe, expect, it } from 'vitest';
+
+import { Path, Router } from './decorators.js';
+import { ReactModule } from './module.js';
+
+type TestResponse = FrameworkResponse & { body?: unknown };
+
+function createRequest(path: string): FrameworkRequest {
+  return {
+    body: undefined,
+    cookies: {},
+    headers: {},
+    method: 'GET',
+    params: {},
+    path,
+    query: {},
+    raw: {},
+    url: path,
+  };
+}
+
+function createResponse(): TestResponse {
+  return {
+    committed: false,
+    headers: {},
+    redirect(status: number, location: string) {
+      this.setStatus(status);
+      this.setHeader('Location', location);
+      this.committed = true;
+    },
+    send(body: unknown) {
+      this.body = body;
+      this.committed = true;
+    },
+    setHeader(name: string, value: string | string[]) {
+      this.headers[name] = value;
+    },
+    setStatus(code: number) {
+      this.statusCode = code;
+      this.statusSet = true;
+    },
+  };
+}
+
+function createDeferred(): { readonly promise: Promise<void>; readonly resolve: () => void } {
+  let resolvePromise: () => void = () => undefined;
+  const promise = new Promise<void>((resolve) => {
+    resolvePromise = resolve;
+  });
+
+  return { promise, resolve: resolvePromise };
+}
+
+describe('React page HTTP lifecycle pipeline', () => {
+  it('preserves middleware, guard, interceptor, and URI versioning order', async () => {
+    const events: string[] = [];
+
+    class TraceMiddleware implements Middleware {
+      async handle(context: MiddlewareContext, next: Next): Promise<void> {
+        events.push(`middleware:${context.request.path}`);
+        context.response.setHeader('x-react-middleware', 'ran');
+        await next();
+      }
+    }
+
+    class AllowGuard implements Guard {
+      canActivate(context: GuardContext) {
+        events.push(`guard:${context.requestContext.request.path}`);
+        context.requestContext.response.setHeader('x-react-guard', 'allowed');
+        return true;
+      }
+    }
+
+    class PageInterceptor implements Interceptor {
+      async intercept(_context: InterceptorContext, next: CallHandler) {
+        events.push('interceptor:before');
+        const value = await next.handle();
+        events.push('interceptor:after');
+
+        return { intercepted: true, value };
+      }
+    }
+
+    @Version('2')
+    @UseGuards(AllowGuard)
+    @UseInterceptors(PageInterceptor)
+    @Router('/pages')
+    class PageRouter {
+      @Path('/home')
+      home() {
+        events.push('handler');
+        return { page: 'home' };
+      }
+    }
+
+    @Module({
+      imports: [
+        ReactModule.forRoot({
+          controllers: [PageRouter],
+          middleware: [TraceMiddleware],
+          providers: [AllowGuard, PageInterceptor],
+        }),
+      ],
+    })
+    class AppModule {}
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+
+    try {
+      // Given: a versioned React page route has module middleware, guards, and interceptors.
+      const response = createResponse();
+
+      // When: the HTTP dispatcher handles the version-prefixed page route.
+      await app.dispatch(createRequest('/v2/pages/home'), response);
+
+      // Then: the normal HTTP lifecycle surrounds the React page handler.
+      expect(response.statusCode).toBe(200);
+      expect(response.headers['x-react-middleware']).toBe('ran');
+      expect(response.headers['x-react-guard']).toBe('allowed');
+      expect(response.body).toEqual({ intercepted: true, value: { page: 'home' } });
+      expect(events).toEqual([
+        'middleware:/v2/pages/home',
+        'guard:/v2/pages/home',
+        'interceptor:before',
+        'handler',
+        'interceptor:after',
+      ]);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('keeps request-scoped React page providers isolated across concurrent requests', async () => {
+    const firstRequestGate = createDeferred();
+
+    class ScopedPageRequest {
+      @FromPath('label')
+      label = '';
+    }
+
+    @Scope('request')
+    class RequestStore {
+      private static nextId = 0;
+      readonly id = ++RequestStore.nextId;
+      readonly labels: string[] = [];
+    }
+
+    @Inject(RequestStore)
+    @Scope('request')
+    @Router('/scope')
+    class ScopedPageRouter {
+      constructor(private readonly store: RequestStore) {}
+
+      @Path('/:label')
+      @RequestDto(ScopedPageRequest)
+      async show(input: ScopedPageRequest) {
+        this.store.labels.push(input.label);
+
+        if (input.label === 'first') {
+          await firstRequestGate.promise;
+        }
+
+        return { id: this.store.id, labels: [...this.store.labels] };
+      }
+    }
+
+    @Module({
+      imports: [ReactModule.forRoot({ controllers: [ScopedPageRouter], providers: [RequestStore] })],
+    })
+    class AppModule {}
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+
+    try {
+      // Given: one React page request is held open while a second request starts.
+      const firstResponse = createResponse();
+      const firstDispatch = app.dispatch(createRequest('/scope/first'), firstResponse);
+      await Promise.resolve();
+      const secondResponse = createResponse();
+      const secondDispatch = app.dispatch(createRequest('/scope/second'), secondResponse);
+
+      // When: both in-flight dispatches settle.
+      firstRequestGate.resolve();
+      await Promise.all([firstDispatch, secondDispatch]);
+
+      // Then: each request observes a distinct request-scoped provider instance.
+      expect(firstResponse.body).toEqual({ id: 1, labels: ['first'] });
+      expect(secondResponse.body).toEqual({ id: 2, labels: ['second'] });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('dispatches ordinary HTTP controllers and React routers from the same app', async () => {
+    @Controller('/api')
+    class ApiController {
+      @Get('/status')
+      status() {
+        return { kind: 'api' };
+      }
+    }
+
+    @Router('/pages')
+    class PageRouter {
+      @Path('/status')
+      status() {
+        return { kind: 'react' };
+      }
+    }
+
+    @Module({
+      controllers: [ApiController],
+      imports: [ReactModule.forRoot({ controllers: [PageRouter] })],
+    })
+    class AppModule {}
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+
+    try {
+      // Given: one app graph contains both ordinary controllers and React routers.
+      const apiResponse = createResponse();
+      const pageResponse = createResponse();
+
+      // When: both routes are dispatched through the runtime.
+      await app.dispatch(createRequest('/api/status'), apiResponse);
+      await app.dispatch(createRequest('/pages/status'), pageResponse);
+
+      // Then: both handler types are present in the same HTTP route table.
+      expect(apiResponse.body).toEqual({ kind: 'api' });
+      expect(pageResponse.body).toEqual({ kind: 'react' });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('reuses HTTP route conflict detection for React routers', async () => {
+    @Controller('/conflict')
+    class ApiController {
+      @Get('/')
+      index() {
+        return { kind: 'api' };
+      }
+    }
+
+    @Router('/conflict')
+    class PageRouter {
+      @Path('/')
+      index() {
+        return { kind: 'react' };
+      }
+    }
+
+    @Module({
+      controllers: [ApiController],
+      imports: [ReactModule.forRoot({ controllers: [PageRouter] })],
+    })
+    class AppModule {}
+
+    await expect(bootstrapApplication({ rootModule: AppModule })).rejects.toThrow(RouteConflictError);
+  });
+
+  it('rejects invalid React route grammar through HTTP route validation', () => {
+    expect(() => Router('/files/*')).toThrow(InvalidRoutePathError);
+    expect(() => Path('/files/:id.json')).toThrow(InvalidRoutePathError);
+    expect(() => Path('/files?')).toThrow(InvalidRoutePathError);
+    expect(() => Path('/(.*)')).toThrow(InvalidRoutePathError);
+  });
+});

--- a/packages/react/src/lifecycle-pipeline.test.ts
+++ b/packages/react/src/lifecycle-pipeline.test.ts
@@ -155,6 +155,7 @@ describe('React page HTTP lifecycle pipeline', () => {
 
   it('keeps request-scoped React page providers isolated across concurrent requests', async () => {
     const firstRequestGate = createDeferred();
+    const firstHandlerStarted = createDeferred();
 
     class ScopedPageRequest {
       @FromPath('label')
@@ -180,6 +181,7 @@ describe('React page HTTP lifecycle pipeline', () => {
         this.store.labels.push(input.label);
 
         if (input.label === 'first') {
+          firstHandlerStarted.resolve();
           await firstRequestGate.promise;
         }
 
@@ -198,7 +200,7 @@ describe('React page HTTP lifecycle pipeline', () => {
       // Given: one React page request is held open while a second request starts.
       const firstResponse = createResponse();
       const firstDispatch = app.dispatch(createRequest('/scope/first'), firstResponse);
-      await Promise.resolve();
+      await firstHandlerStarted.promise;
       const secondResponse = createResponse();
       const secondDispatch = app.dispatch(createRequest('/scope/second'), secondResponse);
 

--- a/packages/react/src/lifecycle-pre-render-failure.test.ts
+++ b/packages/react/src/lifecycle-pre-render-failure.test.ts
@@ -1,0 +1,185 @@
+import { Module } from '@fluojs/core';
+import {
+  UseGuards,
+  UseInterceptors,
+  type CallHandler,
+  type FrameworkRequest,
+  type FrameworkResponse,
+  type Guard,
+  type Interceptor,
+  type InterceptorContext,
+} from '@fluojs/http';
+import { bootstrapApplication } from '@fluojs/runtime';
+import { createElement } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { Path, Router } from './decorators.js';
+import { ReactModule } from './module.js';
+import { createReactServerEntry } from './server-entry.js';
+
+type TestResponse = FrameworkResponse & { body?: unknown };
+
+function createRequest(path: string): FrameworkRequest {
+  return {
+    body: undefined,
+    cookies: {},
+    headers: {},
+    method: 'GET',
+    params: {},
+    path,
+    query: {},
+    raw: {},
+    url: path,
+  };
+}
+
+function createResponse(): TestResponse {
+  return {
+    committed: false,
+    headers: {},
+    redirect(status: number, location: string) {
+      this.setStatus(status);
+      this.setHeader('Location', location);
+      this.committed = true;
+    },
+    send(body: unknown) {
+      this.body = body;
+      this.committed = true;
+    },
+    setHeader(name: string, value: string | string[]) {
+      this.headers[name] = value;
+    },
+    setStatus(code: number) {
+      this.statusCode = code;
+      this.statusSet = true;
+    },
+  };
+}
+
+describe('React page pre-render HTTP failures', () => {
+  it('preserves the ordinary HTTP 403 error response when a guard denies before React rendering', async () => {
+    const events: string[] = [];
+    let renderAttempts = 0;
+
+    class DenyGuard implements Guard {
+      canActivate() {
+        events.push('guard');
+        return false;
+      }
+    }
+
+    function GuardedPage() {
+      renderAttempts += 1;
+      return createElement('main', null, 'guarded page');
+    }
+
+    @UseGuards(DenyGuard)
+    @Router('/guarded')
+    class GuardedRouter {
+      @Path('/')
+      show() {
+        events.push('handler');
+        return createReactServerEntry(createElement(GuardedPage), {
+          headers: { 'x-react-entry': 'guarded' },
+        });
+      }
+    }
+
+    @Module({
+      imports: [ReactModule.forRoot({ controllers: [GuardedRouter], providers: [DenyGuard] })],
+    })
+    class AppModule {}
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+
+    try {
+      // Given: a React page route would render HTML if its guard allowed the request.
+      const response = createResponse();
+
+      // When: the guard denies before the page handler can return a React entry.
+      await app.dispatch(createRequest('/guarded'), response);
+
+      // Then: the HTTP dispatcher writes the canonical guard error and never starts React rendering.
+      expect(response.statusCode).toBe(403);
+      expect(response.headers['Content-Type']).toBeUndefined();
+      expect(response.headers['x-react-entry']).toBeUndefined();
+      expect(response.body).toEqual({
+        error: {
+          code: 'FORBIDDEN',
+          details: undefined,
+          message: 'Access denied.',
+          meta: undefined,
+          requestId: undefined,
+          status: 403,
+        },
+      });
+      expect(events).toEqual(['guard']);
+      expect(renderAttempts).toBe(0);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('preserves the ordinary HTTP 500 error response when an interceptor fails before React rendering', async () => {
+    const events: string[] = [];
+    let renderAttempts = 0;
+
+    class FailingInterceptor implements Interceptor {
+      intercept(_context: InterceptorContext, _next: CallHandler): never {
+        events.push('interceptor');
+        throw new Error('React page pre-render interceptor failed.');
+      }
+    }
+
+    function InterceptedPage() {
+      renderAttempts += 1;
+      return createElement('main', null, 'intercepted page');
+    }
+
+    @UseInterceptors(FailingInterceptor)
+    @Router('/intercepted')
+    class InterceptedRouter {
+      @Path('/')
+      show() {
+        events.push('handler');
+        return createReactServerEntry(createElement(InterceptedPage), {
+          headers: { 'x-react-entry': 'intercepted' },
+        });
+      }
+    }
+
+    @Module({
+      imports: [ReactModule.forRoot({ controllers: [InterceptedRouter], providers: [FailingInterceptor] })],
+    })
+    class AppModule {}
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+
+    try {
+      // Given: a React page route would render HTML if its interceptor continued to the handler.
+      const response = createResponse();
+
+      // When: the interceptor throws before calling the handler.
+      await app.dispatch(createRequest('/intercepted'), response);
+
+      // Then: the HTTP dispatcher writes the canonical server error and never starts React rendering.
+      expect(response.statusCode).toBe(500);
+      expect(response.headers['Content-Type']).toBeUndefined();
+      expect(response.headers['x-react-entry']).toBeUndefined();
+      expect(response.body).toEqual({
+        error: {
+          code: 'INTERNAL_SERVER_ERROR',
+          details: undefined,
+          message: 'Internal server error.',
+          meta: undefined,
+          requestId: undefined,
+          status: 500,
+        },
+      });
+      expect(events).toEqual(['interceptor']);
+      expect(renderAttempts).toBe(0);
+    } finally {
+      await app.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds focused regression coverage for React page handlers registered through `@Router(...)` and `@Path(...)`, proving they continue to run through the ordinary `@fluojs/http` request lifecycle.

Linked context: Closes #2495

## Changes

- Added `packages/react/src/lifecycle-binding.test.ts` covering `@RequestDto`, `@FromPath`, `@FromQuery`, `@FromHeader`, `@FromCookie`, `@FromBody`, converters, and validation failure envelopes for React page routes.
- Added `packages/react/src/lifecycle-pipeline.test.ts` covering middleware, guards, interceptors, URI versioning, concurrent request-scoped provider isolation, ordinary controller coexistence, route conflicts, and invalid route grammar rejection.
- Kept the change test-only: no public API, runtime behavior, package manifest, docs, or release metadata changes.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm -r --filter @fluojs/core --filter @fluojs/di --filter @fluojs/validation --filter @fluojs/http --filter @fluojs/runtime --filter @fluojs/react run build`
- `pnpm --dir packages/react run typecheck`
- `pnpm --dir packages/react exec vitest run -c vitest.config.ts src/lifecycle-binding.test.ts src/lifecycle-pipeline.test.ts`
- `pnpm --dir packages/react run test`
- `pnpm --dir packages/http exec vitest run -c vitest.config.ts src/dispatch/dispatcher.test.ts src/adapters/binding.test.ts`
- `pnpm exec biome lint packages/react/src/lifecycle-binding.test.ts packages/react/src/lifecycle-pipeline.test.ts`
- `git diff --check`

LSP diagnostics were unavailable because the TypeScript LSP server is not installed in this environment and the prior user decision declined installation. TypeScript compiler checks and package-local tests were used as the authoritative diagnostics.

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

No changeset is included because this PR only adds regression tests for already documented `@fluojs/react` HTTP lifecycle preservation; it does not change public package behavior, API surface, package contents, or release metadata.

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [ ] Changed public exports include a source-level summary.
- [ ] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [ ] Source `@example` blocks and README scenario examples still play complementary roles.

No public exports changed; this section is not applicable beyond confirming no TSDoc updates are required.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [ ] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

No new behavioral contract is introduced. The new tests lock the existing `packages/react/README.md` promise that React routers reuse HTTP-owned DTO binding, validation, matching, guards, interceptors, middleware, versioning, request scope, and duplicate route detection.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by the applicable platform harness tests, such as `createPlatformConformanceHarness(...)` for platform component contracts or `createHttpAdapterPortabilityHarness(...)` for HTTP adapter portability contracts.

No governance docs, platform contract docs, package README claims, or platform adapter contracts changed. The package-local React runtime tests provide the regression evidence for this test-only lifecycle coverage PR.
