### PR TITLE
Resolve #2598: Correct Chapter 6 query binding example

### DIFF
--- a/book/beginner/ch06-validation.ko.md
+++ b/book/beginner/ch06-validation.ko.md
@@ -220,7 +220,10 @@ export class PublicCreateDto extends OmitType(CreatePostDto, ['published']) {}
 만약 쿼리 파라미터에서 꼭 숫자를 받아야 한다면, DTO에 먼저 바인딩한 뒤 변환을 코드에서 명시적으로 드러내면 됩니다.
 
 ```typescript
+import { FromQuery, Get, RequestDto } from '@fluojs/http';
+
 class ListPostsQueryDto {
+  @FromQuery('page')
   page = '1';
 }
 
@@ -232,7 +235,7 @@ findAll(input: ListPostsQueryDto) {
 }
 ```
 
-이렇게 하면 변환 과정이 명시적이고 가시적이게 됩니다. 먼저 DTO 입력 계약을 고정하고, 그 다음 필요한 변환을 코드에서 드러내는 방식입니다.
+이렇게 하면 요청 소스와 변환 과정이 모두 명시적이고 가시적이게 됩니다. 먼저 `@FromQuery('page')`가 `page` 쿼리 필드를 DTO에 바인딩하고, 그 다음 핸들러가 필요한 변환을 코드에서 드러냅니다.
 
 ## 6.6 What FluoBlog Looks Like After Validation
 

--- a/book/beginner/ch06-validation.md
+++ b/book/beginner/ch06-validation.md
@@ -220,7 +220,10 @@ Do not assume the network sends the exact type you want. Describe the type you e
 If you really need to accept a number from a query parameter, bind it to a DTO first, then make the conversion explicit in code.
 
 ```typescript
+import { FromQuery, Get, RequestDto } from '@fluojs/http';
+
 class ListPostsQueryDto {
+  @FromQuery('page')
   page = '1';
 }
 
@@ -232,7 +235,7 @@ findAll(input: ListPostsQueryDto) {
 }
 ```
 
-This makes the conversion process explicit and visible. First you fix the DTO input contract, then you show the required conversion in code.
+This makes both the request source and the conversion process explicit and visible. First `@FromQuery('page')` binds the `page` query field to the DTO, then the handler shows the required conversion in code.
 
 ## 6.6 What FluoBlog Looks Like After Validation
 


### PR DESCRIPTION
## Summary

Correct the Chapter 6 query parameter example so the documented `?page=2` value is explicitly bound to the DTO before conversion.

Linked context: Closes #2598

## Changes

- import `FromQuery` in the English and Korean Chapter 6 examples
- apply `@FromQuery("page")` to `ListPostsQueryDto.page`
- clarify that request source selection and scalar conversion are both explicit

## Testing

- `pnpm docs:sync-check` — passed, 42 EN/KO page pairs and 10 navigation metadata pairs
- `pnpm verify:platform-consistency-governance` — passed
- focused EN/KO source-binding assertion — passed
- `git diff --check origin/main...HEAD` — passed

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact. It changes book documentation only.

## Public export documentation

- [x] No public exports or source declarations changed.
- [x] Exported function documentation is not applicable.
- [x] The corrected scenario example now matches the documented HTTP binding surface.

## Behavioral contract

- [x] No documented behavioral contract was removed.
- [x] Runtime behavior is unchanged.
- [x] The example now reflects explicit request-source binding.
- [x] No runtime invariant test is required for this docs-only correction.

## Platform consistency governance (SSOT)

- [x] English/Korean companion pages were updated together.
- [x] No platform contract docs changed.
- [x] Locale parity and governance checks pass.