### PR TITLE
Resolve #2518: Add HTTP cleanup regression coverage

### DIFF
--- a/packages/http/src/dispatch/dispatcher.test.ts
+++ b/packages/http/src/dispatch/dispatcher.test.ts
@@ -445,6 +445,30 @@ describe('dispatcher runtime', () => {
     expect(root.requestScopeDisposeCount).toBe(2);
   });
 
+  it('disposes a request scope exactly once when the handler throws', async () => {
+    @ScopeDecorator('request')
+    @Controller('/request-controller-error')
+    class FailingRequestController {
+      @Get('/')
+      fail() {
+        throw new Error('handler failed');
+      }
+    }
+
+    const root = new CountingContainer().register(FailingRequestController);
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: FailingRequestController }]),
+      rootContainer: root,
+    });
+    const response = createResponse();
+
+    await dispatcher.dispatch(createRequest('/request-controller-error', 'GET'), response);
+
+    expect(response.statusCode).toBe(500);
+    expect(root.requestScopeCreateCount).toBe(1);
+    expect(root.requestScopeDisposeCount).toBe(1);
+  });
+
   it('uses request scope for custom binders before they resolve request-scoped providers', async () => {
     let created = 0;
 
@@ -2135,7 +2159,7 @@ describe('dispatcher runtime', () => {
     const events: string[] = [];
     const observer = {
       onRequestError(_context: RequestObservationContext, error: unknown) {
-        events.push(error instanceof Error ? error.message : 'unknown');
+        events.push(`observer:${error instanceof Error ? error.message : 'unknown'}`);
       },
     };
 
@@ -2155,12 +2179,17 @@ describe('dispatcher runtime', () => {
       rootContainer: root,
     });
     const response = createStreamingResponse();
+    const close = response.stream.close.bind(response.stream);
+    response.stream.close = () => {
+      events.push('stream:close');
+      close();
+    };
 
     await dispatcher.dispatch(createRequest('/managed-error', 'GET'), response);
 
     expect(response.stream.writes).toEqual(['data: first\n\n']);
     expect(response.stream.closeCalls).toBe(1);
-    expect(events).toEqual(['source failed']);
+    expect(events).toEqual(['stream:close', 'observer:source failed']);
     expect(response.body).toBeUndefined();
   });
 

--- a/packages/http/src/middleware/rate-limit.test.ts
+++ b/packages/http/src/middleware/rate-limit.test.ts
@@ -169,6 +169,27 @@ describe('createRateLimitMiddleware', () => {
     expect(secondContext.response.statusCode).toBe(200);
   });
 
+  it('uses X-Real-IP client buckets when trustProxyHeaders is enabled', async () => {
+    const middleware = createRateLimitMiddleware({ limit: 1, trustProxyHeaders: true, windowMs: 1_000 });
+    const next = vi.fn(async () => {});
+    const firstContext = createContext({
+      headers: { 'x-real-ip': '198.51.100.10' },
+      raw: { socket: { remoteAddress: '10.0.0.1' } },
+    });
+    const secondContext = createContext({
+      headers: { 'x-real-ip': '198.51.100.11' },
+      raw: { socket: { remoteAddress: '10.0.0.1' } },
+    });
+
+    await middleware.handle(firstContext, next);
+    await middleware.handle(secondContext, next);
+    await middleware.handle(firstContext, next);
+
+    expect(next).toHaveBeenCalledTimes(2);
+    expect(firstContext.response.statusCode).toBe(429);
+    expect(secondContext.response.statusCode).toBe(200);
+  });
+
   it('normalizes ipv4 forwarded identities that include client ports when trustProxyHeaders is enabled', async () => {
     const middleware = createRateLimitMiddleware({ limit: 1, trustProxyHeaders: true, windowMs: 1_000 });
     const next = vi.fn(async () => {});


### PR DESCRIPTION
## Summary

Add executable regression coverage for documented `@fluojs/http` cleanup, managed SSE error ordering, and trusted-proxy rate-limit behavior in the runtime-http lane. Predecessor #2522 is merged, so these tests exercise the current managed SSE cleanup contract.

Linked context: Closes #2518

## Changes

- Verify a throwing request-scoped controller still creates and disposes exactly one request scope.
- Verify a managed SSE stream closes before request error observers run after a committed source failure.
- Verify `trustProxyHeaders: true` uses `X-Real-IP` to maintain distinct client rate-limit buckets.

## Testing

- `pnpm vitest run packages/http/src/dispatch/dispatcher.test.ts packages/http/src/middleware/rate-limit.test.ts` — 2 files, 98 tests passed.
- Changed-file LSP diagnostics — no diagnostics.
- `pnpm verify` — passed on the final run: 284 test files passed; 3995 tests passed and 1 skipped, after build, typecheck, and lint.
- The first full verification run exposed unrelated CLI timeout flakes; the affected timeout test passed in isolation, and the complete verification rerun passed.

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

Test-only contract preservation; no runtime, public API, package contents, documentation, or release metadata changes. No `.changeset/*.md` is required.

## Public export documentation

- [x] No public exports changed.
- [x] Source TSDoc and README examples are unaffected.

## Behavioral contract

- [x] No documented behavioral contracts were removed or changed.
- [x] Existing runtime invariants now have direct regression coverage.
- [x] Intentional limitations remain unchanged.

The tests preserve the documented request-scope disposal, managed SSE close-before-observer, and trusted proxy identity contracts without modifying runtime behavior.

## Platform consistency governance (SSOT)

- [x] No SSOT, platform contract, adapter, or localized documentation changed.
- [x] No companion governance or conformance updates are required for this package-local test-only change.
