### PR TITLE
Resolve #2570: Cover Cron shutdown and registry validation defaults

### DIFF
--- a/packages/cron/src/module.test.ts
+++ b/packages/cron/src/module.test.ts
@@ -2423,6 +2423,7 @@ describe('@fluojs/cron', () => {
   });
 
   it('rejects blank required dynamic task names without changing registry or scheduler state', async () => {
+    vi.useFakeTimers();
     const scheduled = createManualScheduler();
 
     class AppModule {}
@@ -2436,10 +2437,13 @@ describe('@fluojs/cron', () => {
     registry.addCron('existing-cron', CronExpression.EVERY_SECOND, () => {});
     const registryState = registry.getAll();
     const schedulerState = [...scheduled.records];
+    const timerCount = vi.getTimerCount();
 
     expect(() => registry.addCron('   ', CronExpression.EVERY_SECOND, () => {})).toThrow(/non-empty string/i);
     expect(() => registry.addInterval('   ', 1_000, () => {})).toThrow(/non-empty string/i);
+    expect(vi.getTimerCount()).toBe(timerCount);
     expect(() => registry.addTimeout('   ', 1_000, () => {})).toThrow(/non-empty string/i);
+    expect(vi.getTimerCount()).toBe(timerCount);
 
     expect(registry.getAll()).toEqual(registryState);
     expect(scheduled.records).toEqual(schedulerState);

--- a/packages/cron/src/module.test.ts
+++ b/packages/cron/src/module.test.ts
@@ -2422,6 +2422,32 @@ describe('@fluojs/cron', () => {
     await closeApplication(app);
   });
 
+  it('rejects blank required dynamic task names without changing registry or scheduler state', async () => {
+    const scheduled = createManualScheduler();
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [CronModule.forRoot({ scheduler: scheduled.scheduler })],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+    const registry = await app.container.resolve<SchedulingRegistry>(SCHEDULING_REGISTRY);
+
+    registry.addCron('existing-cron', CronExpression.EVERY_SECOND, () => {});
+    const registryState = registry.getAll();
+    const schedulerState = [...scheduled.records];
+
+    expect(() => registry.addCron('   ', CronExpression.EVERY_SECOND, () => {})).toThrow(/non-empty string/i);
+    expect(() => registry.addInterval('   ', 1_000, () => {})).toThrow(/non-empty string/i);
+    expect(() => registry.addTimeout('   ', 1_000, () => {})).toThrow(/non-empty string/i);
+
+    expect(registry.getAll()).toEqual(registryState);
+    expect(scheduled.records).toEqual(schedulerState);
+    expect(schedulerState[0]?.stop).not.toHaveBeenCalled();
+
+    await closeApplication(app);
+  });
+
   it('returns immutable scheduling descriptor snapshots from get and getAll', async () => {
     class AppModule {}
     defineModule(AppModule, {
@@ -2681,6 +2707,57 @@ describe('@fluojs/cron', () => {
     expect(store.intervalCount).toBe(1);
     expect(store.timeoutCount).toBe(0);
     expect(scheduled.records[0]?.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the default 10_000ms timeout when shutdown drains a hung cron task', async () => {
+    vi.useFakeTimers();
+    const scheduled = createManualScheduler();
+    const loggerEvents: string[] = [];
+    const started = createDeferred<void>();
+
+    class TaskService {
+      @Cron(CronExpression.EVERY_SECOND, { name: 'default-timeout-hung-cron' })
+      async run(): Promise<void> {
+        started.resolve();
+        await new Promise(() => {});
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [CronModule.forRoot({ scheduler: scheduled.scheduler })],
+      providers: [TaskService],
+    });
+
+    const app = await bootstrapApplication({
+      logger: createLogger(loggerEvents),
+      rootModule: AppModule,
+    });
+
+    void scheduled.records[0]?.tick();
+    await started.promise;
+
+    let closeResolved = false;
+    const closePromise = app.close().then(() => {
+      closeResolved = true;
+    });
+
+    await Promise.resolve();
+
+    await vi.advanceTimersByTimeAsync(9_999);
+    expect(closeResolved).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await closePromise;
+    await settleCronTeardown();
+
+    expect(closeResolved).toBe(true);
+    expect(scheduled.records[0]?.stop).toHaveBeenCalledTimes(1);
+    expect(
+      loggerEvents.some((event) =>
+        event.includes('Cron shutdown timed out after 10000ms with 1 active task(s) still pending.'),
+      ),
+    ).toBe(true);
   });
 
   it('bounds shutdown when an active cron task never settles', async () => {


### PR DESCRIPTION
## Summary

Add test-only regression coverage for the documented Cron shutdown and dynamic registry validation contracts.

Linked context: Closes #2570

## Changes

- Verify a hung Cron task uses the default `10_000ms` shutdown timeout before bounded shutdown completes.
- Verify blank required names are rejected by `addCron`, `addInterval`, and `addTimeout`.
- Verify validation failures leave existing registry descriptors and scheduler records unchanged.
- Production source, documentation, and Changesets remain unchanged because this PR only locks existing behavior.

## Testing

- `pnpm --dir packages/cron test -- module.test.ts` — passed (4 files, 85 tests).
- `pnpm --filter @fluojs/cron... build && pnpm --dir packages/cron typecheck` — passed.
- `pnpm exec biome check packages/cron/src/module.test.ts` — passed.
- `pnpm verify:platform-consistency-governance` — passed.
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main` — passed.
- Full repository suite is delegated to GitHub CI per the bounded local verification scope.

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

No `.changeset/*.md` is needed because only regression tests changed; public package behavior, API surface, package contents, and release metadata are unchanged.

## Public export documentation

- [ ] Changed public exports include a source-level summary.
- [ ] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [ ] Source `@example` blocks and README scenario examples still play complementary roles.

Not applicable: no public exports or source TSDoc changed.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [ ] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

No README or docs update is needed because the tests cover the existing documented `10_000ms` default and non-empty registry-name contract without changing behavior.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by the applicable platform harness tests, such as `createPlatformConformanceHarness(...)` for platform component contracts or `createHttpAdapterPortabilityHarness(...)` for HTTP adapter portability contracts.

No governance, platform contract, or package README files changed; the canonical governance verifier passes.