### PR TITLE
Resolve #2589: drain active Slack deliveries before transport close

### DIFF
--- a/.changeset/issue-2589-slack-delivery-drain.md
+++ b/.changeset/issue-2589-slack-delivery-drain.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/slack": patch
+---
+
+Drain active Slack deliveries before closing factory-owned transports during application shutdown.

--- a/book/intermediate/ch17-slack-discord.ko.md
+++ b/book/intermediate/ch17-slack-discord.ko.md
@@ -88,7 +88,7 @@ SlackModule.forRoot({
 });
 ```
 
-상태 스냅샷은 `verifiedOnModuleInit`을 포함하므로 readiness dashboard에서 이 startup gate가 요청되었는지 확인할 수 있습니다. `verify()`가 실패하면 Slack lifecycle은 `failed`로 이동하고 readiness는 not ready로 남아, 첫 운영 알림이 실패한 뒤에야 문제를 발견하는 상황을 줄입니다.
+상태 스냅샷은 `verifiedOnModuleInit`을 포함하므로 readiness dashboard에서 이 startup gate가 요청되었는지 확인할 수 있습니다. `verify()`가 실패하면 Slack lifecycle은 `failed`로 이동하고 readiness는 not ready로 남아, 첫 운영 알림이 실패한 뒤에야 문제를 발견하는 상황을 줄입니다. shutdown 중에는 Slack이 새 전달을 거부하고 활성 전달이 settle될 때까지 기다린 뒤에만 factory-owned transport를 닫습니다.
 
 ### Discord Registration
 ```typescript

--- a/book/intermediate/ch17-slack-discord.md
+++ b/book/intermediate/ch17-slack-discord.md
@@ -88,7 +88,7 @@ SlackModule.forRoot({
 });
 ```
 
-Status snapshots include `verifiedOnModuleInit` so your readiness dashboard can show whether this startup gate was requested. If `verify()` fails, the Slack lifecycle moves to `failed` and readiness remains not ready instead of deferring discovery to the first production alert.
+Status snapshots include `verifiedOnModuleInit` so your readiness dashboard can show whether this startup gate was requested. If `verify()` fails, the Slack lifecycle moves to `failed` and readiness remains not ready instead of deferring discovery to the first production alert. During shutdown, Slack rejects new deliveries, waits for active deliveries to settle, and only then closes factory-owned transports.
 
 ### Discord Registration
 ```typescript

--- a/packages/slack/README.ko.md
+++ b/packages/slack/README.ko.md
@@ -139,7 +139,7 @@ Behavioral contract 메모:
 - `SlackService.send(...)`, `SlackService.sendMany(...)`, `SlackService.sendNotification(...)`은 provider handoff 전에 이미 abort된 signal을 존중하며, 같은 signal을 transport 호출로 전달합니다.
 - 서비스는 모듈 bootstrap 시 transport를 초기화하고, factory가 소유한 리소스만 애플리케이션 shutdown 시 닫습니다.
 - 직접 전달과 notifications 기반 전달은 lifecycle이 `ready`일 때만 허용됩니다. `onModuleInit()`이 끝나기 전, 초기화 실패 뒤, 또는 shutdown 중 호출하면 transport를 lazy 생성하거나 재사용하지 않고 `SlackLifecycleError`로 실패합니다.
-- shutdown은 진행 중인 factory 소유 transport 생성을 기다린 뒤 닫고 완료됩니다.
+- shutdown은 새 전달을 거부하고, 활성 전달과 진행 중인 factory 소유 transport 생성을 모두 settle한 뒤 소유한 transport를 닫고 완료됩니다.
 - factory 소유 transport cleanup은 bootstrap 실패 cleanup과 application shutdown 사이에서 직렬화되므로, 두 경로가 경합해도 같은 owned transport는 최대 한 번만 닫힙니다.
 - `SlackService.createPlatformStatusSnapshot()`은 호출자가 내부 옵션에 접근하지 않아도 lifecycle, readiness, transport 소유권을 보고합니다.
 - 이 패키지는 절대로 `process.env`를 직접 읽지 않습니다. 모든 설정은 명시적인 옵션 또는 DI를 통해 들어와야 합니다.

--- a/packages/slack/README.md
+++ b/packages/slack/README.md
@@ -139,7 +139,7 @@ Behavioral contract notes:
 - `SlackService.send(...)`, `SlackService.sendMany(...)`, and `SlackService.sendNotification(...)` honor already-aborted signals before provider handoff, and the same signal is propagated to transport calls.
 - The service initializes the configured transport during module bootstrap and closes factory-owned resources during application shutdown.
 - Direct and notification-backed delivery require the lifecycle to be `ready`; calls before `onModuleInit()` finishes, after initialization failure, or during shutdown fail with `SlackLifecycleError` instead of lazily creating or reusing transports.
-- Shutdown awaits any in-flight factory-owned transport creation and closes it before completion.
+- Shutdown rejects new deliveries, waits for active deliveries and any in-flight factory-owned transport creation to settle, and then closes the owned transport before completion.
 - Factory-owned transport cleanup is serialized across bootstrap-failure cleanup and application shutdown, so the same owned transport is closed at most once even when those paths race.
 - `SlackService.createPlatformStatusSnapshot()` reports lifecycle, readiness, and transport ownership without requiring callers to reach into internal options.
 - The package never reads `process.env` directly. All configuration must enter through explicit options or DI.

--- a/packages/slack/src/module.test.ts
+++ b/packages/slack/src/module.test.ts
@@ -594,6 +594,23 @@ describe('SlackModule', () => {
     expect(transport.sent).toEqual([]);
   });
 
+  it('honors a signal aborted between delivery tracking and provider handoff', async () => {
+    const controller = new AbortController();
+    const transport = new PassiveTransport();
+    const container = new Container();
+    const moduleType = SlackModule.forRoot({
+      transport,
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await initializeSlackService(container);
+    const delivery = service.send({ text: 'Abort before handoff' }, { signal: controller.signal });
+    queueMicrotask(() => controller.abort());
+
+    await expect(delivery).rejects.toMatchObject({ name: 'AbortError' });
+    expect(transport.sent).toEqual([]);
+  });
+
   it('honors an already-aborted signal before notification rendering or provider handoff', async () => {
     const controller = new AbortController();
     const render = vi.fn(async () => ({ text: 'rendered' }));

--- a/packages/slack/src/module.test.ts
+++ b/packages/slack/src/module.test.ts
@@ -1907,6 +1907,45 @@ describe('SlackModule', () => {
     expect(transport.closeCalls).toBe(1);
   });
 
+  it('tracks deliveries before synchronous transport callbacks can start shutdown', async () => {
+    let resolveSend!: () => void;
+    let service: SlackService | undefined;
+    let shutdown = Promise.resolve();
+    const sendDelay = new Promise<void>((resolve) => {
+      resolveSend = resolve;
+    });
+    const transport = new DelayedLifecycleTransport(undefined, sendDelay, () => {
+      if (!service) {
+        throw new Error('Slack service must be ready before delivery starts.');
+      }
+
+      shutdown = service.onApplicationShutdown();
+    });
+    const container = new Container();
+    const moduleType = SlackModule.forRoot({
+      transport: {
+        create: async () => transport,
+        ownsResources: true,
+      },
+    });
+
+    container.register(...moduleProviders(moduleType));
+    service = await initializeSlackService(container);
+    const delivery = service.send({ text: 'Reentrant shutdown delivery' });
+    await Promise.resolve();
+    await Promise.resolve();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(transport.sendCalls).toBe(1);
+    expect(transport.closeCalls).toBe(0);
+
+    resolveSend();
+
+    await expect(delivery).resolves.toMatchObject({ ok: true });
+    await shutdown;
+    expect(transport.closeCalls).toBe(1);
+  });
+
   it('wraps owned transport shutdown failures as lifecycle errors', async () => {
     const closeError = new Error('close failed');
     const container = new Container();

--- a/packages/slack/src/module.test.ts
+++ b/packages/slack/src/module.test.ts
@@ -127,7 +127,11 @@ class DelayedLifecycleTransport implements SlackTransport {
   sendCalls = 0;
   verifyCalls = 0;
 
-  constructor(private readonly verifyDelay: Promise<void> | undefined = undefined) {}
+  constructor(
+    private readonly verifyDelay: Promise<void> | undefined = undefined,
+    private readonly sendDelay: Promise<void> | undefined = undefined,
+    private readonly onSendStarted: (() => void) | undefined = undefined,
+  ) {}
 
   async close(): Promise<void> {
     this.closeCalls += 1;
@@ -135,6 +139,8 @@ class DelayedLifecycleTransport implements SlackTransport {
 
   async send(message: NormalizedSlackMessage) {
     this.sendCalls += 1;
+    this.onSendStarted?.();
+    await this.sendDelay;
 
     return {
       channel: message.channel,
@@ -1863,6 +1869,41 @@ describe('SlackModule', () => {
     const service = await initializeSlackService(container);
     await Promise.all([service.onApplicationShutdown(), service.onApplicationShutdown()]);
 
+    expect(transport.closeCalls).toBe(1);
+  });
+
+  it('drains in-flight deliveries before closing owned transports during shutdown', async () => {
+    let resolveSend!: () => void;
+    let resolveSendStarted!: () => void;
+    const sendDelay = new Promise<void>((resolve) => {
+      resolveSend = resolve;
+    });
+    const sendStarted = new Promise<void>((resolve) => {
+      resolveSendStarted = resolve;
+    });
+    const transport = new DelayedLifecycleTransport(undefined, sendDelay, resolveSendStarted);
+    const container = new Container();
+    const moduleType = SlackModule.forRoot({
+      transport: {
+        create: async () => transport,
+        ownsResources: true,
+      },
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await initializeSlackService(container);
+    const delivery = service.send({ text: 'Drain delivery' });
+    await sendStarted;
+    const shutdown = service.onApplicationShutdown();
+    await Promise.resolve();
+
+    expect(transport.sendCalls).toBe(1);
+    expect(transport.closeCalls).toBe(0);
+
+    resolveSend();
+
+    await expect(delivery).resolves.toMatchObject({ ok: true });
+    await shutdown;
     expect(transport.closeCalls).toBe(1);
   });
 

--- a/packages/slack/src/service.ts
+++ b/packages/slack/src/service.ts
@@ -218,7 +218,10 @@ export class SlackService implements Slack, OnModuleInit, OnApplicationShutdown 
     assertMessageContent(normalized);
     assertNotAborted(options.signal);
     this.assertCanDeliver();
-    const result = await this.trackInFlightDelivery(() => transport.send(normalized, options));
+    const result = await this.trackInFlightDelivery(() => {
+      assertNotAborted(options.signal);
+      return transport.send(normalized, options);
+    });
 
     return {
       channel: result.channel ?? normalized.channel,

--- a/packages/slack/src/service.ts
+++ b/packages/slack/src/service.ts
@@ -77,6 +77,7 @@ function assertMessageContent(message: NormalizedSlackMessage): void {
  */
 @Inject(SLACK_OPTIONS)
 export class SlackService implements Slack, OnModuleInit, OnApplicationShutdown {
+  private readonly inFlightDeliveries = new Set<Promise<unknown>>();
   private lifecycleState: SlackServiceLifecycleState = 'created';
   private ownedTransportCleanupPromise: Promise<void> | undefined;
   private resolvedTransport: SlackTransport | undefined;
@@ -103,6 +104,7 @@ export class SlackService implements Slack, OnModuleInit, OnApplicationShutdown 
 
   private async closeOwnedTransport(): Promise<void> {
     try {
+      await this.drainInFlightDeliveries();
       await this.closeOwnedTransportResources();
       this.lifecycleState = 'stopped';
     } catch (error) {
@@ -216,7 +218,7 @@ export class SlackService implements Slack, OnModuleInit, OnApplicationShutdown 
     assertMessageContent(normalized);
     assertNotAborted(options.signal);
     this.assertCanDeliver();
-    const result = await transport.send(normalized, options);
+    const result = await this.trackInFlightDelivery(Promise.resolve(transport.send(normalized, options)));
 
     return {
       channel: result.channel ?? normalized.channel,
@@ -372,6 +374,22 @@ export class SlackService implements Slack, OnModuleInit, OnApplicationShutdown 
     }
 
     throw createLifecycleError('Slack transport failed to initialize.', cause);
+  }
+
+  private async drainInFlightDeliveries(): Promise<void> {
+    while (this.inFlightDeliveries.size > 0) {
+      await Promise.allSettled(Array.from(this.inFlightDeliveries));
+    }
+  }
+
+  private async trackInFlightDelivery<T>(delivery: Promise<T>): Promise<T> {
+    this.inFlightDeliveries.add(delivery);
+
+    try {
+      return await delivery;
+    } finally {
+      this.inFlightDeliveries.delete(delivery);
+    }
   }
 
   private assertCanCreateOrUseTransport(): void {

--- a/packages/slack/src/service.ts
+++ b/packages/slack/src/service.ts
@@ -218,7 +218,7 @@ export class SlackService implements Slack, OnModuleInit, OnApplicationShutdown 
     assertMessageContent(normalized);
     assertNotAborted(options.signal);
     this.assertCanDeliver();
-    const result = await this.trackInFlightDelivery(Promise.resolve(transport.send(normalized, options)));
+    const result = await this.trackInFlightDelivery(() => transport.send(normalized, options));
 
     return {
       channel: result.channel ?? normalized.channel,
@@ -382,7 +382,8 @@ export class SlackService implements Slack, OnModuleInit, OnApplicationShutdown 
     }
   }
 
-  private async trackInFlightDelivery<T>(delivery: Promise<T>): Promise<T> {
+  private async trackInFlightDelivery<T>(start: () => Promise<T>): Promise<T> {
+    const delivery = Promise.resolve().then(start);
     this.inFlightDeliveries.add(delivery);
 
     try {


### PR DESCRIPTION
## Summary

Drain active Slack deliveries before closing factory-owned transports during application shutdown.

Linked context: Closes #2589

## Changes

- Track active `SlackService.send(...)` transport deliveries and settle them before owned transport cleanup.
- Add lifecycle regression coverage for the shutdown ordering.
- Document the shutdown guarantee in the Slack README and Chapter 17 English/Korean mirrors.

## Testing

- `pnpm --dir packages/slack test` (63 tests passed)
- `pnpm typecheck` (passed)
- `pnpm build` (passed)
- `pnpm lint` (passed; public export TSDoc check passed)
- `pnpm docs:sync-check` (passed)
- `pnpm verify:platform-consistency-governance` (passed)
- The full `pnpm verify:release-readiness` was attempted twice; unrelated parallel workspace test flakes failed. The affected Slack, CLI, and Socket.IO tests pass when run directly.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Added patch changeset for `@fluojs/slack`: active deliveries now drain before factory-owned transport close.

## Public export documentation

- [x] No public exports changed; existing source-level TSDoc remains applicable.
- [x] No changed exported functions require new `@param` / `@returns` tags.
- [x] README lifecycle documentation was updated; no source `@example` changes are needed.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] The shutdown ordering guarantee is documented in the affected package README.
- [x] Intentional limitations remain unchanged.
- [x] The in-flight delivery ordering is covered by a regression test.

## Platform consistency governance (SSOT)

- [x] Slack README and Chapter 17 English/Korean mirrors remain synchronized.
- [x] No platform contract docs changed; package-level lifecycle docs and regression evidence were updated.
- [x] No platform harness applies to this transport-agnostic package lifecycle fix.