### PR TITLE
Resolve #2587: verify Email provider visibility through compiled modules

### DIFF
--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -78,6 +78,7 @@
   },
   "devDependencies": {
     "@fluojs/queue": "workspace:^",
+    "@fluojs/testing": "workspace:^",
     "@types/nodemailer": "^8.0.0",
     "vitest": "^3.2.4"
   }

--- a/packages/email/src/module-visibility.test.ts
+++ b/packages/email/src/module-visibility.test.ts
@@ -1,0 +1,105 @@
+import { Inject, Module } from '@fluojs/core';
+import { createTestingModule } from '@fluojs/testing';
+import { describe, expect, it } from 'vitest';
+
+import { EmailChannel } from './channel.js';
+import { EmailModule } from './module.js';
+import { EmailService } from './service.js';
+import { EMAIL_CHANNEL } from './tokens.js';
+import type { EmailTransport, EmailTransportFactory } from './types.js';
+
+class VisibilityTestTransport implements EmailTransport {
+  async send(): Promise<{ accepted: string[]; messageId: string; pending: []; rejected: [] }> {
+    return {
+      accepted: ['visible@example.com'],
+      messageId: 'visibility-test',
+      pending: [],
+      rejected: [],
+    };
+  }
+}
+
+const visibilityTestTransportFactory = {
+  create: () => new VisibilityTestTransport(),
+  kind: 'visibility-test',
+  ownsResources: false,
+} satisfies EmailTransportFactory;
+
+describe('EmailModule provider visibility', () => {
+  it('makes EmailService and EMAIL_CHANNEL visible through a compiled module graph by default', async () => {
+    @Inject(EmailService, EMAIL_CHANNEL)
+    class RootEmailProbe {
+      constructor(
+        readonly email: EmailService,
+        readonly channel: EmailChannel,
+      ) {}
+    }
+
+    @Module({
+      imports: [EmailModule.forRoot({ transport: visibilityTestTransportFactory })],
+    })
+    class EmailOwnerModule {}
+
+    @Module({
+      imports: [EmailOwnerModule],
+      providers: [RootEmailProbe],
+    })
+    class AppModule {}
+
+    const testingModule = await createTestingModule({ rootModule: AppModule }).compile();
+
+    try {
+      const probe = await testingModule.resolve(RootEmailProbe);
+
+      expect(probe.email).toBeInstanceOf(EmailService);
+      expect(probe.channel).toBeInstanceOf(EmailChannel);
+      expect(probe.channel.channel).toBe('email');
+    } finally {
+      await testingModule.container.dispose();
+    }
+  });
+
+  it('keeps EmailService hidden from root providers when global visibility is disabled', async () => {
+    @Inject(EmailService)
+    class RootEmailServiceProbe {
+      constructor(readonly email: EmailService) {}
+    }
+
+    @Module({
+      imports: [EmailModule.forRoot({ global: false, transport: visibilityTestTransportFactory })],
+    })
+    class EmailOwnerModule {}
+
+    @Module({
+      imports: [EmailOwnerModule],
+      providers: [RootEmailServiceProbe],
+    })
+    class AppModule {}
+
+    await expect(createTestingModule({ rootModule: AppModule }).compile()).rejects.toThrow(
+      /not visible through a global module|EmailService/,
+    );
+  });
+
+  it('keeps EMAIL_CHANNEL hidden from root providers when global visibility is disabled', async () => {
+    @Inject(EMAIL_CHANNEL)
+    class RootEmailChannelProbe {
+      constructor(readonly channel: EmailChannel) {}
+    }
+
+    @Module({
+      imports: [EmailModule.forRoot({ global: false, transport: visibilityTestTransportFactory })],
+    })
+    class EmailOwnerModule {}
+
+    @Module({
+      imports: [EmailOwnerModule],
+      providers: [RootEmailChannelProbe],
+    })
+    class AppModule {}
+
+    await expect(createTestingModule({ rootModule: AppModule }).compile()).rejects.toThrow(
+      /not visible through a global module|fluo.email.channel/,
+    );
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -401,6 +401,9 @@ importers:
       '@fluojs/queue':
         specifier: workspace:^
         version: link:../queue
+      '@fluojs/testing':
+        specifier: workspace:^
+        version: link:../testing
       '@types/nodemailer':
         specifier: ^8.0.0
         version: 8.0.0


### PR DESCRIPTION
## Summary

Add compiled module graph coverage for the documented `@fluojs/email` provider visibility contract.

Linked context: https://github.com/fluojs/fluo/issues/2587

Closes #2587

## Changes

- Add focused `createTestingModule(...)` coverage proving `EmailService` and `EMAIL_CHANNEL` are globally visible by default.
- Add independent compiled-graph assertions proving `global: false` hides `EmailService` and `EMAIL_CHANNEL` from root providers.
- Add `@fluojs/testing` as an `@fluojs/email` development dependency and update the matching lockfile importer.

## Testing

- `pnpm exec biome check packages/email/src/module-visibility.test.ts packages/email/package.json`
- `pnpm --filter @fluojs/email typecheck`
- `pnpm --filter @fluojs/email test` — 6 files, 57 tests passed
- `pnpm build`
- `pnpm verify:platform-consistency-governance`
- `pnpm verify` — 278 files passed; 3953 tests passed, 1 skipped

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

Test-only contract coverage and a development-only workspace dependency do not change published runtime behavior, API surface, or package contents, so no changeset is required.

## Public export documentation

- [x] No public exports changed. Source TSDoc and README scenario documentation are unaffected.

## Behavioral contract

- [x] No documented behavioral contracts were removed.
- [x] The existing global-by-default and `global: false` visibility contract is now exercised through the real compiled module graph.
- [x] No runtime implementation or intentional limitation changed, so README/docs updates are not required.

## Platform consistency governance (SSOT)

- [x] No platform contract or governed EN/KO documentation changed.
- [x] `pnpm verify:platform-consistency-governance` passed.
- [x] The new integration tests use the canonical `createTestingModule({ rootModule })` graph compilation path.