### PR TITLE
Resolve #2588: Correct Email status API changeset classification

### DIFF
--- a/.changeset/email-status-lifecycle-coverage.md
+++ b/.changeset/email-status-lifecycle-coverage.md
@@ -1,5 +1,5 @@
 ---
-"@fluojs/email": patch
+"@fluojs/email": minor
 ---
 
-Keep root email status snapshots transport-agnostic by omitting queue worker metadata unless callers provide it explicitly, and add regression coverage for caller-owned shutdown, notification payload forwarding, and lifecycle public exports.
+Expose root email lifecycle status APIs for diagnostics, keep status snapshots transport-agnostic by omitting queue worker metadata unless callers provide it explicitly, and cover caller-owned shutdown and notification payload forwarding regressions.


### PR DESCRIPTION
## Summary

Reclassify the pending `@fluojs/email` status API changeset from `patch` to `minor` so release metadata matches the backward-compatible public feature policy. Align its consumer-facing summary with the root lifecycle status API surface.

Linked context: Closes #2588

## Changes

- Change `.changeset/email-status-lifecycle-coverage.md` from `patch` to `minor`.
- Describe the root email lifecycle status APIs and their transport-agnostic snapshot behavior in consumer-facing release metadata.
- Preserve all existing runtime code, tests, READMEs, and unrelated changesets.

## Testing

- `pnpm install --frozen-lockfile` — passed.
- `pnpm verify:release-readiness` — passed without writing draft artifacts.
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main` — passed for the stable lane.
- `pnpm changeset status --since=origin/main` — reports `@fluojs/email` at `minor` and no patch or major bumps from this branch.
- `git diff --check` — passed.

## Release impact

- [x] This PR has consumer-visible release impact and updates the existing changeset.
- [ ] This PR has no consumer-visible release impact.

The `minor` intent is required because the existing changeset covers backward-compatible root API additions (`createEmailPlatformStatusSnapshot(...)` and lifecycle status types), which are public feature work under `docs/contracts/release-governance.md`.

## Public export documentation

- [x] No public source exports changed in this PR; existing source TSDoc remains unchanged.
- [x] Exported function parameter and return documentation changes are not applicable.
- [x] Source examples and README scenarios are unchanged because this is release-metadata-only.

## Behavioral contract

- [x] No documented behavioral contracts were removed or changed.
- [x] Existing Email status contracts remain documented in the English and Korean package READMEs.
- [x] Intentional limitations remain unchanged.
- [x] Runtime regression-test changes are not required because runtime behavior is unchanged.

## Platform consistency governance (SSOT)

- [x] No governance or platform contract documents changed.
- [x] Existing English/Korean SSOT mirrors remain unchanged.
- [x] Platform harness updates are not applicable to this release-metadata-only correction; canonical release-readiness and stable-lane verification passed.