### PR TITLE
Resolve #2558: separate Redis registration and Sentinel names

### DIFF
--- a/.changeset/bright-lemons-dance.md
+++ b/.changeset/bright-lemons-dance.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/redis': minor
+---
+
+Add `sentinelName` so ioredis Sentinel master names remain independent from Fluo named Redis registrations.

--- a/packages/redis/README.ko.md
+++ b/packages/redis/README.ko.md
@@ -91,6 +91,7 @@ export class CacheRepository {
 
 - `name`을 생략하면 기본 별칭인 `REDIS_CLIENT` / `RedisService`를 사용합니다.
 - `name`을 지정하면 `getRedisClientToken(name)` / `getRedisServiceToken(name)`으로 이름 있는 바인딩을 가져옵니다.
+- `name`은 Fluo 등록만 식별합니다. ioredis Sentinel master name은 `sentinelName`으로 전달하세요. Fluo는 등록 토큰을 바꾸지 않고 이를 ioredis 생성자 `name` 옵션으로 전달합니다.
 - 이름 있는 클라이언트도 기본 클라이언트와 동일한 bootstrap/shutdown 계약을 따르며, `REDIS_CLIENT` / `RedisService` 별칭은 기본 등록에서만 export됩니다.
 - 이름은 trim되며, blank 또는 whitespace-only name은 token/component helper에서 거부됩니다.
 
@@ -111,6 +112,7 @@ const ANALYTICS_REDIS_CLIENT = getRedisClientToken('analytics');
   imports: [
     RedisModule.forRoot({ host: 'localhost', port: 6379 }),
     RedisModule.forRoot({ name: 'analytics', host: 'localhost', port: 6380 }),
+    RedisModule.forRoot({ name: 'sentinel-cache', sentinelName: 'mymaster', sentinels: [{ host: 'localhost', port: 26379 }] }),
   ],
 })
 export class AppModule {}
@@ -200,7 +202,7 @@ export class PubSubTransportFactory {
 ### 타입
 - `DefaultRedisModuleOptions`: 이름 없는 기본 Redis 등록이 받는 옵션입니다. 선택적 global alias visibility와 lifecycle timeout control을 포함합니다.
 - `NamedRedisModuleOptions`: 추가 이름 있는 Redis 등록이 받는 옵션입니다. 필수 `name`과 scoped lifecycle timeout control을 포함합니다.
-- `RedisModuleOptions`: Fluo가 module-only `name`, `global`, `lifecycle` 필드를 제거한 뒤 `ioredis` 생성자에 전달하는 설정 옵션입니다.
+- `RedisModuleOptions`: Fluo가 module-only `name`, `global`, `lifecycle`, `sentinelName` 필드를 제거한 뒤 `ioredis` 생성자에 전달하는 설정 옵션입니다. `sentinelName`은 ioredis Sentinel master `name`으로 전달되고, `name`은 Fluo 등록 식별자로 유지됩니다.
 - `RedisClientOptions`: Fluo가 module-only field를 제거하고 내부에서 `lazyConnect: true`를 강제하기 전의 Redis constructor option입니다.
 - `RedisLifecycleOptions`: Fluo가 소유한 `connect()`와 `quit()` lifecycle command의 timeout을 조정하는 선택적 옵션입니다.
 - `PersistencePlatformStatusSnapshot`, `RedisStatusAdapterInput`: status snapshot input/output type입니다.

--- a/packages/redis/README.md
+++ b/packages/redis/README.md
@@ -91,6 +91,7 @@ Use `RedisModule.forRoot({ name, ...options })` when one application needs more 
 
 - Omit `name` when you want the default aliases: `REDIS_CLIENT` / `RedisService`.
 - Pass `name` when you want the named helpers: `getRedisClientToken(name)` / `getRedisServiceToken(name)`.
+- `name` identifies the Fluo registration only. For an ioredis Sentinel master name, pass `sentinelName`; Fluo forwards it to ioredis as its constructor `name` option without changing the registration tokens.
 - Named clients follow the same bootstrap/shutdown contract as the default client; only the default registration exports the `REDIS_CLIENT` / `RedisService` aliases.
 - Names are trimmed, and blank or whitespace-only names are rejected by token/component helpers.
 
@@ -111,6 +112,7 @@ const ANALYTICS_REDIS_CLIENT = getRedisClientToken('analytics');
   imports: [
     RedisModule.forRoot({ host: 'localhost', port: 6379 }),
     RedisModule.forRoot({ name: 'analytics', host: 'localhost', port: 6380 }),
+    RedisModule.forRoot({ name: 'sentinel-cache', sentinelName: 'mymaster', sentinels: [{ host: 'localhost', port: 26379 }] }),
   ],
 })
 export class AppModule {}
@@ -200,7 +202,7 @@ export class PubSubTransportFactory {
 ### Types
 - `DefaultRedisModuleOptions`: Options accepted by the unnamed default Redis registration, including optional global alias visibility and lifecycle timeout controls.
 - `NamedRedisModuleOptions`: Options accepted by additional named Redis registrations, including required `name` and scoped lifecycle timeout controls.
-- `RedisModuleOptions`: Configuration options passed to the `ioredis` constructor after Fluo removes module-only `name`, `global`, and `lifecycle` fields.
+- `RedisModuleOptions`: Configuration options passed to the `ioredis` constructor after Fluo removes module-only `name`, `global`, `lifecycle`, and `sentinelName` fields. `sentinelName` is forwarded as the ioredis Sentinel master `name`, while `name` remains the Fluo registration identifier.
 - `RedisClientOptions`: Redis constructor options after Fluo removes module-only fields and before it forces `lazyConnect: true` internally.
 - `RedisLifecycleOptions`: Optional timeout controls for Fluo-owned `connect()` and `quit()` lifecycle commands.
 - `PersistencePlatformStatusSnapshot`, `RedisStatusAdapterInput`: Status snapshot input/output types.

--- a/packages/redis/src/module.test.ts
+++ b/packages/redis/src/module.test.ts
@@ -389,6 +389,52 @@ describe('@fluojs/redis', () => {
     await app.close();
   });
 
+  it('keeps a named registration separate from the ioredis Sentinel master name', async () => {
+    const CACHE_REDIS_CLIENT = getRedisClientToken('cache');
+    const CACHE_REDIS_SERVICE = getRedisServiceToken('cache');
+
+    @Inject(CACHE_REDIS_CLIENT)
+    class CacheClientConsumer {
+      constructor(readonly redis: MockRedisInstance) {}
+    }
+
+    @Inject(CACHE_REDIS_SERVICE)
+    class CacheServiceConsumer {
+      constructor(readonly redis: RedisService) {}
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [
+        RedisModule.forRoot({
+          host: '127.0.0.1',
+          name: 'cache',
+          port: 26379,
+          sentinelName: 'mymaster',
+          sentinels: [{ host: '127.0.0.1', port: 26379 }],
+        }),
+      ],
+      providers: [CacheClientConsumer, CacheServiceConsumer],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+    const clientConsumer = await app.container.resolve(CacheClientConsumer);
+    const serviceConsumer = await app.container.resolve(CacheServiceConsumer);
+
+    expect(mockRedisState.instances[0]?.options).toMatchObject({
+      host: '127.0.0.1',
+      lazyConnect: true,
+      name: 'mymaster',
+      port: 26379,
+      sentinels: [{ host: '127.0.0.1', port: 26379 }],
+    });
+    expect(mockRedisState.instances[0]?.options).not.toHaveProperty('sentinelName');
+    expect(clientConsumer.redis).toBe(mockRedisState.instances[0]);
+    expect(serviceConsumer.redis.getRawClient()).toBe(clientConsumer.redis);
+
+    await app.close();
+  });
+
   it.each([
     ['connectTimeoutMs', -1],
     ['connectTimeoutMs', Number.NaN],

--- a/packages/redis/src/module.ts
+++ b/packages/redis/src/module.ts
@@ -34,7 +34,7 @@ function normalizeRedisModuleOptions(options: RedisModuleOptions): {
   lifecycleOptions: RedisLifecycleOptions;
   name?: string;
 } {
-  const { global, lifecycle, name, ...clientOptions } = options;
+  const { global, lifecycle, name, sentinelName, ...clientOptions } = options;
   const normalizedName = name?.trim();
   const lifecycleOptions = normalizeRedisLifecycleOptions(lifecycle);
 
@@ -47,7 +47,10 @@ function normalizeRedisModuleOptions(options: RedisModuleOptions): {
   }
 
   return {
-    clientOptions,
+    clientOptions: {
+      ...clientOptions,
+      ...(sentinelName === undefined ? {} : { name: sentinelName }),
+    },
     global: normalizedName === undefined ? global ?? true : false,
     lifecycleOptions,
     name: normalizedName,

--- a/packages/redis/src/types.ts
+++ b/packages/redis/src/types.ts
@@ -1,6 +1,6 @@
 import type { RedisOptions } from 'ioredis';
 
-type RedisConnectionOptions = Omit<RedisOptions, 'lazyConnect'>;
+type RedisConnectionOptions = Omit<RedisOptions, 'lazyConnect' | 'name'>;
 
 /** Lifecycle timeout controls for Redis connections owned by Fluo. */
 export interface RedisLifecycleOptions {
@@ -17,6 +17,8 @@ export type DefaultRedisModuleOptions = RedisConnectionOptions & {
   /** Timeout controls for lifecycle-owned `connect()` and `quit()` calls. */
   lifecycle?: RedisLifecycleOptions;
   name?: undefined;
+  /** ioredis Sentinel master name forwarded as the Redis constructor `name` option. */
+  sentinelName?: string;
 };
 
 /** Options accepted by an additional named Redis registration. */
@@ -25,6 +27,8 @@ export type NamedRedisModuleOptions = RedisConnectionOptions & {
   lifecycle?: RedisLifecycleOptions;
   /** Registration name used to derive named raw-client and facade tokens. */
   name: string;
+  /** ioredis Sentinel master name forwarded as the Redis constructor `name` option. */
+  sentinelName?: string;
   /** Named Redis registrations remain scoped to their importing module. */
   global?: false;
 };
@@ -38,4 +42,4 @@ export type NamedRedisModuleOptions = RedisConnectionOptions & {
 export type RedisModuleOptions = DefaultRedisModuleOptions | NamedRedisModuleOptions;
 
 /** Redis constructor options after Fluo module-only fields are removed. */
-export type RedisClientOptions = RedisConnectionOptions;
+export type RedisClientOptions = RedisConnectionOptions & Pick<RedisOptions, 'name'>;


### PR DESCRIPTION
## Summary

Add an explicit `sentinelName` option so a Fluo named Redis registration remains independent from the ioredis Sentinel master name.

Linked context: https://github.com/fluojs/fluo/issues/2558

Closes #2558

## Changes

- Map `sentinelName` to the ioredis constructor `name` option while keeping `name` for Fluo DI registration tokens.
- Cover constructor options plus named client and facade injection through a bootstrapped module graph.
- Document the configuration in English and Korean package READMEs.

## Testing

- Passed: `pnpm --filter @fluojs/redis run test` (60 tests), `pnpm --filter @fluojs/redis run typecheck`, and `pnpm --filter @fluojs/redis run build`.
- Passed: targeted Sentinel module bootstrap/token test, changed-file TypeScript diagnostics, scoped Biome lint, public-export TSDoc, platform-consistency governance, and stable changeset lane verification.
- `pnpm lint` and `pnpm verify:release-readiness` remain blocked by existing `origin/main` Config lint diagnostics and `@fluojs/email` resolving no `@fluojs/testing` types; this PR does not modify those paths.

## Release impact

- [x] This PR has consumer-visible release impact and includes `.changeset/bright-lemons-dance.md` with a `minor` bump for `@fluojs/redis`.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public option properties include source-level summaries.
- [x] Changed exported functions are not applicable.
- [x] README scenario examples document the new configuration path.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] The new `sentinelName` contract is documented in both package READMEs.
- [x] The registration-token and Sentinel-master-name invariant is covered by a bootstrapped module regression test.

## Platform consistency governance (SSOT)

- [x] English/Korean package README mirrors remain synchronized.
- [x] Platform contract docs and platform harness changes are not applicable; this is a Redis package registration option.
- [x] `pnpm verify:platform-consistency-governance` passed.