### PR TITLE
Resolve #2583: Cover duplicate Notifications channel rejection

### DIFF
--- a/packages/notifications/src/module.test.ts
+++ b/packages/notifications/src/module.test.ts
@@ -5,7 +5,11 @@ import { FluoFactory } from '@fluojs/runtime';
 import { createTestingModule } from '@fluojs/testing';
 import { describe, expect, it } from 'vitest';
 
-import { NotificationChannelNotFoundError, NotificationQueueNotConfiguredError } from './errors.js';
+import {
+  NotificationChannelNotFoundError,
+  NotificationQueueNotConfiguredError,
+  NotificationsConfigurationError,
+} from './errors.js';
 import { NotificationsModule } from './module.js';
 import { NotificationsService } from './service.js';
 import { NOTIFICATION_CHANNELS, NOTIFICATIONS } from './tokens.js';
@@ -435,6 +439,27 @@ describe('NotificationsModule', () => {
         recipients: ['user@example.com'],
       },
     ]);
+  });
+
+  it('rejects duplicate static channel registrations before creating a provider graph', () => {
+    const duplicateEmailChannels: readonly NotificationChannel[] = [
+      {
+        channel: 'email',
+        async send() {
+          return { externalId: 'first-email-provider' };
+        },
+      },
+      {
+        channel: 'email',
+        async send() {
+          return { externalId: 'second-email-provider' };
+        },
+      },
+    ];
+
+    expect(() => NotificationsModule.forRoot({ channels: duplicateEmailChannels })).toThrowError(
+      new NotificationsConfigurationError('Duplicate notification channel registration detected for "email".'),
+    );
   });
 
   it('supports documented class-level service injection for application services', async () => {
@@ -1101,6 +1126,44 @@ describe('NotificationsModule', () => {
       'notification.dispatch.requested',
       'notification.dispatch.delivered',
     ]);
+  });
+
+  it('rejects duplicate async channel registrations before creating dependent providers', async () => {
+    let dependentProviderConstructions = 0;
+
+    @Inject(NotificationsService)
+    class NotificationsDependentProvider {
+      constructor(readonly notifications: NotificationsService) {
+        dependentProviderConstructions += 1;
+      }
+    }
+
+    const container = new Container();
+    const moduleType = NotificationsModule.forRootAsync({
+      useFactory: async () => ({
+        channels: [
+          {
+            channel: 'email',
+            async send() {
+              return { externalId: 'first-email-provider' };
+            },
+          },
+          {
+            channel: 'email',
+            async send() {
+              return { externalId: 'second-email-provider' };
+            },
+          },
+        ],
+      }),
+    });
+
+    container.register(...moduleProviders(moduleType), NotificationsDependentProvider);
+
+    await expect(container.resolve(NotificationsDependentProvider)).rejects.toThrowError(
+      new NotificationsConfigurationError('Duplicate notification channel registration detected for "email".'),
+    );
+    expect(dependentProviderConstructions).toBe(0);
   });
 
   it('exposes configured service status diagnostics under details only', async () => {


### PR DESCRIPTION
## Summary

Add regression coverage for the existing duplicate notification channel rejection contract in both static and async module registration.

Linked context: Closes #2583

## Changes

- Verify `NotificationsModule.forRoot(...)` throws `NotificationsConfigurationError` for duplicate channel names before returning a module/provider graph.
- Verify `NotificationsModule.forRootAsync(...)` fails with the same deterministic error before constructing a dependent provider.

## Testing

- `pnpm --filter @fluojs/notifications test` — passed (55 tests).
- `pnpm --filter @fluojs/notifications typecheck` — passed after the workspace build.
- `pnpm exec biome check packages/notifications/src/module.test.ts` — passed.
- LSP diagnostics for `packages/notifications/src/module.test.ts` — no diagnostics.
- `pnpm verify` — build, typecheck, and lint passed; the repository-wide parallel test phase remained non-green because unrelated `packages/platform-express/src/adapter.test.ts` and `packages/cli/src/new/scaffold.test.ts` cases timed out under full-suite load. The previously timed-out CLI cache test passed when run alone.

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

Test-only coverage of an existing behavior; no package output, runtime behavior, API surface, or release metadata changes.

## Public export documentation

- [x] No public exports changed. Source TSDoc and README examples are unaffected.

## Behavioral contract

- [x] No documented behavioral contracts were removed.
- [x] Existing duplicate channel rejection is now covered for static and async registration.
- [x] Runtime invariants are covered by regression tests.

README/docs updates are not required because this PR preserves already-implemented behavior and changes tests only.

## Platform consistency governance (SSOT)

- [x] No platform contract or governance docs changed.
- [x] EN/KR documentation mirrors are unaffected.
- [x] No platform conformance claim or harness change is introduced.