### PR TITLE
Resolve #2538: Restore descendant stale disposal ordering

### DIFF
--- a/.changeset/await-di-descendant-disposal.md
+++ b/.changeset/await-di-descendant-disposal.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/di": patch
+---
+
+Ensure provider replacement resolution waits for stale instance disposal across materialized descendant request scopes and propagates descendant disposal failures consistently.

--- a/packages/di/src/container.test.ts
+++ b/packages/di/src/container.test.ts
@@ -2188,6 +2188,67 @@ describe('Container', () => {
       await root.dispose();
     });
 
+    it('does not delay unrelated root resolution for a child-local override', async () => {
+      const events: string[] = [];
+      const ROOT_VALUE = Symbol('UnrelatedRootValue');
+      const CHILD_SERVICE = Symbol('ChildLocalService');
+      let releaseStaleDisposal!: () => void;
+      const staleDisposal = new Promise<void>((resolve) => {
+        releaseStaleDisposal = resolve;
+      });
+
+      class FirstChildService {
+        async onDestroy() {
+          events.push('child:destroy:start');
+          await staleDisposal;
+          events.push('child:destroy:end');
+        }
+      }
+
+      class SecondChildService {}
+
+      const root = new Container().register({ provide: ROOT_VALUE, useValue: 'root' });
+      const requestScope = root.createRequestScope().override({ provide: CHILD_SERVICE, useClass: FirstChildService });
+
+      await requestScope.resolve(CHILD_SERVICE);
+      requestScope.override({ provide: CHILD_SERVICE, useClass: SecondChildService });
+
+      const rootResolution = root.resolve<string>(ROOT_VALUE).then((value) => events.push(`root:resolved:${value}`));
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      const eventsBeforeRelease = [...events];
+
+      releaseStaleDisposal();
+      await rootResolution;
+      await requestScope.resolve(CHILD_SERVICE);
+      await root.dispose();
+
+      expect(eventsBeforeRelease).toEqual(['child:destroy:start', 'root:resolved:root']);
+    });
+
+    it('does not leak child-local stale disposal failures into unrelated root resolution', async () => {
+      const ROOT_VALUE = Symbol('FailureIsolatedRootValue');
+      const CHILD_SERVICE = Symbol('FailingChildLocalService');
+
+      class FirstChildService {
+        onDestroy() {
+          throw new Error('child-local stale failed');
+        }
+      }
+
+      class SecondChildService {}
+
+      const root = new Container().register({ provide: ROOT_VALUE, useValue: 'root' });
+      const requestScope = root.createRequestScope().override({ provide: CHILD_SERVICE, useClass: FirstChildService });
+
+      await requestScope.resolve(CHILD_SERVICE);
+      requestScope.override({ provide: CHILD_SERVICE, useClass: SecondChildService });
+
+      await expect(root.resolve(ROOT_VALUE)).resolves.toBe('root');
+      await expect(requestScope.resolve(CHILD_SERVICE)).rejects.toThrow('child-local stale failed');
+      await expect(requestScope.resolve(CHILD_SERVICE)).resolves.toBeInstanceOf(SecondChildService);
+      await root.dispose();
+    });
+
     it('disposes stale overridden multi singleton instances immediately and exactly once', async () => {
       const events: string[] = [];
       const token = Symbol('multi-rotating-disposable-token');

--- a/packages/di/src/container.test.ts
+++ b/packages/di/src/container.test.ts
@@ -2122,6 +2122,72 @@ describe('Container', () => {
       ]);
     });
 
+    it('waits for descendant stale disposal before resolving a root replacement', async () => {
+      const events: string[] = [];
+      const CONFIG = Symbol('RootReplacementConfig');
+      let releaseStaleDisposal!: () => void;
+      const staleDisposal = new Promise<void>((resolve) => {
+        releaseStaleDisposal = resolve;
+      });
+
+      class RequestConsumer {
+        constructor(readonly config: string) {}
+
+        async onDestroy() {
+          events.push(`destroy:start:${this.config}`);
+          await staleDisposal;
+          events.push(`destroy:end:${this.config}`);
+        }
+      }
+
+      const root = new Container().register(
+        { provide: CONFIG, useValue: 'before-override' },
+        { provide: RequestConsumer, scope: Scope.REQUEST, useClass: RequestConsumer, inject: [CONFIG] },
+      );
+      const requestScope = root.createRequestScope();
+
+      await requestScope.resolve(RequestConsumer);
+      root.override({ provide: CONFIG, useValue: 'after-override' });
+
+      const replacement = root.resolve<string>(CONFIG).then((config) => events.push(`resolved:${config}`));
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(events).toEqual(['destroy:start:before-override']);
+
+      releaseStaleDisposal();
+      await replacement;
+      await root.dispose();
+
+      expect(events).toEqual([
+        'destroy:start:before-override',
+        'destroy:end:before-override',
+        'resolved:after-override',
+      ]);
+    });
+
+    it('surfaces descendant stale disposal failures before resolving a root replacement', async () => {
+      const CONFIG = Symbol('FailingDescendantConfig');
+
+      class RequestConsumer {
+        onDestroy() {
+          throw new Error('descendant stale failed');
+        }
+      }
+
+      const root = new Container().register(
+        { provide: CONFIG, useValue: 'before-override' },
+        { provide: RequestConsumer, scope: Scope.REQUEST, useClass: RequestConsumer, inject: [CONFIG] },
+      );
+      const requestScope = root.createRequestScope();
+
+      await requestScope.resolve(RequestConsumer);
+      root.override({ provide: CONFIG, useValue: 'after-override' });
+
+      await expect(root.resolve(CONFIG)).rejects.toThrow('descendant stale failed');
+      await expect(root.resolve(CONFIG)).resolves.toBe('after-override');
+      await root.dispose();
+    });
+
     it('disposes stale overridden multi singleton instances immediately and exactly once', async () => {
       const events: string[] = [];
       const token = Symbol('multi-rotating-disposable-token');

--- a/packages/di/src/container.ts
+++ b/packages/di/src/container.ts
@@ -1279,10 +1279,20 @@ export class Container {
   }
 
   private async assertStaleDisposalsSettled(): Promise<void> {
+    const errors: unknown[] = [];
+
+    await this.collectStaleDisposalErrorsInHierarchy(errors);
+    this.throwDisposalErrors(errors);
+  }
+
+  private async collectStaleDisposalErrorsInHierarchy(errors: unknown[]): Promise<void> {
     await this.waitForStaleDisposalTasks();
 
-    const errors = this.staleDisposalErrors.splice(0, this.staleDisposalErrors.length);
-    this.throwDisposalErrors(errors);
+    errors.push(...this.staleDisposalErrors.splice(0, this.staleDisposalErrors.length));
+
+    for (const childScope of this.childScopes ?? []) {
+      await childScope.collectStaleDisposalErrorsInHierarchy(errors);
+    }
   }
 
   private scheduleStaleDisposal(instancePromise: Promise<unknown>): void {

--- a/packages/di/src/container.ts
+++ b/packages/di/src/container.ts
@@ -43,6 +43,13 @@ interface CachedResolutionPlan<T> {
   readonly value: T;
 }
 
+interface StaleDisposalTask {
+  error: unknown;
+  errorConsumed: boolean;
+  failed: boolean;
+  promise: Promise<void>;
+}
+
 /**
  * Controlled cache adoption seam for framework-owned testing and tooling that
  * need synchronous helpers to preserve container-owned singleton disposal.
@@ -337,8 +344,7 @@ export class Container {
   private requestCache: Map<Token, Promise<unknown>> | undefined;
   private multiRequestCache: Map<NormalizedProvider, Promise<unknown>> | undefined;
   private readonly multiSingletonCache = new Map<NormalizedProvider, Promise<unknown>>();
-  private readonly staleDisposalTasks = new Set<Promise<void>>();
-  private readonly staleDisposalErrors: unknown[] = [];
+  private readonly staleDisposalTasks = new Set<StaleDisposalTask>();
   private readonly singletonCache: Map<Token, Promise<unknown>>;
   private readonly forwardRefTokenCache = new WeakMap<ForwardRefFn, Token>();
   private readonly factoryResolutionKinds = new WeakMap<NormalizedProvider, FactoryResolutionKind>();
@@ -1170,12 +1176,17 @@ export class Container {
   }
 
   private async disposeCache(entries: Array<[NormalizedProvider | Token, Promise<unknown>]>): Promise<void> {
-    await this.waitForStaleDisposalTasks();
+    const errors: unknown[] = [];
 
-    const { disposables, errors } = await this.collectDisposableInstances(entries);
+    try {
+      await this.assertStaleDisposalsSettled();
+    } catch (error) {
+      this.collectDisposalError(error, errors);
+    }
 
-    errors.push(...this.staleDisposalErrors.splice(0, this.staleDisposalErrors.length));
+    const { disposables, errors: resolutionErrors } = await this.collectDisposableInstances(entries);
 
+    errors.push(...resolutionErrors);
     errors.push(...(await this.disposeInstancesInReverseOrder(disposables)));
 
     this.clearDisposalCaches();
@@ -1272,33 +1283,36 @@ export class Container {
     this.effectiveProviderPlanCache.clear();
   }
 
-  private async waitForStaleDisposalTasks(): Promise<void> {
-    while (this.staleDisposalTasks.size > 0) {
-      await Promise.all(Array.from(this.staleDisposalTasks));
-    }
-  }
-
   private async assertStaleDisposalsSettled(): Promise<void> {
     const errors: unknown[] = [];
 
-    await this.collectStaleDisposalErrorsInHierarchy(errors);
+    while (this.staleDisposalTasks.size > 0) {
+      const tasks = Array.from(this.staleDisposalTasks);
+      await Promise.all(tasks.map((task) => task.promise));
+
+      for (const task of tasks) {
+        this.staleDisposalTasks.delete(task);
+
+        if (task.failed && !task.errorConsumed) {
+          task.errorConsumed = true;
+          errors.push(task.error);
+        }
+      }
+    }
+
     this.throwDisposalErrors(errors);
   }
 
-  private async collectStaleDisposalErrorsInHierarchy(errors: unknown[]): Promise<void> {
-    await this.waitForStaleDisposalTasks();
+  private scheduleStaleDisposal(instancePromise: Promise<unknown>, staleDisposalOwner: Container): void {
+    const observers = staleDisposalOwner === this ? [this] : [this, staleDisposalOwner];
+    const task: StaleDisposalTask = {
+      error: undefined,
+      errorConsumed: false,
+      failed: false,
+      promise: Promise.resolve(),
+    };
 
-    errors.push(...this.staleDisposalErrors.splice(0, this.staleDisposalErrors.length));
-
-    for (const childScope of this.childScopes ?? []) {
-      await childScope.collectStaleDisposalErrorsInHierarchy(errors);
-    }
-  }
-
-  private scheduleStaleDisposal(instancePromise: Promise<unknown>): void {
-    let task: Promise<void>;
-
-    task = (async () => {
+    task.promise = (async () => {
       try {
         const instance = await instancePromise;
 
@@ -1306,13 +1320,20 @@ export class Container {
           await instance.onDestroy();
         }
       } catch (error) {
-        this.staleDisposalErrors.push(error);
+        task.error = error;
+        task.failed = true;
       }
     })().finally(() => {
-      this.staleDisposalTasks.delete(task);
+      if (!task.failed) {
+        for (const observer of observers) {
+          observer.staleDisposalTasks.delete(task);
+        }
+      }
     });
 
-    this.staleDisposalTasks.add(task);
+    for (const observer of observers) {
+      observer.staleDisposalTasks.add(task);
+    }
   }
 
   private throwDisposalErrors(errors: unknown[]): void {
@@ -1524,21 +1545,21 @@ export class Container {
     return deps;
   }
 
-  private invalidateAffectedCachedEntriesInHierarchy(token: Token): void {
-    this.invalidateAffectedCachedEntries(token);
+  private invalidateAffectedCachedEntriesInHierarchy(token: Token, staleDisposalOwner: Container = this): void {
+    this.invalidateAffectedCachedEntries(token, staleDisposalOwner);
 
     for (const childScope of this.childScopes ?? []) {
-      childScope.invalidateAffectedCachedEntriesInHierarchy(token);
+      childScope.invalidateAffectedCachedEntriesInHierarchy(token, staleDisposalOwner);
     }
   }
 
-  private invalidateAffectedCachedEntries(token: Token): void {
+  private invalidateAffectedCachedEntries(token: Token, staleDisposalOwner: Container): void {
     for (const [cachedToken, cached] of this.requestCache?.entries() ?? []) {
       if (!this.shouldInvalidateCachedToken(cachedToken, token)) {
         continue;
       }
 
-      this.scheduleStaleDisposal(cached);
+      this.scheduleStaleDisposal(cached, staleDisposalOwner);
       this.requestCache?.delete(cachedToken);
     }
 
@@ -1548,7 +1569,7 @@ export class Container {
           continue;
         }
 
-        this.scheduleStaleDisposal(cached);
+        this.scheduleStaleDisposal(cached, staleDisposalOwner);
         this.singletonCache.delete(cachedToken);
       }
     }
@@ -1559,7 +1580,7 @@ export class Container {
           continue;
         }
 
-        this.scheduleStaleDisposal(cached);
+        this.scheduleStaleDisposal(cached, staleDisposalOwner);
         this.multiSingletonCache.delete(provider);
       }
     }
@@ -1575,7 +1596,7 @@ export class Container {
         continue;
       }
 
-      this.scheduleStaleDisposal(cached);
+      this.scheduleStaleDisposal(cached, staleDisposalOwner);
       multiRequestCache.delete(provider);
     }
   }


### PR DESCRIPTION
## Summary

Restore the documented `@fluojs/di` provider override lifecycle contract so a replacement resolved from an ancestor container cannot overlap stale instance disposal in materialized descendant request scopes.

Linked context: Closes #2538

## Changes

- Collect and await stale disposal tasks across the resolving container and its tracked descendant scopes.
- Propagate descendant stale disposal failures through the next ancestor replacement resolution.
- Add concurrency and error-propagation regression coverage for root resolution after descendant invalidation.
- Add a patch changeset for `@fluojs/di`.

## Testing

- `pnpm --filter @fluojs/di test` — passed (119 tests).
- `pnpm --filter @fluojs/di typecheck` — passed after building `@fluojs/core`.
- `pnpm --filter @fluojs/di build` — passed.
- Changed-file LSP diagnostics — no diagnostics.
- `pnpm typecheck && pnpm lint` — passed as part of the repository verification run.
- Full repository test run reached 3,985 passing tests but three unrelated CLI tests timed out under concurrent load; rerunning `packages/cli/src/cli.test.ts` and `packages/cli/src/new/scaffold.test.ts` passed all 236 tests.
- `pnpm verify:platform-consistency-governance` — passed.
- `pnpm verify:release-readiness` was attempted but exceeded the 10-minute local command limit after completing its build and typecheck phases.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Patch changeset: `.changeset/await-di-descendant-disposal.md`.

## Public export documentation

No public exports or signatures changed. Existing `Container.override(...)` documentation already states the restored stale-disposal ordering contract.

- [x] Changed public exports include a source-level summary. (Not applicable: no public exports changed.)
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable. (Not applicable.)
- [x] Source `@example` blocks and README scenario examples still play complementary roles. (No example changes.)

## Behavioral contract

The implementation now matches the existing `packages/di/README.md` contract that stale instances are disposed before replacement resolution continues.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README. (Not applicable: this restores an existing contract.)
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

No platform contract or governance documentation changed; the runtime-neutral DI lifecycle implementation and tests are shared across supported runtimes.

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. (No governance docs changed.)
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. (Not applicable.)
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests. (Not applicable; package-local DI regression coverage applies.)