### PR TITLE
Resolve #2585: validate Email queue notification channels

### DIFF
--- a/.changeset/validate-email-queue-channels.md
+++ b/.changeset/validate-email-queue-channels.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/email": patch
+---
+
+Reject queued notifications whose channel does not match the configured email channel before calling the email transport.

--- a/packages/email/README.ko.md
+++ b/packages/email/README.ko.md
@@ -299,6 +299,7 @@ Behavioral contract 메모:
 
 - Queue 지원은 opt-in입니다. 루트 `@fluojs/email` 엔트리포인트와 `EmailModule`은 `@fluojs/queue`를 import하거나 `EmailNotificationsQueueWorker`를 등록하거나 queue peer 설치를 요구하지 않습니다.
 - `EmailNotificationsQueueWorker`는 `@fluojs/email/queue`에서 export되며, queue 기반 전달을 활성화하는 애플리케이션이 직접 등록해야 합니다.
+- worker는 transport handoff 전에 queued notification channel이 구성된 `EmailChannel.channel`과 정확히 일치하는지 확인합니다. 일치하지 않으면 `EmailMessageValidationError`로 실패하므로 non-email 작업이 email transport에 도달하지 않습니다.
 - worker는 `EmailChannel` 전달 semantics를 재사용하므로 transport가 수락된 수신자 0명 또는 `pending`/`rejected` 수신자를 보고하면 queued job이 실패합니다. 따라서 incomplete delivery는 성공한 job으로 승인되지 않고 `@fluojs/queue`의 retry/dead-letter 흐름으로 넘어갑니다.
 
 ### 의도적인 제한 사항

--- a/packages/email/README.md
+++ b/packages/email/README.md
@@ -299,6 +299,7 @@ Behavioral contract notes:
 
 - Queue support is opt-in. The root `@fluojs/email` entrypoint and `EmailModule` do not import `@fluojs/queue`, register `EmailNotificationsQueueWorker`, or require queue peer installation.
 - `EmailNotificationsQueueWorker` is exported from `@fluojs/email/queue` and must be registered by applications that enable queue-backed delivery.
+- Before transport handoff, the worker requires the queued notification channel to exactly match the configured `EmailChannel.channel`. A mismatch fails with `EmailMessageValidationError`, so non-email work cannot reach the email transport.
 - The worker reuses `EmailChannel` delivery semantics, so a queued job fails when the underlying transport reports zero accepted recipients or any `pending`/`rejected` recipients. This lets `@fluojs/queue` retry and dead-letter incomplete deliveries instead of acknowledging them as successful jobs.
 
 ### Intentional limitations

--- a/packages/email/src/queue.test.ts
+++ b/packages/email/src/queue.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+
+import { EmailChannel } from './channel.js';
+import { EmailMessageValidationError } from './errors.js';
+import { EmailNotificationQueueJob, EmailNotificationsQueueWorker } from './queue.js';
+import { EmailService } from './service.js';
+import type { EmailTransport, NormalizedEmailMessage, NormalizedEmailModuleOptions } from './types.js';
+
+function createQueueTestFixture(channel = 'email'): {
+  readonly delivered: readonly NormalizedEmailMessage[];
+  readonly worker: EmailNotificationsQueueWorker;
+} {
+  const delivered: NormalizedEmailMessage[] = [];
+  const transport: EmailTransport = {
+    async send(message) {
+      delivered.push(message);
+      return {
+        accepted: message.to.map((recipient) => recipient.address),
+        messageId: 'queue-test-message',
+        pending: [],
+        rejected: [],
+      };
+    },
+  };
+  const options: NormalizedEmailModuleOptions = {
+    defaultFrom: { address: 'noreply@example.com' },
+    defaultReplyTo: [],
+    notifications: { channel },
+    transport: {
+      create: async () => transport,
+      kind: 'queue-test',
+      ownsResources: false,
+    },
+    verifyOnModuleInit: false,
+  };
+  const service = new EmailService(options);
+
+  return {
+    delivered,
+    worker: new EmailNotificationsQueueWorker(new EmailChannel(service, options)),
+  };
+}
+
+describe('EmailNotificationsQueueWorker', () => {
+  it('rejects another notification channel before email transport handoff', async () => {
+    // Given
+    const { delivered, worker } = createQueueTestFixture();
+    const job = new EmailNotificationQueueJob(
+      {
+        channel: 'slack',
+        payload: { text: 'Do not route this through email.' },
+        recipients: ['user@example.com'],
+        subject: 'Wrong channel',
+      },
+      '2026-07-10T00:00:00.000Z',
+    );
+
+    // When / Then
+    await expect(worker.handle(job)).rejects.toEqual(
+      new EmailMessageValidationError(
+        'Queued notification channel "slack" does not match configured email channel "email".',
+      ),
+    );
+    expect(delivered).toHaveLength(0);
+  });
+
+  it('uses the configured email channel when validating queued notifications', async () => {
+    // Given
+    const { delivered, worker } = createQueueTestFixture('transactional-email');
+    const job = new EmailNotificationQueueJob(
+      {
+        channel: 'email',
+        payload: { text: 'This targets the default channel, not the configured one.' },
+        recipients: ['user@example.com'],
+        subject: 'Default channel mismatch',
+      },
+      '2026-07-10T00:00:00.000Z',
+    );
+
+    // When / Then
+    await expect(worker.handle(job)).rejects.toEqual(
+      new EmailMessageValidationError(
+        'Queued notification channel "email" does not match configured email channel "transactional-email".',
+      ),
+    );
+    expect(delivered).toHaveLength(0);
+  });
+});

--- a/packages/email/src/queue.ts
+++ b/packages/email/src/queue.ts
@@ -4,6 +4,7 @@ import { QueueWorker, type QueueLifecycleService, type QueueWorkerOptions } from
 
 import { DEFAULT_EMAIL_QUEUE_WORKER_OPTIONS } from './constants.js';
 import { EmailChannel } from './channel.js';
+import { EmailMessageValidationError } from './errors.js';
 import type { EmailNotificationDispatchRequest } from './types.js';
 
 /** Queue worker execution defaults used by the built-in notifications queue integration. */
@@ -46,12 +47,10 @@ export class EmailNotificationQueueJob {
 export function createEmailNotificationsQueueAdapter(queue: QueueLifecycleService): NotificationsQueueAdapter {
   return {
     enqueue(job: NotificationsQueueJob): Promise<string> {
-      return queue.enqueue(new EmailNotificationQueueJob(job.notification as EmailNotificationDispatchRequest, job.queuedAt));
+      return queue.enqueue(new EmailNotificationQueueJob(job.notification, job.queuedAt));
     },
     enqueueMany(jobs: readonly NotificationsQueueJob[]): Promise<readonly string[]> {
-      return Promise.all(
-        jobs.map((job) => queue.enqueue(new EmailNotificationQueueJob(job.notification as EmailNotificationDispatchRequest, job.queuedAt))),
-      );
+      return Promise.all(jobs.map((job) => queue.enqueue(new EmailNotificationQueueJob(job.notification, job.queuedAt))));
     },
   };
 }
@@ -67,8 +66,17 @@ export class EmailNotificationsQueueWorker {
    *
    * @param job Queued notification payload created by `createEmailNotificationsQueueAdapter(...)`.
    * @returns A promise that resolves only when email delivery is accepted by the channel contract.
+   * @throws {EmailMessageValidationError} When the queued notification targets another configured channel.
    */
   async handle(job: EmailNotificationQueueJob): Promise<void> {
+    const expectedChannel = this.channel.channel;
+
+    if (job.notification.channel !== expectedChannel) {
+      throw new EmailMessageValidationError(
+        `Queued notification channel "${job.notification.channel}" does not match configured email channel "${expectedChannel}".`,
+      );
+    }
+
     await this.channel.send(job.notification, {});
   }
 }


### PR DESCRIPTION
## Summary

`@fluojs/email/queue`가 generic notification payload를 Email 작업으로 강제 변환하던 경계를 수정하고, configured `EmailChannel.channel`과 다른 queued notification을 email transport handoff 전에 거부합니다.

Linked context: Closes #2585

## Changes

- `createEmailNotificationsQueueAdapter(...)`에서 불필요한 `EmailNotificationDispatchRequest` force-cast를 제거했습니다.
- `EmailNotificationsQueueWorker.handle(...)`가 queued notification channel과 configured Email channel을 exact-match 검증하고 mismatch를 `EmailMessageValidationError`로 거부하도록 했습니다.
- default/custom channel mismatch가 transport에 도달하지 않는 회귀 테스트를 추가했습니다.
- `packages/email/README.md`와 `README.ko.md`에 queue channel validation contract를 동기화했습니다.
- `@fluojs/email` patch changeset을 추가했습니다.

## Testing

- `pnpm exec vitest run -c vitest.config.ts src/queue.test.ts` — TDD red에서 2건이 expected rejection 대신 resolve됨을 확인한 뒤 green 2/2 passed
- `pnpm --filter @fluojs/email... --if-present run build` — passed
- `pnpm test` in `packages/email` — 5 files, 54 tests passed
- `pnpm typecheck` in `packages/email` — passed
- `pnpm exec biome lint packages/email/src/queue.ts packages/email/src/queue.test.ts` — 2 files passed
- `pnpm docs:sync-check` — 42 EN/KO pairs와 10 navigation metadata pairs passed
- `pnpm verify:platform-consistency-governance` — passed
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main` — passed
- TypeScript no-excuse audit — 2 files, no violations
- Node.js 20.20.2에서 `VITEST_MAX_THREADS=1 pnpm verify:release-readiness` — passed without writing draft artifacts

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

`@fluojs/email`의 queue delivery failure behavior가 수정되므로 patch changeset `.changeset/validate-email-queue-channels.md`를 포함합니다.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

새 public export는 없습니다. 기존 exported worker method의 TSDoc에 channel mismatch `@throws`를 추가했습니다.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

EN/KO Email README와 package-local queue regression tests가 exact channel-match 및 pre-transport rejection을 고정합니다.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests, such as `createPlatformConformanceHarness(...)` for platform component contracts or `createHttpAdapterPortabilityHarness(...)` for HTTP adapter portability contracts.

Platform contract/governance docs와 platform conformance claim은 변경하지 않았습니다. Package README mirror는 동기화했고 관련 governance verifier를 통과했습니다.