### PR TITLE
Resolve #2559: Normalize fractional Redis TTL values

### DIFF
--- a/.changeset/normalize-redis-fractional-ttl.md
+++ b/.changeset/normalize-redis-fractional-ttl.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/redis': patch
+---
+
+Normalize fractional RedisService TTLs to integer millisecond expiry values.

--- a/packages/redis/README.ko.md
+++ b/packages/redis/README.ko.md
@@ -53,7 +53,7 @@ export class AppModule {}
 
 `RedisService`를 주입받아 고수준 작업을 수행하거나, `REDIS_CLIENT`를 통해 원시 `ioredis` 인스턴스를 직접 사용할 수 있습니다.
 
-`RedisService.get()`은 JSON parse를 시도하고 실패하면 raw string을 반환합니다. 누락된 key는 `null`을 반환합니다. `RedisService.set()`은 값을 `JSON.stringify()`로 직렬화하고 양수 TTL에만 `EX`를 사용합니다.
+`RedisService.get()`은 JSON parse를 시도하고 실패하면 raw string을 반환합니다. 누락된 key는 `null`을 반환합니다. `RedisService.set()`은 값을 `JSON.stringify()`로 직렬화하며, 유한한 양의 정수 TTL에는 Redis `EX`를 사용하고 유한한 양의 소수 TTL에는 올림한 밀리초 값으로 `PX`를 사용합니다. TTL을 생략하거나 0 이하 또는 유한하지 않은 값을 전달하면 persistent key를 저장합니다.
 
 ```typescript
 import { Inject } from '@fluojs/core';

--- a/packages/redis/README.md
+++ b/packages/redis/README.md
@@ -53,7 +53,7 @@ export class AppModule {}
 
 Inject `RedisService` for high-level operations or `REDIS_CLIENT` for the raw `ioredis` instance.
 
-`RedisService.get()` attempts JSON parsing and falls back to the raw string; missing keys return `null`. `RedisService.set()` serializes values with `JSON.stringify()` and uses `EX` only for positive TTL values.
+`RedisService.get()` attempts JSON parsing and falls back to the raw string; missing keys return `null`. `RedisService.set()` serializes values with `JSON.stringify()`: finite positive integer TTLs use Redis `EX`, while finite positive fractional TTLs use `PX` with milliseconds rounded up. Omit the TTL or pass a non-positive or non-finite value for a persistent key.
 
 ```typescript
 import { Inject } from '@fluojs/core';

--- a/packages/redis/src/module.test.ts
+++ b/packages/redis/src/module.test.ts
@@ -820,9 +820,13 @@ describe('@fluojs/redis', () => {
 
   it.each([
     ['positive TTL', 60, ['EX', 60]],
-    ['fractional positive TTL', 0.5, ['EX', 0.5]],
+    ['fractional positive TTL', 0.5, ['PX', 500]],
+    ['fractional TTL with sub-millisecond precision', 1.2345, ['PX', 1235]],
     ['zero TTL', 0, []],
     ['negative TTL', -1, []],
+    ['infinite TTL', Number.POSITIVE_INFINITY, []],
+    ['negative infinite TTL', Number.NEGATIVE_INFINITY, []],
+    ['NaN TTL', Number.NaN, []],
     ['omitted TTL', undefined, []],
   ])('serializes values and forwards %s using the documented RedisService.set args', async (_caseName, ttlSeconds, expectedArgs) => {
     @Inject(RedisService)

--- a/packages/redis/src/redis-service.ts
+++ b/packages/redis/src/redis-service.ts
@@ -72,16 +72,22 @@ export class RedisService {
    *
    * @param key Redis key to write.
    * @param value Serializable value stored as JSON.
-   * @param ttlSeconds Optional TTL in seconds. Omit or pass a non-positive value for a persistent key.
+   * @param ttlSeconds Optional TTL in seconds. Finite positive integers use `EX`; finite positive fractions use `PX` rounded up to milliseconds. Omit or pass a non-positive or non-finite value for a persistent key.
    * @returns A promise that resolves after Redis acknowledges the write.
    */
   async set<T>(key: string, value: T, ttlSeconds?: number): Promise<void> {
     const serialized = JSON.stringify(value);
-    if (ttlSeconds !== undefined && ttlSeconds > 0) {
-      await this.client.set(key, serialized, 'EX', ttlSeconds);
-    } else {
-      await this.client.set(key, serialized);
+    if (ttlSeconds !== undefined && Number.isFinite(ttlSeconds) && ttlSeconds > 0) {
+      if (Number.isInteger(ttlSeconds)) {
+        await this.client.set(key, serialized, 'EX', ttlSeconds);
+        return;
+      }
+
+      await this.client.set(key, serialized, 'PX', Math.ceil(ttlSeconds * 1000));
+      return;
     }
+
+    await this.client.set(key, serialized);
   }
 
   /**


### PR DESCRIPTION
## Summary

Normalize `RedisService.set()` TTL command arguments so fractional TTLs no longer reach Redis `EX` as invalid decimal seconds.

Linked context: https://github.com/fluojs/fluo/issues/2559

Closes #2559

## Changes

- Preserve finite positive integer TTLs with Redis `EX`.
- Normalize finite positive fractional TTLs to rounded-up integer milliseconds with Redis `PX`.
- Keep non-positive and non-finite TTLs persistent, with focused regression coverage.
- Document the TTL contract in the English and Korean Redis READMEs.

## Testing

- Passed: `pnpm --dir packages/redis test` (64 tests).
- Passed: `pnpm --dir packages/redis build` and `pnpm --dir packages/redis typecheck`.
- Passed: `pnpm typecheck`, changed-file Biome lint, changed-file LSP diagnostics, `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main`, and `pnpm verify:platform-consistency-governance`.
- Manual library smoke: direct `RedisService` import produced `PX 500` for `0.5` and `EX 2` for `2`.
- Blocked by unrelated repository baseline: root `pnpm verify` / `pnpm verify:release-readiness` fail while building unrelated packages due TS7016 resolution of generated `@fluojs/core` declarations; root `pnpm lint` also reports pre-existing unrelated diagnostics.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Added a patch changeset for `@fluojs/redis` because callers with fractional TTLs now receive a valid Redis expiry command.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

`RedisService.set()` already existed; its TSDoc now documents the integer-second versus fractional-millisecond TTL contract.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests, such as `createPlatformConformanceHarness(...)` for platform component contracts or `createHttpAdapterPortabilityHarness(...)` for HTTP adapter portability contracts.

No platform contract docs or adapters changed. `pnpm verify:platform-consistency-governance` passed.