### PR TITLE
Resolve #2565: repair the Queue InvoiceWorker book example

### DIFF
--- a/book/intermediate/ch11-queue.ko.md
+++ b/book/intermediate/ch11-queue.ko.md
@@ -47,7 +47,7 @@ import { QueueModule } from '@fluojs/queue';
     RedisModule.forRoot({ host: 'localhost', port: 6379 }),
     QueueModule.forRoot(),
   ],
-  providers: [InvoiceWorker, EmailWorker, CatalogSyncWorker],
+  providers: [InvoiceService, InvoiceWorker, EmailWorker, CatalogSyncWorker],
 })
 export class BackgroundJobsModule {}
 ```
@@ -63,7 +63,9 @@ Job은 직렬화된 작업 단위입니다. Worker는 그 job을 처리하는 �
 Invoice PDF 생성은 전형적인 queue task입니다. checkout confirmation path 안에서 처리하기에는 오래 걸립니다. file storage나 rendering outage 같은 일시적인 원인으로 실패할 수도 있습니다.
 
 ```typescript
+import { Inject } from '@fluojs/core';
 import { QueueWorker } from '@fluojs/queue';
+import { InvoiceService } from './invoice.service.js';
 
 export class GenerateInvoiceJob {
   constructor(public readonly orderId: string) {}
@@ -73,8 +75,11 @@ export class GenerateInvoiceJob {
   attempts: 5,
   backoff: { type: 'exponential', delayMs: 1_000 },
 })
+@Inject(InvoiceService)
 export class InvoiceWorker {
-  async handle(job: GenerateInvoiceJob) {
+  constructor(private readonly invoices: InvoiceService) {}
+
+  async handle(job: GenerateInvoiceJob): Promise<void> {
     await this.invoices.renderAndStore(job.orderId);
   }
 }

--- a/book/intermediate/ch11-queue.md
+++ b/book/intermediate/ch11-queue.md
@@ -47,7 +47,7 @@ import { QueueModule } from '@fluojs/queue';
     RedisModule.forRoot({ host: 'localhost', port: 6379 }),
     QueueModule.forRoot(),
   ],
-  providers: [InvoiceWorker, EmailWorker, CatalogSyncWorker],
+  providers: [InvoiceService, InvoiceWorker, EmailWorker, CatalogSyncWorker],
 })
 export class BackgroundJobsModule {}
 ```
@@ -63,7 +63,9 @@ A job is a serialized unit of work. A worker owns how that job is processed. Thi
 Invoice PDF generation is a typical queue task. It takes too long to run inside the checkout confirmation path. It may also fail for temporary reasons such as file storage or rendering outages.
 
 ```typescript
+import { Inject } from '@fluojs/core';
 import { QueueWorker } from '@fluojs/queue';
+import { InvoiceService } from './invoice.service.js';
 
 export class GenerateInvoiceJob {
   constructor(public readonly orderId: string) {}
@@ -73,8 +75,11 @@ export class GenerateInvoiceJob {
   attempts: 5,
   backoff: { type: 'exponential', delayMs: 1_000 },
 })
+@Inject(InvoiceService)
 export class InvoiceWorker {
-  async handle(job: GenerateInvoiceJob) {
+  constructor(private readonly invoices: InvoiceService) {}
+
+  async handle(job: GenerateInvoiceJob): Promise<void> {
     await this.invoices.renderAndStore(job.orderId);
   }
 }


### PR DESCRIPTION
## Summary

Repair the Chapter 11 Queue `InvoiceWorker` example so it follows the current public DI, worker discovery, and processor contracts.

Linked context: Closes #2565

## Changes

- import `Inject` and the application-owned `InvoiceService` in the EN/KO worker examples
- add explicit `@Inject(InvoiceService)` constructor injection
- register `InvoiceService` with the background jobs module providers
- declare the Queue processor as `handle(job: GenerateInvoiceJob): Promise<void>`
- keep English and Korean Chapter 11 examples synchronized

## Testing

- `pnpm docs:sync-check`
- `pnpm verify:docs`
- `pnpm verify:platform-consistency-governance`
- `pnpm vitest run tooling/governance/verify-platform-consistency-governance.test.ts` (81 tests passed)
- `pnpm build`
- `pnpm typecheck`
- `pnpm --filter @fluojs/queue build`
- `pnpm --filter @fluojs/queue test` (58 tests passed)
- `pnpm lint` (passed; existing non-failing repository diagnostics remain)
- `pnpm verify:release-readiness`

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

No changeset is included because this is a book-only correction. It does not change `@fluojs/queue` behavior, API surface, published package contents, or release metadata.

## Public export documentation

- [x] No public exports changed.
- [x] The example now uses the existing documented `Inject`, `QueueWorker`, `QueueModule.forRoot(...)`, and `handle(job)` contracts.
- [x] Package README and source TSDoc remain unchanged because their current API documentation already matches the corrected example.

## Behavioral contract

- [x] No documented behavioral contracts were removed.
- [x] No runtime behavior or API contract changed.
- [x] The book example now reflects explicit constructor injection, singleton provider registration, and the current worker processor signature.
- [x] Existing Queue regression tests passed.

## Platform consistency governance (SSOT)

- [x] English/Korean Chapter 11 mirrors remain synchronized.
- [x] `pnpm docs:sync-check` and `pnpm verify:platform-consistency-governance` passed.
- [x] No platform contract or conformance claim changed; additional platform harness coverage is not applicable.
