### PR TITLE
Resolve #2592: Consume Slack webhook responses before retry

### DIFF
--- a/.changeset/issue-2592-slack-retry-response-consumption.md
+++ b/.changeset/issue-2592-slack-retry-response-consumption.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/slack": patch
+---
+
+Consume transient webhook response bodies before retrying delivery.

--- a/packages/slack/README.ko.md
+++ b/packages/slack/README.ko.md
@@ -321,7 +321,7 @@ await slack.send({
 Behavioral contract 메모:
 
 - `fetch`를 명시적으로 전달하는 방식이 portable path이며 모든 지원 런타임에서 권장됩니다. 하위 호환성을 위해 `fetch`를 생략하면 ambient runtime API인 `globalThis.fetch`가 있을 때 이를 폴백으로 사용합니다. `globalThis.fetch`가 없는 런타임에서는 `SlackConfigurationError`로 빠르게 실패합니다.
-- 내장 webhook transport는 `408`, `429`, `5xx` 같은 일시적 실패를 호출자에게 에러를 노출하기 전에 bounded exponential backoff로 재시도합니다.
+- 내장 webhook transport는 `408`, `429`, `5xx` 같은 일시적 실패 응답의 본문을 소비한 뒤 bounded exponential backoff로 재시도하고, 재시도가 모두 소진된 뒤에만 호출자에게 에러를 노출합니다.
 - Abort signal은 주입된 `fetch` 경계로 전달되며, retry backoff를 취소할 때 `AbortError`를 `SlackTransportError`로 감싸지 않습니다.
 - 호출자에게 보이는 `SlackTransportError` 메시지는 기본적으로 raw upstream response body를 포함하지 않습니다.
 

--- a/packages/slack/README.md
+++ b/packages/slack/README.md
@@ -321,7 +321,7 @@ For richer API integrations such as `chat.postMessage`, implement the exported `
 Behavioral contract notes:
 
 - Passing `fetch` explicitly is the portable path and is recommended for all supported runtimes. For backward compatibility, omitting `fetch` falls back to `globalThis.fetch` when that ambient runtime API exists; runtimes without `globalThis.fetch` fail fast with `SlackConfigurationError`.
-- The built-in webhook transport retries transient `408`, `429`, and `5xx` failures with bounded exponential backoff before surfacing an error.
+- The built-in webhook transport consumes transient `408`, `429`, and `5xx` response bodies before retrying with bounded exponential backoff, then surfaces an error only after retries are exhausted.
 - Abort signals are passed to the injected `fetch` boundary and cancel retry backoff without wrapping `AbortError` values as `SlackTransportError`.
 - Caller-visible `SlackTransportError` messages omit raw upstream response bodies by default.
 

--- a/packages/slack/src/module.test.ts
+++ b/packages/slack/src/module.test.ts
@@ -1479,7 +1479,7 @@ describe('SlackModule', () => {
     expect(sent).toEqual(['first']);
   });
 
-  it('retries transient webhook failures with exponential backoff before succeeding', async () => {
+  it('consumes transient webhook responses before retrying with exponential backoff', async () => {
     vi.useFakeTimers();
 
     try {
@@ -1514,15 +1514,15 @@ describe('SlackModule', () => {
 
       await expect(pending).resolves.toMatchObject({ ok: true, response: 'ok', statusCode: 200 });
       expect(fetchLike).toHaveBeenCalledTimes(3);
-      expect(rateLimitedText).not.toHaveBeenCalled();
-      expect(outageText).not.toHaveBeenCalled();
+      expect(rateLimitedText).toHaveBeenCalledOnce();
+      expect(outageText).toHaveBeenCalledOnce();
       expect(successText).toHaveBeenCalledOnce();
     } finally {
       vi.useRealTimers();
     }
   });
 
-  it('retries request-timeout webhook failures before succeeding', async () => {
+  it('consumes request-timeout webhook responses before retrying', async () => {
     vi.useFakeTimers();
 
     try {
@@ -1551,7 +1551,45 @@ describe('SlackModule', () => {
 
       await expect(pending).resolves.toMatchObject({ ok: true, response: 'ok', statusCode: 200 });
       expect(fetchLike).toHaveBeenCalledTimes(2);
-      expect(requestTimeoutText).not.toHaveBeenCalled();
+      expect(requestTimeoutText).toHaveBeenCalledOnce();
+      expect(successText).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('continues retrying when consuming a transient webhook response fails', async () => {
+    vi.useFakeTimers();
+
+    try {
+      const responseReadFailure = new Error('response stream failed');
+      const transientText = vi.fn(async () => {
+        throw responseReadFailure;
+      });
+      const successText = vi.fn(async () => 'ok');
+      const fetchLike = vi
+        .fn<SlackFetchLike>()
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 429,
+          text: transientText,
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          text: successText,
+        });
+      const transport = createSlackWebhookTransport({
+        fetch: fetchLike,
+        webhookUrl: 'https://hooks.slack.test/services/T000/B000/XXXX',
+      });
+
+      const pending = transport.send({ attachments: [], blocks: [], channel: '#ops', text: 'Response read retry path' }, {});
+      await vi.runAllTimersAsync();
+
+      await expect(pending).resolves.toMatchObject({ ok: true, response: 'ok', statusCode: 200 });
+      expect(fetchLike).toHaveBeenCalledTimes(2);
+      expect(transientText).toHaveBeenCalledOnce();
       expect(successText).toHaveBeenCalledOnce();
     } finally {
       vi.useRealTimers();

--- a/packages/slack/src/webhook.ts
+++ b/packages/slack/src/webhook.ts
@@ -135,6 +135,7 @@ export function createSlackWebhookTransport(options: SlackWebhookTransportOption
             method: 'POST',
             signal: context.signal,
           });
+          const body = await readResponseBody(response);
 
           if (!response.ok) {
             if (attempt < DEFAULT_RETRY_ATTEMPTS && isTransientStatus(response.status)) {
@@ -142,11 +143,8 @@ export function createSlackWebhookTransport(options: SlackWebhookTransportOption
               continue;
             }
 
-            await readResponseBody(response);
             throw new SlackTransportError(createStatusFailureMessage(response, attempt));
           }
-
-          const body = await readResponseBody(response);
 
           return {
             channel: message.channel,


### PR DESCRIPTION
## Summary

Consume transient Slack webhook response bodies before retrying so fetch-compatible runtimes can release response resources promptly without changing retry, abort, or caller-visible error behavior.

Closes #2592

Linked context: https://github.com/fluojs/fluo/issues/2592

## Changes

- Consume each webhook response body before deciding whether a transient `408`, `429`, or `5xx` response should retry.
- Preserve retry behavior when response-body consumption itself fails.
- Document the response-consumption guarantee in the Slack README and Korean mirror.
- Add a patch changeset for `@fluojs/slack`.

## Testing

- `pnpm --filter @fluojs/slack test`
- `pnpm --filter @fluojs/slack build`
- `pnpm --filter @fluojs/slack typecheck`
- `pnpm docs:sync-check`
- `pnpm verify:platform-consistency-governance`
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main`
- Changed-file TypeScript diagnostics passed.

`pnpm verify:release-readiness` was also run twice but remains non-blocking for this general package change: its aggregate package suite times out in unchanged `packages/cli/src/new/scaffold.test.ts`. No CLI code or tests were modified; relevant Slack gates above are green.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

The `@fluojs/slack` patch changeset records the documented response-resource consumption behavior.

## Public export documentation

- [x] Changed public exports include a source-level summary. Not applicable: no public export changed.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable. Not applicable: no exported signature changed.
- [x] Source `@example` blocks and README scenario examples still play complementary roles. Existing examples remain accurate.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

The retry status set, exponential backoff, abort propagation, and sanitized caller-visible errors remain unchanged.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. The Slack README pair passed `pnpm docs:sync-check`.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. Not applicable: no platform contract docs changed.
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests, such as `createPlatformConformanceHarness(...)` for platform component contracts or `createHttpAdapterPortabilityHarness(...)` for HTTP adapter portability contracts. Not applicable: webhook transport behavior is covered by its package regression tests.