### PR TITLE
Resolve #2591: Preserve Slack renderer fallback for blank payload text

### DIFF
--- a/.changeset/issue-2591-slack-blank-payload-text.md
+++ b/.changeset/issue-2591-slack-blank-payload-text.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/slack": patch
+---
+
+Preserve renderer and subject text fallbacks when notification payload text is blank.

--- a/book/intermediate/ch17-slack-discord.ko.md
+++ b/book/intermediate/ch17-slack-discord.ko.md
@@ -231,7 +231,7 @@ await this.notifications.dispatch({
 });
 ```
 
-`sendNotification(...)`은 `notification.template`과 `renderer`가 모두 있을 때에만 renderer를 호출합니다. 명시적인 payload 필드는 `attachments`, `blocks`, `text`에서 rendered 필드보다 우선하며, text는 payload text에서 rendered text, 그리고 `subject` 순서로 fallback합니다. Metadata는 payload metadata, dispatch metadata, subject marker, template marker 순서로 merge되므로 최종 Slack 메시지는 운영 routing context를 보존합니다.
+`sendNotification(...)`은 `notification.template`과 `renderer`가 모두 있을 때에만 renderer를 호출합니다. 명시적인 payload 필드는 `attachments`, `blocks`에서 rendered 필드보다 우선하고, 비공백 payload text는 rendered text보다 우선합니다. 빈 문자열 또는 공백 전용 text는 미지정으로 취급하므로 text는 비공백 rendered text, 그리고 비공백 `subject` 순서로 fallback합니다. Metadata는 payload metadata, dispatch metadata, subject marker, template marker 순서로 merge되므로 최종 Slack 메시지는 운영 routing context를 보존합니다.
 
 ## 17.5 Rich Formatting: Blocks and Embeds
 

--- a/book/intermediate/ch17-slack-discord.md
+++ b/book/intermediate/ch17-slack-discord.md
@@ -231,7 +231,7 @@ await this.notifications.dispatch({
 });
 ```
 
-`sendNotification(...)` only calls the renderer when both `notification.template` and `renderer` are present. Explicit payload fields win over rendered fields for `attachments`, `blocks`, and `text`; text falls back from payload text to rendered text and then to `subject`. Metadata is merged from payload metadata, dispatch metadata, a subject marker, and a template marker in that order, so the final Slack message preserves the operational routing context.
+`sendNotification(...)` only calls the renderer when both `notification.template` and `renderer` are present. Explicit payload fields win over rendered fields for `attachments` and `blocks`, while non-blank payload text wins over rendered text; empty or whitespace-only text is treated as unspecified, so text falls back to non-blank rendered text and then to a non-blank `subject`. Metadata is merged from payload metadata, dispatch metadata, a subject marker, and a template marker in that order, so the final Slack message preserves the operational routing context.
 
 ## 17.5 Rich Formatting: Blocks and Embeds
 

--- a/packages/slack/README.ko.md
+++ b/packages/slack/README.ko.md
@@ -295,8 +295,8 @@ await notifications.dispatch({
 
 Merge precedence는 결정적입니다.
 
-- `payload.attachments`, `payload.blocks`, `payload.text`가 정의되어 있으면 rendered `attachments`, `blocks`, `text`보다 우선합니다.
-- Text는 `payload.text`에서 rendered `text`, 그리고 `notification.subject` 순서로 fallback합니다.
+- `payload.attachments`, `payload.blocks`가 정의되어 있으면 rendered `attachments`, `blocks`보다 우선합니다. 비공백 `payload.text`는 rendered `text`보다 우선합니다.
+- Text는 비공백 `payload.text`에서 비공백 rendered `text`, 그리고 비공백 `notification.subject` 순서로 fallback합니다. 빈 문자열 또는 공백 전용 text 값은 미지정으로 취급합니다.
 - Metadata는 payload metadata, dispatch metadata, subject marker, template marker 순서로 merge됩니다. 중복 키는 뒤쪽 값이 이기므로, 최종 메시지는 존재하는 dispatch `subject`와 `template` marker를 기록합니다.
 - `template`이 없거나 renderer가 등록되지 않았다면 template rendering은 실행되지 않습니다. 이 경우 notification은 payload와 subject만으로 Slack 메시지로 변환됩니다.
 

--- a/packages/slack/README.md
+++ b/packages/slack/README.md
@@ -295,8 +295,8 @@ await notifications.dispatch({
 
 Merge precedence is deterministic:
 
-- `payload.attachments`, `payload.blocks`, and `payload.text` win over rendered `attachments`, `blocks`, and `text` when those payload fields are defined.
-- Text falls back from `payload.text` to rendered `text`, then to `notification.subject`.
+- `payload.attachments` and `payload.blocks` win over rendered `attachments` and `blocks` when those payload fields are defined. Non-blank `payload.text` wins over rendered `text`.
+- Text falls back from non-blank `payload.text` to non-blank rendered `text`, then to non-blank `notification.subject`. Empty or whitespace-only text values are treated as unspecified.
 - Metadata is merged as payload metadata, dispatch metadata, subject marker, then template marker. Later entries win on duplicate keys, so the final message records the dispatch `subject` and `template` markers when present.
 - If no `template` is set or no renderer is registered, no template rendering occurs; the notification is adapted from its payload and subject only.
 

--- a/packages/slack/src/module.test.ts
+++ b/packages/slack/src/module.test.ts
@@ -1020,7 +1020,7 @@ describe('SlackModule', () => {
       async render(input) {
         renderInputs.push(input);
 
-        if (input.template === 'deploy.subject-fallback') {
+        if (input.template === 'deploy.subject-fallback' || input.template === 'deploy.blank-payload-subject-fallback') {
           return {};
         }
 
@@ -1081,8 +1081,22 @@ describe('SlackModule', () => {
       subject: 'Subject fallback text',
       template: 'deploy.subject-fallback',
     });
+    await service.sendNotification({
+      channel: 'slack',
+      payload: { text: '   ' },
+      recipients: ['#ops'],
+      subject: 'Blank payload text fallback',
+      template: 'deploy.blank-payload-text',
+    });
+    await service.sendNotification({
+      channel: 'slack',
+      payload: { text: '   ' },
+      recipients: ['#ops'],
+      subject: 'Blank payload subject fallback',
+      template: 'deploy.blank-payload-subject-fallback',
+    });
 
-    expect(renderInputs).toHaveLength(3);
+    expect(renderInputs).toHaveLength(5);
     expect(renderInputs[0]).toMatchObject({
       locale: 'en',
       metadata: {
@@ -1117,6 +1131,8 @@ describe('SlackModule', () => {
       template: 'deploy.subject-fallback',
     });
     expect(transportState.sent[2]?.text).toBe('Subject fallback text');
+    expect(transportState.sent[3]?.text).toBe('Rendered Blank payload text fallback');
+    expect(transportState.sent[4]?.text).toBe('Blank payload subject fallback');
   });
 
   it('creates a webhook-first transport with an explicit fetch-compatible boundary', async () => {

--- a/packages/slack/src/service.ts
+++ b/packages/slack/src/service.ts
@@ -329,7 +329,7 @@ export class SlackService implements Slack, OnModuleInit, OnApplicationShutdown 
         },
         mrkdwn: payload.mrkdwn,
         replyBroadcast: payload.replyBroadcast,
-        text: payload.text ?? rendered?.text ?? notification.subject,
+        text: normalizeOptionalString(payload.text) ?? normalizeOptionalString(rendered?.text) ?? normalizeOptionalString(notification.subject),
         threadTs: payload.threadTs,
         unfurlLinks: payload.unfurlLinks,
         unfurlMedia: payload.unfurlMedia,


### PR DESCRIPTION
## Summary

Preserve Slack template renderer and subject text fallbacks when notification payload text is blank.

Linked context: Closes #2591

## Changes

- Normalize candidate payload, rendered, and subject text before applying fallback precedence.
- Add renderer and subject fallback regressions for whitespace-only payload text.
- Synchronize Slack package and intermediate-book EN/KO contract docs.

## Testing

- `pnpm --filter @fluojs/slack test`
- `pnpm build`
- `pnpm --filter @fluojs/slack typecheck`
- `pnpm docs:sync-check`
- `pnpm verify:platform-consistency-governance`
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main`
- `pnpm verify:release-readiness`
- Built-package manual delivery check with blank `payload.text` printed `rendered fallback`.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Patch rationale: this restores documented fallback behavior without changing the public API.

## Public export documentation

- [x] No public exports changed; source-level export documentation is not applicable.
- [x] No exported function parameter or return documentation changed.
- [x] README contract documentation was updated for the existing public behavior.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] The Slack README documents that blank text is unspecified before renderer and subject fallback.
- [x] No intentional limitations were removed.
- [x] Regression tests cover both renderer and subject fallbacks.

## Platform consistency governance (SSOT)

- [x] Slack package and intermediate-book English/Korean mirrors are synchronized.
- [x] No platform contract docs changed; discoverability, tooling, and CI enforcement updates are not applicable.
- [x] `pnpm verify:platform-consistency-governance` passed.