### PR TITLE
Resolve #2537: Restore ConfigModule runtimeOverrides type contract

### DIFF
--- a/.changeset/config-module-runtime-overrides-type.md
+++ b/.changeset/config-module-runtime-overrides-type.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/config': patch
+---
+
+Expose the documented `runtimeOverrides` input on `ConfigModuleOptions` and preserve its registration-time snapshot.

--- a/packages/config/src/module.test.ts
+++ b/packages/config/src/module.test.ts
@@ -120,6 +120,25 @@ function moduleProviders(moduleType: Constructor): Provider[] {
   return metadata.providers as Provider[];
 }
 
+describe('ConfigModule registration', () => {
+  it('applies the registration-time runtime overrides snapshot above lower-precedence sources', async () => {
+    const runtimeOverrides = { PORT: '4100' };
+    const moduleRef = ConfigModule.forRoot({
+      defaults: { PORT: '3000' },
+      processEnv: { PORT: '4000' },
+      runtimeOverrides,
+    });
+    const container = new Container();
+
+    runtimeOverrides.PORT = '4200';
+    container.register(...moduleProviders(moduleRef));
+
+    const service = await container.resolve(ConfigService);
+
+    expect(service.get('PORT')).toBe('4100');
+  });
+});
+
 describe('ConfigModule watch mode', () => {
   it('activates watch reloads from ConfigModule.forRoot without replacing ConfigService identity', async () => {
     const cwd = mkdtempSync(join(tmpdir(), 'fluo-config-module-watch-'));

--- a/packages/config/src/options.ts
+++ b/packages/config/src/options.ts
@@ -54,6 +54,7 @@ export function snapshotConfigModuleOptions(options?: ConfigModuleOptions): Conf
     ...options,
     defaults: snapshotConfigDictionary(options.defaults),
     processEnv: snapshotProcessEnv(options.processEnv),
+    runtimeOverrides: snapshotConfigDictionary(options.runtimeOverrides),
     schema: snapshotConfigSchema(options.schema),
   });
 }

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -45,6 +45,8 @@ export interface ConfigModuleOptions {
   processEnv?: NodeJS.ProcessEnv;
   schema?: ConfigSchema;
   defaults?: ConfigDictionary;
+  /** Highest-precedence values applied after defaults, env files, and `processEnv`. */
+  runtimeOverrides?: ConfigDictionary;
   /** Supply a custom file parser (e.g. for YAML or TOML). Receives raw file content,
    *  returns a flat key-value record. Defaults to dotenv parsing. */
   parse?: (content: string) => Record<string, string>;
@@ -60,7 +62,6 @@ export interface ConfigModuleOptions {
  */
 export interface ConfigLoadOptions extends ConfigModuleOptions {
   cwd?: string;
-  runtimeOverrides?: ConfigDictionary;
 }
 
 /**


### PR DESCRIPTION
## Summary

Restore the documented `ConfigModule.forRoot(...)` `runtimeOverrides` input on the public `ConfigModuleOptions` type.

Linked context: Closes #2537

## Changes

- add `runtimeOverrides?: ConfigDictionary` with source TSDoc to `ConfigModuleOptions`
- preserve a detached registration-time snapshot of runtime overrides
- add module-path regression coverage for precedence and caller mutation isolation
- add an `@fluojs/config` patch changeset

## Testing

- `pnpm --filter @fluojs/config... build` — passed
- `pnpm --filter @fluojs/config typecheck` — passed
- `pnpm --filter @fluojs/config test` — passed (8 files, 80 tests)
- `pnpm lint` — passed; changed public-export TSDoc check passed (repository emitted pre-existing warnings/infos)
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main` — passed
- changed-file LSP diagnostics — no diagnostics
- `pnpm verify:release-readiness` — attempted twice; build/typecheck and the issue-scoped config tests passed, but the full repository test stage ended on unrelated timeout flakes. The reported CLI, Express, scaffold, and JWKS suites passed on isolated reruns. CI remains the authoritative full-gate rerun.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Patch rationale: runtime support and documentation already exist; this fixes the missing public TypeScript declaration and snapshots the accepted input.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No exported function signature changed. The existing package README already documents `runtimeOverrides` precedence and `ConfigModule.forRoot(...)` usage.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

This aligns the public type with the existing documented/runtime contract and preserves registration-time option isolation.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests.

No platform or governance document changed. The runtime-neutral config precedence contract remains unchanged.