### PR TITLE
Resolve #2569: Correct Cron breaking changeset classification

### DIFF
--- a/.changeset/curly-cron-locks.md
+++ b/.changeset/curly-cron-locks.md
@@ -1,5 +1,10 @@
 ---
-"@fluojs/cron": patch
+"@fluojs/cron": major
 ---
 
 Reject blank decorator scheduling task names, normalize distributed Redis client names, and cover cron lifecycle/status regression paths.
+
+Migration notes:
+
+- Replace blank decorator `name` values with stable non-empty names, and move any scheduled static methods behind public instance methods.
+- Remove leading or trailing whitespace from `distributed.clientName` and register the Redis client under that trimmed name, or omit `clientName` to keep using the default Redis registration.

--- a/.changeset/four-crons-preserve-locks.md
+++ b/.changeset/four-crons-preserve-locks.md
@@ -1,5 +1,11 @@
 ---
-"@fluojs/cron": patch
+"@fluojs/cron": major
 ---
 
 Preserve distributed lock lifecycle contracts by validating enabled lock TTLs before Redis I/O, bounding shutdown lock release attempts, retaining local ownership when release I/O times out, and returning immutable scheduling descriptor snapshots.
+
+Migration notes:
+
+- Configure every enabled module-level `distributed.lockTtlMs` and enabled task-level `lockTtlMs` as an integer of at least `1_000ms` before module registration.
+- Treat values from `SchedulingRegistry.get()` and `getAll()` as immutable snapshots. Use `enable()`, `disable()`, `remove()`, `updateCronExpression()`, or `updateIntervalMs()` instead of mutating descriptors or scheduler handles.
+- Review `shutdown.timeoutMs` against expected Redis latency. Owned-lock release I/O now stops waiting at that boundary and preserves local ownership visibility when the release cannot be confirmed in time.


### PR DESCRIPTION
## Summary

Reclassify two pending `@fluojs/cron` changesets from `patch` to `major` so the release metadata matches the stable 1.0+ behavioral contract policy. Add consumer-facing migration notes for every affected configuration, registry, and shutdown boundary.

Linked context: Closes #2569

## Changes

- Mark `.changeset/curly-cron-locks.md` as `major` and document migration from blank/static scheduling names and whitespace-padded Redis client names.
- Mark `.changeset/four-crons-preserve-locks.md` as `major` and document migration for enabled lock TTLs, immutable registry descriptors, and bounded Redis lock release I/O.
- Preserve the already implemented and documented Cron behavior; this PR changes release classification and migration guidance only.

## Testing

- `pnpm --dir packages/cron test` — passed: 4 files, 78 tests.
- `pnpm verify:platform-consistency-governance` — passed.
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main` — passed.
- `pnpm changeset status --since=origin/main` — reports `@fluojs/cron` at `major`.
- `pnpm dlx node@20 tooling/release/verify-release-readiness.mjs` — passed the full supported-runtime release-readiness build, typecheck, package/app/example/tooling tests, and CLI sandbox matrix without writing draft artifacts.

## Release impact

- [x] This PR has consumer-visible release impact and updates the existing changesets.
- [ ] This PR has no consumer-visible release impact.

The resulting `major` changesets require explicit maintainer approval before merge, as required by release governance.

## Public export documentation

- [x] No public exports or source TSDoc changed; the existing public export documentation remains unchanged.
- [x] Changed exported functions: not applicable.
- [x] Source examples: not applicable.

## Behavioral contract

- [x] No documented behavioral contracts were removed.
- [x] Existing Cron contracts remain documented in the English/Korean package READMEs and governed docs.
- [x] Migration notes now explain the consumer actions required by the existing breaking behavior.
- [x] Existing Cron regression tests cover task-name validation, enabled TTL validation, immutable descriptors, and bounded lock release behavior.

## Platform consistency governance (SSOT)

- [x] No platform contract docs changed.
- [x] Existing English/Korean governed surfaces remain synchronized.
- [x] `pnpm verify:platform-consistency-governance` passed; platform harness changes are not applicable to release-metadata-only edits.