### PR TITLE
Resolve #2586: make Email transport shutdown idempotent

### DIFF
--- a/.changeset/email-idempotent-shutdown.md
+++ b/.changeset/email-idempotent-shutdown.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/email": patch
+---
+
+Make repeated and concurrent Email service shutdown calls share one cleanup operation so owned transports close at most once.

--- a/packages/email/README.ko.md
+++ b/packages/email/README.ko.md
@@ -195,7 +195,7 @@ Behavioral contract 메모:
 - `EmailService.createPlatformStatusSnapshot()`은 diagnostics를 위해 lifecycle, readiness, health, transport ownership details를 노출합니다.
 - 서비스는 모듈 bootstrap 시 transport를 초기화하며, `verifyOnModuleInit: true`인 경우 bootstrap 검증이 성공적으로 끝날 때까지 delivery가 transport handoff로 진행되지 않습니다.
 - 거부된 `forRootAsync(...)` 옵션 factory 결과는 영구 memoize되지 않으며, 다음 provider resolution에서 configuration lookup을 다시 시도할 수 있습니다.
-- shutdown이 시작된 뒤에는 `EmailService.send(...)`와 `EmailService.sendNotification(...)`이 transport를 재사용하거나 lazy 생성하지 않고 `EmailLifecycleError`로 실패합니다. 진행 중인 factory 소유 transport 생성은 shutdown이 기다리고, 활성 transport `verify()` / `send()` 호출을 drain한 뒤 소유 transport를 닫습니다.
+- shutdown이 시작된 뒤에는 `EmailService.send(...)`와 `EmailService.sendNotification(...)`이 transport를 재사용하거나 lazy 생성하지 않고 `EmailLifecycleError`로 실패합니다. 진행 중인 factory 소유 transport 생성은 shutdown이 기다리고, 활성 transport `verify()` / `send()` 호출을 drain한 뒤 소유 transport를 닫습니다. 동시에 또는 반복해서 shutdown을 호출하면 동일한 완료 Promise를 공유하므로 소유 transport는 최대 한 번만 닫힙니다.
 - transport `verify()`와 `close()`에서 발생한 provider error는 diagnostics를 위해 lifecycle failure의 `cause`로 보존됩니다.
 - 모듈 옵션은 provider wiring 전에 trim 및 normalize됩니다. 여기에는 sender 기본값, notification channel 이름, transport factory 소유권이 포함됩니다.
 - `EmailModule.forRoot(...)`와 `EmailModule.forRootAsync(...)`는 기본적으로 global입니다. module-local visibility가 필요할 때만 `global: false`를 사용합니다.

--- a/packages/email/README.md
+++ b/packages/email/README.md
@@ -195,7 +195,7 @@ Behavioral contract notes:
 - `EmailService.createPlatformStatusSnapshot()` exposes lifecycle, readiness, health, and transport ownership details for diagnostics.
 - The service initializes the configured transport during module bootstrap and, when `verifyOnModuleInit: true`, delivery waits until bootstrap verification has completed successfully before transport handoff.
 - Rejected `forRootAsync(...)` option factories are not memoized permanently; the next provider resolution can retry configuration lookup.
-- Once shutdown starts, `EmailService.send(...)` and `EmailService.sendNotification(...)` fail with `EmailLifecycleError` instead of reusing or lazily creating transports; any in-flight factory-owned transport creation is awaited, active transport `verify()` / `send()` calls are drained, and then owned transports are closed by shutdown.
+- Once shutdown starts, `EmailService.send(...)` and `EmailService.sendNotification(...)` fail with `EmailLifecycleError` instead of reusing or lazily creating transports; any in-flight factory-owned transport creation is awaited, active transport `verify()` / `send()` calls are drained, and then owned transports are closed by shutdown. Concurrent and repeated shutdown calls share the same completion promise, so an owned transport is closed at most once.
 - Transport `verify()` and `close()` provider errors are preserved as the `cause` of lifecycle failures for diagnostics.
 - Module options are trimmed and normalized before provider wiring, including sender defaults, notification channel names, and transport factory ownership.
 - `EmailModule.forRoot(...)` and `EmailModule.forRootAsync(...)` are global by default. Use `global: false` to opt into module-local visibility.

--- a/packages/email/src/module.test.ts
+++ b/packages/email/src/module.test.ts
@@ -1208,6 +1208,33 @@ describe('EmailModule', () => {
     expect(transportState.sent).toHaveLength(1);
   });
 
+  it('shares one shutdown promise and closes owned transports exactly once across repeated calls', async () => {
+    const transport = new DelayedLifecycleTransport();
+    const container = new Container();
+    const moduleType = EmailModule.forRoot({
+      defaultFrom: 'noreply@example.com',
+      transport: {
+        create: async () => transport,
+        ownsResources: true,
+      },
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(EmailService);
+    await service.send({ subject: 'Idempotent shutdown', text: 'hello', to: ['user@example.com'] });
+
+    const firstShutdown = service.onApplicationShutdown();
+    const concurrentShutdown = service.onApplicationShutdown();
+
+    expect(concurrentShutdown).toBe(firstShutdown);
+    await firstShutdown;
+
+    const repeatedShutdown = service.onApplicationShutdown();
+    expect(repeatedShutdown).toBe(firstShutdown);
+    await repeatedShutdown;
+    expect(transport.closeCalls).toBe(1);
+  });
+
   it('normalizes lazy transport factory rejections and clears rejected state before shutdown', async () => {
     const create = vi.fn(async (): Promise<EmailTransport> => {
       throw new Error('provider create failed');

--- a/packages/email/src/service.ts
+++ b/packages/email/src/service.ts
@@ -112,13 +112,19 @@ function assertMessageContent(message: NormalizedEmailMessage): void {
 export class EmailService implements Email, OnModuleInit, OnApplicationShutdown {
   private lifecycleState: EmailServiceLifecycleState = 'created';
   private bootstrapPromise: Promise<void> | undefined;
+  private shutdownPromise: Promise<void> | undefined;
   private readonly inFlightOperations = new Set<Promise<unknown>>();
   private resolvedTransport: EmailTransport | undefined;
   private transportPromise: Promise<EmailTransport> | undefined;
 
   constructor(private readonly options: NormalizedEmailModuleOptions) {}
 
-  async onApplicationShutdown(): Promise<void> {
+  onApplicationShutdown(): Promise<void> {
+    this.shutdownPromise ??= this.shutdown();
+    return this.shutdownPromise;
+  }
+
+  private async shutdown(): Promise<void> {
     this.lifecycleState = 'stopping';
 
     let transport: EmailTransport | undefined;


### PR DESCRIPTION
## Summary

Memoize the Email service shutdown operation so concurrent and repeated lifecycle calls share one completion promise and close a factory-owned transport at most once.

Linked context: Closes #2586

## Changes

- Add a shared `shutdownPromise` at the `EmailService` lifecycle seam.
- Add regression coverage for promise identity and exactly-once owned transport cleanup across concurrent and repeated shutdown calls.
- Document the shutdown guarantee in the Email English and Korean READMEs.
- Add a patch changeset for `@fluojs/email`.

## Testing

- `pnpm exec vitest run -c vitest.config.ts src/module.test.ts -t "shares one shutdown promise"` (red before implementation, green after)
- `pnpm test` in `packages/email` (58 tests passed)
- `pnpm typecheck` in `packages/email`
- `pnpm build` at repository root, including `@fluojs/email`
- `pnpm verify:platform-consistency-governance`
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main`
- `pnpm verify:release-readiness`

## Release impact

- [x] This PR has consumer-visible release impact and includes `.changeset/email-idempotent-shutdown.md` with a patch bump for `@fluojs/email`.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] No public export shape or exported symbol documentation changed.
- [x] The consumer-visible lifecycle guarantee is documented in both package README mirrors.
- [x] Source examples remain complementary; no new public API example is required.

## Behavioral contract

- [x] No documented behavioral contracts were removed.
- [x] The idempotent shutdown contract is documented in the affected package README.
- [x] Intentional transport ownership limitations remain unchanged.
- [x] Runtime invariants are covered by a regression test.

## Platform consistency governance (SSOT)

- [x] Email English/Korean README contract text remains synchronized.
- [x] No platform contract SSOT or adapter conformance claim changed.
- [x] `pnpm verify:platform-consistency-governance` and `pnpm verify:release-readiness` passed.