### PR TITLE
Resolve #2593: verify app-owned Slack transport cleanup

### DIFF
--- a/packages/slack/src/module.test.ts
+++ b/packages/slack/src/module.test.ts
@@ -2083,6 +2083,29 @@ describe('SlackModule', () => {
     expect(transport.sent).toEqual([]);
   });
 
+  it('preserves app-owned closeable transports when bootstrap verification fails', async () => {
+    const verificationError = new Error('app-owned slack auth failed');
+    const transport = new FailingVerificationTransport(verificationError);
+    const container = new Container();
+    const moduleType = SlackModule.forRoot({
+      defaultChannel: '#ops',
+      transport,
+      verifyOnModuleInit: true,
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(SlackService);
+
+    await expect(service.onModuleInit()).rejects.toThrowError(
+      new SlackLifecycleError('Slack transport failed to initialize.', { cause: verificationError }),
+    );
+    await service.onApplicationShutdown();
+
+    expect(transport.verifyCalls).toBe(1);
+    expect(transport.closeCalls).toBe(0);
+    expect(transport.sent).toEqual([]);
+  });
+
   it('serializes init-failure cleanup with app shutdown so owned transport closes once', async () => {
     let rejectVerify = (_reason: Error): void => {
       throw new Error('Verification reject callback was not initialized.');


### PR DESCRIPTION
## Summary

Slack bootstrap verification 실패 시 직접 주입된 app-owned closeable transport가 application shutdown에서도 닫히지 않는 ownership 회귀를 검증합니다.

Linked context: Closes #2593

## Changes

- app-owned `FailingVerificationTransport`가 verification 실패 후 shutdown을 거쳐도 `close()`되지 않음을 회귀 테스트로 추가했습니다.
- factory-owned transport의 기존 cleanup 경계는 그대로 유지합니다.

## Testing

- `pnpm vitest run packages/slack/src/module.test.ts`
- `pnpm --filter @fluojs/slack typecheck`
- `pnpm --filter @fluojs/slack build`
- `pnpm verify:public-export-tsdoc`
- `pnpm verify:platform-consistency-governance`
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main`
- `pnpm verify:release-readiness`

## Release impact

- [x] This PR has no consumer-visible release impact.

## Public export documentation

- [x] No public exports changed.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] No governance docs or platform contracts changed.