### PR TITLE
Resolve #2563: cover Queue-owned Redis cleanup

### DIFF
--- a/packages/queue/src/module.test.ts
+++ b/packages/queue/src/module.test.ts
@@ -1761,6 +1761,40 @@ describe('@fluojs/queue', () => {
     });
   });
 
+  it('closes Queue-owned Redis duplicates without closing the shared client when duplicate connect fails', async () => {
+    // Given
+    class DuplicateConnectFailureJob {
+      constructor(public readonly id: string) {}
+    }
+
+    @QueueWorker(DuplicateConnectFailureJob)
+    class DuplicateConnectFailureWorker {
+      async handle(_job: DuplicateConnectFailureJob): Promise<void> {}
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [QueueModule.forRoot()],
+      providers: [DuplicateConnectFailureWorker],
+    });
+
+    const redis = new MockRedisClient();
+    redis.failConnectOnDuplicate = 2;
+
+    // When
+    const bootstrap = bootstrapApplication({
+      providers: [{ provide: REDIS_CLIENT, useValue: redis }],
+      rootModule: AppModule,
+    });
+
+    // Then
+    await expect(bootstrap).rejects.toThrow('connect fail:dup-2');
+    expect(redis.duplicates).toHaveLength(2);
+    expect(redis.duplicates.every((connection) => connection.status === 'end')).toBe(true);
+    expect(redis.quitCalls).toEqual([]);
+    expect(redis.disconnectCalls).toEqual([]);
+  });
+
   it('rolls back partially initialized workers, queues, and connections when startup fails', async () => {
     class StartupFirstJob {
       constructor(public readonly id: string) {}
@@ -2076,6 +2110,11 @@ describe('@fluojs/queue', () => {
 
     const worker = bullmqState.workers.get('hanging-processor-job');
     expect(worker?.closeCalls).toBe(2);
+    expect(bullmqState.queues.get('hanging-processor-job')?.closeCalls).toBe(1);
+    expect(redis.duplicates).toHaveLength(2);
+    expect(redis.duplicates.every((connection) => connection.status === 'end')).toBe(true);
+    expect(redis.quitCalls).toEqual([]);
+    expect(redis.disconnectCalls).toEqual([]);
     expect(loggerEvents.some((event) => event.includes('Failed to close queue worker within shutdown timeout.'))).toBe(true);
   });
 


### PR DESCRIPTION
## Summary

Add regression coverage for Queue-owned Redis resource cleanup on duplicate connection failures and forced worker shutdown timeouts.

Linked context: Closes #2563

## Changes

- Verify duplicate connection failures close both Queue-owned Redis duplicates.
- Verify the shared Redis client is never closed by Queue cleanup.
- Verify forced shutdown timeout still closes the worker, queue, and owned duplicate connections.

## Testing

- `pnpm --dir packages/queue test` — 51 tests passed.
- `pnpm --dir packages/queue typecheck` — passed.
- `pnpm --filter @fluojs/queue... build` — passed.
- `pnpm exec biome check packages/queue/src/module.test.ts` — passed.
- Changed-file LSP diagnostics — no errors.
- `git diff --check` — passed.

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

This is test-only regression coverage and does not change public API, package contents, or observable behavior.

## Public export documentation

- [x] No public exports changed; source-level export documentation is not applicable.
- [x] No exported function signatures changed; `@param` / `@returns` updates are not applicable.
- [x] README and source example roles are unchanged.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] No new public behavioral contract was introduced.
- [x] Intentional ownership limitations remain unchanged.
- [x] Queue resource-ownership invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] No governance or EN/KO documentation changed.
- [x] No platform contract documentation changed, so companion updates are not applicable.
- [x] No package README alignment or platform conformance claim changed.