### PR TITLE
Resolve #2531: Regenerate Deno published constructor declarations

### DIFF
--- a/.changeset/calm-denos-declare.md
+++ b/.changeset/calm-denos-declare.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/platform-deno': patch
+---
+
+Republish the Deno adapter declarations with optional constructor options and verify the generated public type surface during package tests.

--- a/packages/platform-deno/README.ko.md
+++ b/packages/platform-deno/README.ko.md
@@ -66,7 +66,7 @@ try {
 ```
 
 ### 직접 어댑터 생성
-애플리케이션 코드는 보통 `createDenoAdapter(options)`, `bootstrapDenoApplication(...)`, `runDenoApplication(...)`을 사용해 adapter setup 경계를 명확히 유지하는 편을 권장합니다. 커스텀 orchestration이나 테스트에서는 `new DenoHttpApplicationAdapter(options)`를 직접 사용할 수 있으며, constructor는 factory와 같은 public `DenoAdapterOptions`를 받아 기본 port를 적용하고, portable `host` alias보다 `hostname`을 우선하며, 잘못된 `port` 또는 `maxBodySize` 값은 setup 시점에 거절합니다.
+애플리케이션 코드는 보통 `createDenoAdapter(options)`, `bootstrapDenoApplication(...)`, `runDenoApplication(...)`을 사용해 adapter setup 경계를 명확히 유지하는 편을 권장합니다. 커스텀 orchestration이나 테스트에서는 `new DenoHttpApplicationAdapter(options?)`를 직접 사용할 수 있으며, constructor는 factory와 같은 optional public `DenoAdapterOptions`를 받고 options가 생략되면 기본 port를 적용하며, portable `host` alias보다 `hostname`을 우선하고, 잘못된 `port` 또는 `maxBodySize` 값은 setup 시점에 거절합니다.
 
 ### Opt-in Deno WebSocket 바인딩
 어댑터는 애플리케이션이 `@fluojs/websockets/deno` 바인딩을 import하고 설정한 뒤에 Deno의 네이티브 `Deno.upgradeWebSocket`을 지원합니다. 해당 바인딩이 없으면 websocket upgrade 요청은 암묵적으로 upgrade되지 않고 일반 HTTP dispatch 경로를 계속 따릅니다.
@@ -112,7 +112,7 @@ Advanced option에는 test 또는 non-hosted runtime을 위한 injectable `serve
 
 ## Conformance 커버리지
 
-`packages/platform-deno/src/adapter.test.ts`는 문서화된 Deno 계약을 검증하는 package-local regression 대상입니다. 이 파일은 shared Web dispatch delegation, `listen(dispatcher)` 이후 direct `adapter.handle(...)` success-path dispatch, 직접 constructor/factory option normalization, HTTPS startup forwarding, `Deno.serve(...)` bind target과 startup log에 대한 `host` alias 및 `hostname` 우선순위, 중복 `listen(...)` no-op dispatcher 보존, 기본 `SIGINT`/`SIGTERM` signal listener 등록, `shutdownSignals: false`, partial signal-registration failure 이후 listener rollback, websocket upgrade binding 및 no-binding HTTP fallback, websocket listen 전 bootstrap gating, global Deno serve/upgrade fallback seam, listen 전 `500` 처리, shutdown 중 `503` 처리, serve-signal abort 전 in-flight request drain, bounded 10초 close timeout을 검증합니다.
+`packages/platform-deno/src/adapter.test.ts`는 문서화된 Deno 계약을 검증하는 package-local regression 대상입니다. 이 파일은 shared Web dispatch delegation, `listen(dispatcher)` 이후 direct `adapter.handle(...)` success-path dispatch, 직접 constructor/factory option normalization, HTTPS startup forwarding, `Deno.serve(...)` bind target과 startup log에 대한 `host` alias 및 `hostname` 우선순위, 중복 `listen(...)` no-op dispatcher 보존, 기본 `SIGINT`/`SIGTERM` signal listener 등록, `shutdownSignals: false`, partial signal-registration failure 이후 listener rollback, websocket upgrade binding 및 no-binding HTTP fallback, websocket listen 전 bootstrap gating, global Deno serve/upgrade fallback seam, listen 전 `500` 처리, shutdown 중 `503` 처리, serve-signal abort 전 in-flight request drain, bounded 10초 close timeout을 검증합니다. `packages/platform-deno/src/declaration-surface.test.ts`는 package를 다시 build하고 manifest가 export하는 declaration이 zero-argument adapter construction을 보존하는지 검증합니다.
 
 공유 edge portability suite인 `packages/testing/src/portability/web-runtime-adapter-portability.test.ts`는 Deno를 Bun 및 Cloudflare Workers와 함께 실행해 malformed cookie 보존, query decoding, JSON/text raw-body capture, multipart raw-body 제외, SSE framing을 검증합니다. 패키지 테스트의 README parity assertion은 이 edge-runtime 커버리지 문서가 한국어 mirror와 계속 동기화되도록 확인합니다.
 
@@ -121,7 +121,7 @@ Advanced option에는 test 또는 non-hosted runtime을 위한 injectable `serve
 - `createDenoAdapter(options)`: Deno HTTP 어댑터를 위한 팩토리이며, 직접 생성과 같은 validation 및 normalization을 공유합니다.
 - `bootstrapDenoApplication(module, options)`: 커스텀 오케스트레이션을 위한 고급 부트스트랩입니다.
 - `runDenoApplication(module, options)`: Deno를 위한 권장 빠른 시작 헬퍼입니다.
-- `DenoHttpApplicationAdapter(options)`: 핵심 adapter 구현체입니다. Direct `new DenoHttpApplicationAdapter(options)`는 `createDenoAdapter(options)`와 같은 기본 port, `host` alias 처리, `hostname` 우선순위, 숫자 option validation을 적용합니다.
+- `DenoHttpApplicationAdapter(options?)`: 핵심 adapter 구현체입니다. Direct `new DenoHttpApplicationAdapter()` 또는 `new DenoHttpApplicationAdapter(options)`는 `createDenoAdapter(options)`와 같은 기본 port, `host` alias 처리, `hostname` 우선순위, 숫자 option validation을 적용합니다.
 - `listen(dispatcher)`: fluo HTTP dispatcher를 bind하고 `Deno.serve`를 시작합니다. 중복 호출은 원래 dispatcher를 보존하는 no-op입니다.
 - `close()`: 새 유입을 중단하고 active request를 최대 10초 drain한 뒤, shutdown이 끝나지 않으면 Deno serve signal을 abort합니다.
 - `handle(request)`: 수동 `Request` to `Response` 디스패처입니다. `listen(dispatcher)`가 runtime dispatcher를 bind한 뒤에는 성공 경로를 실행하고, bind 전에는 JSON `500`, shutdown 중에는 JSON `503`을 반환합니다.

--- a/packages/platform-deno/README.md
+++ b/packages/platform-deno/README.md
@@ -66,7 +66,7 @@ try {
 ```
 
 ### Direct Adapter Construction
-Application code should usually prefer `createDenoAdapter(options)`, `bootstrapDenoApplication(...)`, or `runDenoApplication(...)` so adapter setup stays explicit. Custom orchestration and tests may use `new DenoHttpApplicationAdapter(options)` directly; the constructor accepts the same public `DenoAdapterOptions` as the factory, applies the default port, preserves `hostname` over the portable `host` alias, and rejects invalid `port` or `maxBodySize` values during setup.
+Application code should usually prefer `createDenoAdapter(options)`, `bootstrapDenoApplication(...)`, or `runDenoApplication(...)` so adapter setup stays explicit. Custom orchestration and tests may use `new DenoHttpApplicationAdapter(options?)` directly; the constructor accepts the same optional public `DenoAdapterOptions` as the factory, applies the default port when options are omitted, preserves `hostname` over the portable `host` alias, and rejects invalid `port` or `maxBodySize` values during setup.
 
 ### Opt-in Deno WebSocket Binding
 The adapter supports Deno's native `Deno.upgradeWebSocket` after the application imports and configures the `@fluojs/websockets/deno` binding. Without that binding, websocket upgrade requests continue through normal HTTP dispatch instead of being upgraded implicitly.
@@ -112,7 +112,7 @@ Advanced options include injectable `serve` and `upgradeWebSocket` seams for tes
 
 ## Conformance Coverage
 
-`packages/platform-deno/src/adapter.test.ts` is the package-local regression target for the documented Deno contract. It covers shared Web dispatch delegation, direct `adapter.handle(...)` success-path dispatch after `listen(dispatcher)`, direct constructor/factory option normalization, HTTPS startup forwarding, `host` alias and `hostname` precedence for the `Deno.serve(...)` bind target and startup log, duplicate `listen(...)` no-op dispatcher preservation, default `SIGINT`/`SIGTERM` signal listener registration, `shutdownSignals: false`, listener rollback after partial signal-registration failure, websocket upgrade binding and no-binding HTTP fallback, websocket pre-listen bootstrap gating, global Deno serve/upgrade fallback seams, pre-listen `500` handling, shutdown `503` handling, in-flight request drain before serve-signal abort, and the bounded 10-second close timeout.
+`packages/platform-deno/src/adapter.test.ts` is the package-local regression target for the documented Deno contract. It covers shared Web dispatch delegation, direct `adapter.handle(...)` success-path dispatch after `listen(dispatcher)`, direct constructor/factory option normalization, HTTPS startup forwarding, `host` alias and `hostname` precedence for the `Deno.serve(...)` bind target and startup log, duplicate `listen(...)` no-op dispatcher preservation, default `SIGINT`/`SIGTERM` signal listener registration, `shutdownSignals: false`, listener rollback after partial signal-registration failure, websocket upgrade binding and no-binding HTTP fallback, websocket pre-listen bootstrap gating, global Deno serve/upgrade fallback seams, pre-listen `500` handling, shutdown `503` handling, in-flight request drain before serve-signal abort, and the bounded 10-second close timeout. `packages/platform-deno/src/declaration-surface.test.ts` rebuilds the package and verifies that the manifest-exported declarations preserve zero-argument adapter construction.
 
 The shared edge portability suite in `packages/testing/src/portability/web-runtime-adapter-portability.test.ts` exercises Deno beside Bun and Cloudflare Workers for malformed cookie preservation, query decoding, JSON/text raw-body capture, multipart raw-body exclusion, and SSE framing. The README parity assertion in the package test keeps these documented edge-runtime coverage claims synchronized with the Korean mirror.
 
@@ -121,7 +121,7 @@ The shared edge portability suite in `packages/testing/src/portability/web-runti
 - `createDenoAdapter(options)`: Factory for the Deno HTTP adapter; it shares validation and normalization with direct construction.
 - `bootstrapDenoApplication(module, options)`: Advanced bootstrap for custom orchestration.
 - `runDenoApplication(module, options)`: Recommended quick-start helper for Deno.
-- `DenoHttpApplicationAdapter(options)`: Core adapter implementation. Direct `new DenoHttpApplicationAdapter(options)` applies the same default port, `host` alias handling, `hostname` precedence, and numeric option validation as `createDenoAdapter(options)`.
+- `DenoHttpApplicationAdapter(options?)`: Core adapter implementation. Direct `new DenoHttpApplicationAdapter()` or `new DenoHttpApplicationAdapter(options)` applies the same default port, `host` alias handling, `hostname` precedence, and numeric option validation as `createDenoAdapter(options)`.
 - `listen(dispatcher)`: Binds the fluo HTTP dispatcher and starts `Deno.serve`; duplicate calls are no-ops while preserving the original dispatcher.
 - `close()`: Stops ingress, drains active requests for up to 10 seconds, and aborts the Deno serve signal if shutdown does not settle.
 - `handle(request)`: Manual `Request` to `Response` dispatcher. It succeeds after `listen(dispatcher)` binds the runtime dispatcher, returns JSON `500` before binding, and returns JSON `503` while shutdown is in progress.

--- a/packages/platform-deno/src/declaration-surface.test.ts
+++ b/packages/platform-deno/src/declaration-surface.test.ts
@@ -1,0 +1,45 @@
+import { execFile } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+import { describe, expect, it } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+const packageRootPath = fileURLToPath(new URL('..', import.meta.url));
+const repoRootPath = fileURLToPath(new URL('../../..', import.meta.url));
+const buildClosureScriptPath = fileURLToPath(
+  new URL('../../../tooling/scripts/run-workspace-build-closure.mjs', import.meta.url),
+);
+
+describe('@fluojs/platform-deno declaration surface', () => {
+  it('keeps zero-argument adapter construction in the manifest-exported declarations', async () => {
+    // Given: the package manifest publishes its root declarations from dist/index.d.ts.
+    const manifest: unknown = JSON.parse(readFileSync(resolve(packageRootPath, 'package.json'), 'utf8'));
+
+    expect(manifest).toMatchObject({
+      exports: {
+        '.': {
+          types: './dist/index.d.ts',
+        },
+      },
+    });
+
+    // When: publication declaration outputs are generated when a prior build is unavailable.
+    if (!existsSync(resolve(packageRootPath, 'dist/adapter.d.ts'))) {
+      await execFileAsync(process.execPath, [buildClosureScriptPath, '@fluojs/platform-deno'], {
+        cwd: repoRootPath,
+        env: process.env,
+      });
+    }
+
+    // Then: the exported root reaches an adapter declaration whose options argument is optional.
+    expect(readFileSync(resolve(packageRootPath, 'dist/index.d.ts'), 'utf8')).toContain(
+      "export * from './adapter.js';",
+    );
+    expect(readFileSync(resolve(packageRootPath, 'dist/adapter.d.ts'), 'utf8')).toContain(
+      'constructor(options?: DenoAdapterOptions);',
+    );
+  }, 300_000);
+});


### PR DESCRIPTION
## Summary

Regenerate and guard the published Deno constructor declaration so consumers can construct `DenoHttpApplicationAdapter` without options, matching the existing source and runtime contract.

Linked context: https://github.com/fluojs/fluo/issues/2531

Closes #2531

## Changes

- add a declaration-surface regression that checks the manifest-exported root declaration and `constructor(options?: DenoAdapterOptions)`
- document optional direct-constructor options consistently in the English and Korean package READMEs
- add a patch changeset for `@fluojs/platform-deno` so the corrected declarations are republished

## Testing

- `pnpm --filter @fluojs/platform-deno typecheck` — passed
- `pnpm --filter @fluojs/platform-deno test` — passed, 40 tests
- `pnpm exec biome check packages/platform-deno/src/declaration-surface.test.ts` — passed
- `pnpm lint` — passed; existing repository-wide informational diagnostics remain non-blocking
- `pnpm verify:platform-consistency-governance` — passed
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main` — passed
- `pnpm verify:release-readiness` — build, typecheck, lint, governance, and the changed Deno test passed; the packages-wide test phase remained red from unrelated timing-sensitive CLI/microservices tests under full parallel load. The isolated CLI cache test passed on rerun.

## Release impact

- [x] This PR has consumer-visible release impact and includes `.changeset/calm-denos-declare.md` with a patch bump.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

No source export was added or renamed. The new regression verifies the generated declaration reached through the existing root export map, and the package READMEs now spell the constructor as `DenoHttpApplicationAdapter(options?)`. Existing source TSDoc already documents the public constructor.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] The existing zero-argument construction contract is explicit in both README mirrors.
- [x] The generated declaration invariant is covered by a regression test.
- [x] Runtime behavior is unchanged; this is declaration/package-content alignment.

## Platform consistency governance (SSOT)

- [x] English/Korean package README mirrors were updated together.
- [x] No platform SSOT contract document changed.
- [x] The package-local declaration test provides regression evidence for the Deno adapter surface.