### PR TITLE
Resolve #2590: Preserve Slack abort semantics

### DIFF
--- a/.changeset/issue-2590-slack-abort-semantics.md
+++ b/.changeset/issue-2590-slack-abort-semantics.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/slack": patch
+---
+
+Preserve caller cancellation across tolerant Slack batches and notification-channel delivery.

--- a/packages/slack/README.ko.md
+++ b/packages/slack/README.ko.md
@@ -135,8 +135,8 @@ SlackModule.forRootAsync({
 Behavioral contract 메모:
 
 - `SlackService.send(...)`는 전달 전에 `defaultChannel`을 해석합니다.
-- `SlackService.sendMany(...)`는 메시지를 순차적으로 보내며, fail-fast 대신 batch result가 필요한 호출자를 위해 `continueOnError`를 지원합니다.
-- `SlackService.send(...)`, `SlackService.sendMany(...)`, `SlackService.sendNotification(...)`은 provider handoff 전에 이미 abort된 signal을 존중하며, 같은 signal을 transport 호출로 전달합니다.
+- `SlackService.sendMany(...)`는 메시지를 순차적으로 보내며, fail-fast 대신 batch result가 필요한 호출자를 위해 `continueOnError`를 지원합니다. 다만 일반 provider 실패만 수집하며 caller 취소는 항상 batch를 reject합니다.
+- `SlackService.send(...)`, `SlackService.sendMany(...)`, `SlackService.sendNotification(...)`은 provider handoff 전에 이미 abort된 signal을 존중합니다. Abort된 signal 또는 transport의 `AbortError`는 `continueOnError`보다 우선하며, 같은 signal은 notification channel을 거쳐 transport 호출까지 전달됩니다.
 - 서비스는 모듈 bootstrap 시 transport를 초기화하고, factory가 소유한 리소스만 애플리케이션 shutdown 시 닫습니다.
 - 직접 전달과 notifications 기반 전달은 lifecycle이 `ready`일 때만 허용됩니다. `onModuleInit()`이 끝나기 전, 초기화 실패 뒤, 또는 shutdown 중 호출하면 transport를 lazy 생성하거나 재사용하지 않고 `SlackLifecycleError`로 실패합니다.
 - shutdown은 새 전달을 거부하고, 활성 전달과 진행 중인 factory 소유 transport 생성을 모두 settle한 뒤 소유한 transport를 닫고 완료됩니다.

--- a/packages/slack/README.md
+++ b/packages/slack/README.md
@@ -135,8 +135,8 @@ SlackModule.forRootAsync({
 Behavioral contract notes:
 
 - `SlackService.send(...)` resolves `defaultChannel` before delivery.
-- `SlackService.sendMany(...)` sends messages sequentially and supports `continueOnError` when callers need a batch result instead of fail-fast behavior.
-- `SlackService.send(...)`, `SlackService.sendMany(...)`, and `SlackService.sendNotification(...)` honor already-aborted signals before provider handoff, and the same signal is propagated to transport calls.
+- `SlackService.sendMany(...)` sends messages sequentially and supports `continueOnError` when callers need a batch result instead of fail-fast behavior; it collects ordinary provider failures only, while caller cancellation always rejects the batch.
+- `SlackService.send(...)`, `SlackService.sendMany(...)`, and `SlackService.sendNotification(...)` honor already-aborted signals before provider handoff. An aborted signal or a transport `AbortError` takes precedence over `continueOnError`, and the same signal is propagated through notification channels to transport calls.
 - The service initializes the configured transport during module bootstrap and closes factory-owned resources during application shutdown.
 - Direct and notification-backed delivery require the lifecycle to be `ready`; calls before `onModuleInit()` finishes, after initialization failure, or during shutdown fail with `SlackLifecycleError` instead of lazily creating or reusing transports.
 - Shutdown rejects new deliveries, waits for active deliveries and any in-flight factory-owned transport creation to settle, and then closes the owned transport before completion.

--- a/packages/slack/src/module.test.ts
+++ b/packages/slack/src/module.test.ts
@@ -868,6 +868,45 @@ describe('SlackModule', () => {
     });
   });
 
+  it('forwards notification dispatch signals through SlackChannel to the transport', async () => {
+    const controller = new AbortController();
+    let observedSignal: AbortSignal | undefined;
+    const container = new Container();
+    const slackModuleType = SlackModule.forRoot({
+      transport: {
+        async send(message, context) {
+          observedSignal = context.signal;
+
+          return {
+            channel: message.channel,
+            ok: true,
+            response: 'ok',
+            statusCode: 200,
+            warnings: [],
+          };
+        },
+      },
+    });
+    container.register(...moduleProviders(slackModuleType));
+    const channel = await container.resolve(SlackChannel);
+    const notificationsModuleType = NotificationsModule.forRoot({ channels: [channel] });
+    container.register(...moduleProviders(notificationsModuleType));
+
+    await initializeSlackService(container);
+    const notifications = await container.resolve(NotificationsService);
+
+    await expect(
+      notifications.dispatch(
+        {
+          channel: 'slack',
+          payload: { text: 'Signal forwarding through notifications' },
+        },
+        { signal: controller.signal },
+      ),
+    ).resolves.toMatchObject({ channel: 'slack', status: 'delivered' });
+    expect(observedSignal).toBe(controller.signal);
+  });
+
   it('renders notification templates and adapts them through SlackChannel', async () => {
     const container = new Container();
     const moduleType = SlackModule.forRoot({
@@ -1366,7 +1405,7 @@ describe('SlackModule', () => {
     expect(transport.sent).toEqual(['ok-1', 'fail-2', 'ok-3']);
   });
 
-  it('propagates sendMany abort signals between sequential deliveries', async () => {
+  it('rethrows signal aborts between sendMany deliveries even when continueOnError is enabled', async () => {
     const controller = new AbortController();
     const container = new Container();
     const moduleType = SlackModule.forRoot({
@@ -1391,14 +1430,37 @@ describe('SlackModule', () => {
     container.register(...moduleProviders(moduleType));
     const service = await initializeSlackService(container);
 
-    const result = await service.sendMany([{ text: 'first' }, { text: 'second' }], {
-      continueOnError: true,
-      signal: controller.signal,
+    await expect(
+      service.sendMany([{ text: 'first' }, { text: 'second' }], {
+        continueOnError: true,
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+    expect(transportState.sent.map((entry) => entry.text)).toEqual(['first']);
+  });
+
+  it('rethrows transport AbortErrors from sendMany even when continueOnError is enabled', async () => {
+    const sent: string[] = [];
+    const abortError = new Error('Slack transport aborted delivery.');
+    abortError.name = 'AbortError';
+    const container = new Container();
+    const moduleType = SlackModule.forRoot({
+      defaultChannel: '#ops',
+      transport: {
+        async send(message) {
+          sent.push(message.text ?? '');
+          throw abortError;
+        },
+      },
     });
 
-    expect(result).toMatchObject({ failed: 1, succeeded: 1 });
-    expect(result.failures[0]?.error).toMatchObject({ name: 'AbortError' });
-    expect(transportState.sent.map((entry) => entry.text)).toEqual(['first']);
+    container.register(...moduleProviders(moduleType));
+    const service = await initializeSlackService(container);
+
+    await expect(
+      service.sendMany([{ text: 'first' }, { text: 'second' }], { continueOnError: true }),
+    ).rejects.toBe(abortError);
+    expect(sent).toEqual(['first']);
   });
 
   it('retries transient webhook failures with exponential backoff before succeeding', async () => {

--- a/packages/slack/src/service.ts
+++ b/packages/slack/src/service.ts
@@ -31,6 +31,10 @@ function assertNotAborted(signal: AbortSignal | undefined): void {
   }
 }
 
+function isAbortError(error: Error): boolean {
+  return error.name === 'AbortError';
+}
+
 type SlackServiceLifecycleState = 'created' | 'starting' | 'ready' | 'stopping' | 'stopped' | 'failed';
 
 function createLifecycleError(message: string, cause: unknown): SlackLifecycleError {
@@ -264,7 +268,7 @@ export class SlackService implements Slack, OnModuleInit, OnApplicationShutdown 
           message,
         };
 
-        if (!(options.continueOnError ?? false)) {
+        if (options.signal?.aborted || isAbortError(failure.error) || !(options.continueOnError ?? false)) {
           throw failure.error;
         }
 


### PR DESCRIPTION
## Summary

`continueOnError` no longer converts caller cancellation or transport `AbortError` values into successful tolerant Slack batch results.

Linked context: Closes #2590

## Changes

- Rethrow aborts from `SlackService.sendMany(...)` regardless of `continueOnError`.
- Cover signal-aborted batches, transport `AbortError` values, and `NotificationsService` -> `SlackChannel` -> transport signal identity.
- Synchronize English/Korean Slack behavioral-contract notes.

## Testing

- `pnpm --filter @fluojs/slack test` (68 passed)
- `pnpm --filter @fluojs/slack... build`
- `pnpm --filter @fluojs/slack typecheck`
- Manual compiled-library driver: aborted first batch delivery rejected with `AbortError` and skipped the second delivery.
- `pnpm docs:sync-check`
- `pnpm verify:platform-consistency-governance`
- `pnpm verify:release-readiness`
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main`

## Release impact

- [x] This PR has consumer-visible release impact and includes a patch changeset for `@fluojs/slack`.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] No public export shape changed; existing public-method TSDoc remains applicable.
- [x] README behavioral-contract documentation was updated in English and Korean.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] The affected package README documents abort precedence over `continueOnError`.
- [x] Signal-aborted batches, transport `AbortError` values, and notification-channel signal propagation have regression coverage.

## Platform consistency governance (SSOT)

- [x] No governed platform-contract document changed; package README EN/KO mirrors were synchronized.
- [x] `pnpm verify:platform-consistency-governance` passed.
- [x] This change is runtime-neutral and requires no platform harness update.