### PR TITLE
Resolve #2557: close Redis monitoring clients

### DIFF
--- a/.changeset/close-redis-monitoring-clients.md
+++ b/.changeset/close-redis-monitoring-clients.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/redis': patch
+---
+
+Close lifecycle-owned Redis clients that are in monitoring mode during application shutdown.

--- a/packages/redis/README.ko.md
+++ b/packages/redis/README.ko.md
@@ -82,7 +82,7 @@ export class CacheRepository {
 - 호출자가 옵션을 강제로 캐스팅하더라도 Fluo는 항상 `lazyConnect: true`를 강제하므로, 소켓은 import 시점이 아니라 애플리케이션 bootstrap 중에 열립니다.
 - bootstrap 단계에서는 클라이언트가 ioredis `wait` 상태일 때만 lifecycle service가 `connect()`를 호출합니다.
 - lifecycle이 소유한 `connect()`와 `quit()` 호출은 package timeout(기본 `10_000` ms)으로 제한되어, Redis 명령이 멈춰도 bootstrap/shutdown이 무기한 대기하지 않습니다. `lifecycle.connectTimeoutMs`와 `lifecycle.quitTimeoutMs`로 재정의할 수 있으며, host process가 의도적으로 무제한 대기를 소유하는 경우에만 `0`을 전달하세요.
-- shutdown 단계에서는 ready/connecting 계열 상태에 `quit()`를 우선 시도해 정상 종료를 노리고, wait/종료 전이 상태에서는 `disconnect()`를 직접 사용합니다.
+- shutdown 단계에서는 ready/connecting 계열 상태에 `quit()`를 우선 시도해 정상 종료를 노리고, monitoring, wait/종료 전이 상태에서는 `disconnect()`를 직접 사용합니다.
 - `quit()`가 실패하면 Fluo는 `disconnect()`로 fallback하고, 그 뒤에도 클라이언트가 닫히지 않은 경우에만 에러를 다시 던집니다.
 
 ### 이름 있는 클라이언트

--- a/packages/redis/README.md
+++ b/packages/redis/README.md
@@ -82,7 +82,7 @@ export class CacheRepository {
 - Fluo always forces `lazyConnect: true`, even if callers cast options manually, so sockets open during application bootstrap instead of import time.
 - During bootstrap, the lifecycle service only calls `connect()` while the client is still in ioredis `wait` state.
 - Lifecycle-owned `connect()` and `quit()` calls are bounded by package timeouts (`10_000` ms by default) so bootstrap and shutdown do not wait forever on a stalled Redis command. Override them with `lifecycle.connectTimeoutMs` and `lifecycle.quitTimeoutMs`; pass `0` only when the host process intentionally owns an unbounded wait.
-- During shutdown, ready/connecting clients attempt `quit()` first for graceful teardown, while wait/closed-transition states use `disconnect()` directly.
+- During shutdown, ready/connecting clients attempt `quit()` first for graceful teardown, while monitoring, wait, and closed-transition states use `disconnect()` directly.
 - If `quit()` fails, Fluo falls back to `disconnect()` and only rethrows when the client still remains open afterward.
 
 ### Named Clients

--- a/packages/redis/src/module.test.ts
+++ b/packages/redis/src/module.test.ts
@@ -46,6 +46,7 @@ const mockRedisState = vi.hoisted(() => ({
   events: [] as string[],
   getError: undefined as Error | undefined,
   instances: [] as MockRedisInstance[],
+  initialStatus: 'wait',
   disconnectStatus: undefined as string | undefined,
   quitError: undefined as Error | undefined,
   quitDeferred: undefined as Deferred<'OK'> | undefined,
@@ -57,7 +58,7 @@ const mockRedisState = vi.hoisted(() => ({
 vi.mock('ioredis', () => ({
   default: class MockRedis {
     readonly options: Record<string, unknown>;
-    status = 'wait';
+    status = mockRedisState.initialStatus;
     private readonly storage = new Map<string, string>();
 
     constructor(options: Record<string, unknown> = {}) {
@@ -164,6 +165,7 @@ describe('@fluojs/redis', () => {
     mockRedisState.events.length = 0;
     mockRedisState.getError = undefined;
     mockRedisState.instances.length = 0;
+    mockRedisState.initialStatus = 'wait';
     mockRedisState.disconnectStatus = undefined;
     mockRedisState.quitError = undefined;
     mockRedisState.quitDeferred = undefined;
@@ -511,6 +513,22 @@ describe('@fluojs/redis', () => {
     await expect(app.close()).resolves.toBeUndefined();
     expect(mockRedisState.events).toEqual(['connect', 'quit', 'disconnect']);
     expect(mockRedisState.instances[0]?.status).toBe('close');
+  });
+
+  it('disconnects a monitoring client during shutdown', async () => {
+    mockRedisState.initialStatus = 'monitoring';
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [RedisModule.forRoot({ host: '127.0.0.1', port: 6379 })],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+
+    await app.close();
+
+    expect(mockRedisState.events).toEqual(['disconnect']);
+    expect(mockRedisState.instances[0]?.status).toBe('end');
   });
 
   it('falls back to disconnect for each named client when quit fails after bootstrap', async () => {

--- a/packages/redis/src/service.ts
+++ b/packages/redis/src/service.ts
@@ -7,7 +7,7 @@ import { getRedisComponentId, REDIS_CLIENT } from './tokens.js';
 import type { RedisLifecycleOptions } from './types.js';
 
 const QUITTABLE_STATUSES = new Set(['connect', 'connecting', 'ready', 'reconnecting']);
-const DISCONNECTABLE_STATUSES = new Set(['close', 'connect', 'connecting', 'ready', 'reconnecting', 'wait']);
+const DISCONNECTABLE_STATUSES = new Set(['close', 'connect', 'connecting', 'monitoring', 'ready', 'reconnecting', 'wait']);
 const DEFAULT_REDIS_LIFECYCLE_TIMEOUT_MS = 10_000;
 
 function isClosed(status: string): boolean {


### PR DESCRIPTION
## Summary

Close lifecycle-owned `@fluojs/redis` clients that enter ioredis monitoring mode during application shutdown.

Linked context: Closes #2557

## Changes

- Treat ioredis `monitoring` as a direct-disconnect shutdown state.
- Add a lifecycle regression test for a monitoring client.
- Document the monitoring-state shutdown contract in both Redis README mirrors.

## Testing

- `pnpm --filter @fluojs/redis test` (59 tests passed)
- `pnpm --filter @fluojs/redis typecheck`
- `pnpm --filter @fluojs/redis build`
- `pnpm lint` (completed; repository has pre-existing warnings/infos)
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main`
- Changed-file LSP diagnostics: no diagnostics.

`pnpm verify` was attempted twice. Its Redis, build, typecheck, and lint stages completed, but unrelated workspace tests timed out under this runner; see remaining risk below.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Added a patch changeset for `@fluojs/redis`: lifecycle-owned monitoring clients are now closed during shutdown.

## Public export documentation

- [x] No public exports changed; source export documentation is not applicable.
- [x] No changed exported functions require `@param` or `@returns` updates.
- [x] README lifecycle documentation was updated in English and Korean.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] The affected Redis README documents the monitoring shutdown behavior in both locales.
- [x] Intentional limitations are unchanged.
- [x] The monitoring shutdown invariant has regression coverage in `packages/redis/src/module.test.ts`.

## Platform consistency governance (SSOT)

- [x] No governed platform contract document changed.
- [x] No platform contract documentation or enforcement change is applicable.
- [x] Package README alignment is covered by the Redis lifecycle regression test.

## Remaining risk

Full `pnpm verify` did not reach exit code 0 in this runner because unrelated workspace tests exceeded their configured timeouts during concurrent build/test activity. The affected Redis package suite, typecheck, build, lint, and release-lane checks pass.