### PR TITLE
Resolve #2560: Cover Redis lifecycle timeout regressions

### DIFF
--- a/.changeset/redis-late-connect-cleanup.md
+++ b/.changeset/redis-late-connect-cleanup.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/redis': patch
+---
+
+Close Redis connections that complete after the lifecycle connect timeout.

--- a/packages/redis/src/module.test.ts
+++ b/packages/redis/src/module.test.ts
@@ -283,6 +283,30 @@ describe('@fluojs/redis', () => {
     expect(mockRedisState.instances[0]?.status).toBe('end');
   });
 
+  it('disconnects a late default connect after the lifecycle timeout expires', async () => {
+    vi.useFakeTimers();
+    const connectDeferred = createDeferred<void>();
+    mockRedisState.connectDeferred = connectDeferred;
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [RedisModule.forRoot({ host: '127.0.0.1', port: 6379 })],
+    });
+
+    const bootstrapPromise = bootstrapApplication({ rootModule: AppModule });
+    const bootstrapAssertion = expect(bootstrapPromise).rejects.toThrow(
+      'Redis client default connect timed out after 10000ms.',
+    );
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    await bootstrapAssertion;
+    connectDeferred.resolve(undefined);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(mockRedisState.events).toEqual(['connect', 'disconnect', 'disconnect']);
+    expect(mockRedisState.instances[0]?.status).toBe('end');
+  });
+
   it('fails bootstrap when a named lifecycle-owned connect exceeds the configured timeout', async () => {
     vi.useFakeTimers();
     mockRedisState.connectHangs = true;
@@ -613,6 +637,24 @@ describe('@fluojs/redis', () => {
     const closePromise = app.close();
     const closeAssertion = expect(closePromise).resolves.toBeUndefined();
     await vi.advanceTimersByTimeAsync(25);
+
+    await closeAssertion;
+    expect(mockRedisState.events).toEqual(['connect', 'quit', 'disconnect']);
+  });
+
+  it('forces disconnect when lifecycle-owned quit exceeds the default timeout', async () => {
+    vi.useFakeTimers();
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [RedisModule.forRoot({ host: '127.0.0.1', port: 6379 })],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+    mockRedisState.quitHangs = true;
+    const closePromise = app.close();
+    const closeAssertion = expect(closePromise).resolves.toBeUndefined();
+    await vi.advanceTimersByTimeAsync(10_000);
 
     await closeAssertion;
     expect(mockRedisState.events).toEqual(['connect', 'quit', 'disconnect']);

--- a/packages/redis/src/service.ts
+++ b/packages/redis/src/service.ts
@@ -127,14 +127,22 @@ export class RedisLifecycleService implements OnModuleInit, OnApplicationShutdow
   }
 
   private async connectWithDisconnectFallback(): Promise<void> {
+    const connectPromise = this.client.connect();
+
     try {
       await withLifecycleTimeout(
-        this.client.connect(),
+        connectPromise,
         normalizeTimeoutMs(this.lifecycleOptions.connectTimeoutMs),
         `Redis client ${this.describeClient()} connect timed out after ${String(normalizeTimeoutMs(this.lifecycleOptions.connectTimeoutMs))}ms.`,
       );
     } catch (error: unknown) {
       this.disconnectIfPossible(this.client.status);
+      void connectPromise.then(
+        () => {
+          this.disconnectIfPossible(this.client.status);
+        },
+        () => undefined,
+      );
 
       throw error;
     }


### PR DESCRIPTION
## Summary

Prevent a Redis client from remaining connected when an in-flight `connect()` completes after the lifecycle timeout.

Closes #2560

Linked context: https://github.com/fluojs/fluo/issues/2560

## Changes

- Retain the lifecycle-owned connect promise and disconnect it if it resolves after timeout cleanup.
- Add default 10,000ms connect/quit timeout regression coverage and late-connect cleanup coverage.

## Testing

- `pnpm --filter @fluojs/redis test -- module.test.ts`
- `pnpm verify`
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main`
- `pnpm verify:release-readiness` was attempted but its internal full package Vitest run timed out in unrelated CLI, GraphQL, microservices, and JWT tests; the focused Redis suite and `pnpm verify` passed.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Patch changeset: `@fluojs/redis` now closes a connect operation that completes after lifecycle timeout cleanup.

## Public export documentation

- [x] No public exports changed.
- [x] No exported function documentation changed.
- [x] README examples remain applicable.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] The existing Redis README lifecycle contract already documents bounded connect/quit and disconnect fallback; no README change was required.
- [x] The late-connect lifecycle invariant is covered by regression tests.
- [x] No intentional limitations were changed.

## Platform consistency governance (SSOT)

- [x] No governed English/Korean documentation changed.
- [x] No platform contract documentation or package conformance claims changed.
- [x] No platform harness update is applicable to this Redis lifecycle fix.