### PR TITLE
Resolve #2552: Add Discord renderer setup examples

### DIFF
--- a/book/intermediate/ch17-slack-discord.ko.md
+++ b/book/intermediate/ch17-slack-discord.ko.md
@@ -12,7 +12,7 @@
 - `@fluojs/notifications`에 채팅 채널을 연결하는 방식을 구현합니다.
 - Block Kit과 Embed로 구조화된 메시지를 구성합니다.
 - transport가 readiness check를 노출할 때 Slack bootstrap 검증을 설정합니다.
-- Slack notification template을 렌더링하고 payload와 rendered 결과의 merge precedence를 판단합니다.
+- Slack과 Discord notification template을 렌더링하고 payload와 rendered 결과의 merge precedence를 판단합니다.
 - 재시도 정책과 상태 스냅샷을 기준으로 채팅 연동을 운영합니다.
 
 ## Prerequisites
@@ -236,6 +236,50 @@ await this.notifications.dispatch({
 ```
 
 `sendNotification(...)`은 `notification.template`과 `renderer`가 모두 있을 때에만 renderer를 호출합니다. 명시적인 payload 필드는 `attachments`, `blocks`에서 rendered 필드보다 우선하고, 비공백 payload text는 rendered text보다 우선합니다. 빈 문자열 또는 공백 전용 text는 미지정으로 취급하므로 text는 비공백 rendered text, 그리고 비공백 `subject` 순서로 fallback합니다. Metadata는 payload metadata, dispatch metadata, subject marker, template marker 순서로 merge되므로 최종 Slack 메시지는 운영 routing context를 보존합니다.
+
+### Discord Template Rendering
+Discord도 자체 public `DiscordTemplateRenderer` 계약을 사용해 같은 registration pattern을 따릅니다. Renderer는 `content`, `embeds`, `components`를 반환할 수 있고, webhook transport는 계속 `DiscordModule.forRoot(...)`에 명시적으로 설정합니다.
+
+```typescript
+import type { DiscordTemplateRenderer } from '@fluojs/discord';
+
+const discordRenderer: DiscordTemplateRenderer = {
+  render(input) {
+    return {
+      content: `Order ${String(input.payload.orderId)} was received.`,
+      embeds: [
+        {
+          description: input.subject,
+          title: 'New order',
+        },
+      ],
+    };
+  },
+};
+
+DiscordModule.forRoot({
+  defaultThreadId: 'community-orders',
+  renderer: discordRenderer,
+  transport: createDiscordWebhookTransport({
+    fetch: runtime.fetch,
+    webhookUrl: config.discordWebhookUrl,
+  }),
+});
+
+await this.notifications.dispatch({
+  channel: 'discord',
+  locale: 'en',
+  metadata: { source: 'orders' },
+  payload: {
+    content: 'Order #123 is ready for review.',
+    orderId: '123',
+  },
+  subject: 'New order received',
+  template: 'orders.received',
+});
+```
+
+Discord rendering은 `template`과 `renderer`가 모두 있을 때만 실행됩니다. Renderer는 `{ template, payload, subject, locale, metadata, signal }`을 받습니다. 명시적인 `payload.content`, `payload.embeds`, `payload.components` 값은 rendered 값보다 우선합니다. `payload.content`가 `undefined`이면 rendered content, `subject` 순서로 fallback합니다. 이 예제에서는 dispatch한 `content`가 renderer의 content를 override하고, rendered embed는 유지됩니다.
 
 ## 17.5 Rich Formatting: Blocks and Embeds
 

--- a/book/intermediate/ch17-slack-discord.md
+++ b/book/intermediate/ch17-slack-discord.md
@@ -12,7 +12,7 @@ This chapter covers how to extend FluoShop's notification system into team commu
 - Implement chat channel connections through `@fluojs/notifications`.
 - Build structured messages with Block Kit and Embed.
 - Configure Slack bootstrap verification when a transport exposes a readiness check.
-- Render Slack notification templates and reason about payload-versus-rendered merge precedence.
+- Render Slack and Discord notification templates and reason about payload-versus-rendered merge precedence.
 - Operate chat integrations around retry policies and status snapshots.
 
 ## Prerequisites
@@ -236,6 +236,50 @@ await this.notifications.dispatch({
 ```
 
 `sendNotification(...)` only calls the renderer when both `notification.template` and `renderer` are present. Explicit payload fields win over rendered fields for `attachments` and `blocks`, while non-blank payload text wins over rendered text; empty or whitespace-only text is treated as unspecified, so text falls back to non-blank rendered text and then to a non-blank `subject`. Metadata is merged from payload metadata, dispatch metadata, a subject marker, and a template marker in that order, so the final Slack message preserves the operational routing context.
+
+### Discord Template Rendering
+Discord uses the same registration pattern with its own public `DiscordTemplateRenderer` contract. A renderer can return `content`, `embeds`, or `components`, while the webhook transport remains explicit in `DiscordModule.forRoot(...)`.
+
+```typescript
+import type { DiscordTemplateRenderer } from '@fluojs/discord';
+
+const discordRenderer: DiscordTemplateRenderer = {
+  render(input) {
+    return {
+      content: `Order ${String(input.payload.orderId)} was received.`,
+      embeds: [
+        {
+          description: input.subject,
+          title: 'New order',
+        },
+      ],
+    };
+  },
+};
+
+DiscordModule.forRoot({
+  defaultThreadId: 'community-orders',
+  renderer: discordRenderer,
+  transport: createDiscordWebhookTransport({
+    fetch: runtime.fetch,
+    webhookUrl: config.discordWebhookUrl,
+  }),
+});
+
+await this.notifications.dispatch({
+  channel: 'discord',
+  locale: 'en',
+  metadata: { source: 'orders' },
+  payload: {
+    content: 'Order #123 is ready for review.',
+    orderId: '123',
+  },
+  subject: 'New order received',
+  template: 'orders.received',
+});
+```
+
+Discord rendering runs only when both `template` and `renderer` are present. The renderer receives `{ template, payload, subject, locale, metadata, signal }`. Explicit `payload.content`, `payload.embeds`, and `payload.components` values take precedence over rendered values; if `payload.content` is `undefined`, content falls back to rendered content and then to `subject`. In this example the dispatched `content` overrides the renderer's content, while the rendered embed is preserved.
 
 ## 17.5 Rich Formatting: Blocks and Embeds
 

--- a/packages/discord/README.ko.md
+++ b/packages/discord/README.ko.md
@@ -16,6 +16,7 @@ fluo를 위한 webhook-first, transport-agnostic Discord 전달 코어 패키지
   - [`DiscordService`를 이용한 standalone 전달](#discordservice를-이용한-standalone-전달)
   - [`verifyOnModuleInit` bootstrap verification](#verifyonmoduleinit-bootstrap-verification)
   - [`@fluojs/notifications`와의 통합](#fluojs-notifications와의-통합)
+  - [payload override를 사용하는 template rendering](#payload-override를-사용하는-template-rendering)
   - [명시적 fetch 주입을 사용하는 webhook-first 전달](#명시적-fetch-주입을-사용하는-webhook-first-전달)
   - [의도적인 제한 사항](#의도적인-제한-사항)
 - [공개 API 개요](#공개-api-개요)
@@ -180,6 +181,50 @@ Behavioral contract 메모:
 - notification metadata는 payload metadata, dispatch metadata, template/subject marker를 합쳐 구성됩니다. 중복 key에서는 dispatch metadata가 payload metadata를 덮어쓰고, 최종 `subject` / `template` marker가 둘 모두를 덮어씁니다. `template`은 renderer가 구성된 경우에만 렌더링됩니다.
 - Template rendering은 서비스가 ready일 때만 시작합니다. Render input에는 `signal`이 포함되므로 renderer는 transport delivery 전에 caller-cancelled 작업을 중단할 수 있습니다.
 - 여러 Discord thread로 fan-out이 필요한 notification workflow라면 thread별 concrete Discord message를 만들어 `DiscordService.sendMany(...)`로 보내거나 별도 notification dispatch를 실행해야 합니다. 하나의 notification dispatch는 multi-recipient fan-out을 암묵적으로 확장하지 않습니다.
+
+### payload override를 사용하는 template rendering
+
+Notification template에서 재사용 가능한 Discord content, embed, component를 생성하려면 `DiscordTemplateRenderer`를 등록합니다. 같은 module registration에 transport를 설정하고 `@fluojs/notifications`를 통해 `template` key를 dispatch하세요.
+
+```typescript
+import type { DiscordTemplateRenderer } from '@fluojs/discord';
+
+const renderer: DiscordTemplateRenderer = {
+  render(input) {
+    return {
+      content: `Order ${String(input.payload.orderId)} was received.`,
+      embeds: [
+        {
+          description: input.subject,
+          title: 'New order',
+        },
+      ],
+    };
+  },
+};
+
+DiscordModule.forRoot({
+  renderer,
+  transport: createDiscordWebhookTransport({
+    fetch: runtime.fetch,
+    webhookUrl: config.discordWebhookUrl,
+  }),
+});
+
+await notifications.dispatch({
+  channel: 'discord',
+  locale: 'en',
+  metadata: { source: 'orders' },
+  payload: {
+    content: 'Order #123 is ready for review.',
+    orderId: '123',
+  },
+  subject: 'New order received',
+  template: 'orders.received',
+});
+```
+
+`DiscordService.sendNotification(...)`은 `template`과 `renderer`가 모두 있을 때만 renderer를 호출합니다. Renderer는 `{ template, payload, subject, locale, metadata, signal }`을 받습니다. 명시적인 `payload.content`, `payload.embeds`, `payload.components` 값은 대응하는 rendered 값보다 우선합니다. `payload.content`가 `undefined`이면 rendered content, `subject` 순서로 fallback합니다. 따라서 renderer나 transport 설정을 교체하지 않고도 호출자가 template 결과의 일부를 override할 수 있습니다.
 
 ### 명시적 fetch 주입을 사용하는 webhook-first 전달
 

--- a/packages/discord/README.md
+++ b/packages/discord/README.md
@@ -16,6 +16,7 @@ Migration boundary: the module API is intentionally Nest-like but not a NestJS d
   - [Standalone delivery with `DiscordService`](#standalone-delivery-with-discordservice)
   - [Bootstrap verification with `verifyOnModuleInit`](#bootstrap-verification-with-verifyonmoduleinit)
   - [Integration with `@fluojs/notifications`](#integration-with-fluojs-notifications)
+  - [Template rendering with payload overrides](#template-rendering-with-payload-overrides)
   - [Webhook-first delivery with explicit fetch injection](#webhook-first-delivery-with-explicit-fetch-injection)
   - [Intentional limitations](#intentional-limitations)
 - [Public API Overview](#public-api-overview)
@@ -180,6 +181,50 @@ Behavioral contract notes:
 - Notification metadata is merged from payload metadata, dispatch metadata, and template/subject markers. On duplicate keys, dispatch metadata overrides payload metadata, and final `subject` / `template` markers override both. `template` is rendered only when a renderer is configured.
 - Template rendering starts only while the service is ready. The render input includes `signal`, so renderers can stop caller-cancelled work before transport delivery.
 - If a notification workflow needs fan-out across multiple Discord threads, create one concrete Discord message per thread with `DiscordService.sendMany(...)` or issue separate notification dispatches; a single notification dispatch never expands multi-recipient fan-out implicitly.
+
+### Template rendering with payload overrides
+
+Register a `DiscordTemplateRenderer` when notification templates should produce reusable Discord content, embeds, or components. Keep transport setup in the same module registration and dispatch a `template` key through `@fluojs/notifications`.
+
+```typescript
+import type { DiscordTemplateRenderer } from '@fluojs/discord';
+
+const renderer: DiscordTemplateRenderer = {
+  render(input) {
+    return {
+      content: `Order ${String(input.payload.orderId)} was received.`,
+      embeds: [
+        {
+          description: input.subject,
+          title: 'New order',
+        },
+      ],
+    };
+  },
+};
+
+DiscordModule.forRoot({
+  renderer,
+  transport: createDiscordWebhookTransport({
+    fetch: runtime.fetch,
+    webhookUrl: config.discordWebhookUrl,
+  }),
+});
+
+await notifications.dispatch({
+  channel: 'discord',
+  locale: 'en',
+  metadata: { source: 'orders' },
+  payload: {
+    content: 'Order #123 is ready for review.',
+    orderId: '123',
+  },
+  subject: 'New order received',
+  template: 'orders.received',
+});
+```
+
+`DiscordService.sendNotification(...)` calls the renderer only when both `template` and `renderer` are present. The renderer receives `{ template, payload, subject, locale, metadata, signal }`. Explicit `payload.content`, `payload.embeds`, and `payload.components` values take precedence over the corresponding rendered values; when `payload.content` is `undefined`, content falls back to rendered content and then to `subject`. This lets callers override one template result without replacing the renderer or transport configuration.
 
 ### Webhook-first delivery with explicit fetch injection
 


### PR DESCRIPTION
## Summary

Document the existing DiscordTemplateRenderer setup and payload-over-rendered precedence in the package README and the intermediate Slack/Discord chapter.

Linked context: https://github.com/fluojs/fluo/issues/2552

Closes #2552

## Changes

- Add EN/KO @fluojs/discord README examples for renderer registration, explicit transport setup, and templated notification dispatch.
- Add matching EN/KO book examples alongside the existing Slack renderer guidance.
- Explain that payload content, embeds, and components override rendered values, with content fallback to rendered content and then subject.

## Testing

- pnpm docs:sync-check
- pnpm verify:platform-consistency-governance
- git diff --check

All checks passed.

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

Docs-only clarification of existing public types and runtime behavior; no changeset is required.

## Public export documentation

- [x] No public exports changed.
- [x] README scenario examples use the existing DiscordTemplateRenderer and DiscordModule public surface.

## Behavioral contract

- [x] No documented behavioral contracts were removed.
- [x] The new examples describe the existing renderer invocation and payload precedence implemented by DiscordService.sendNotification(...).
- [x] Runtime source and tests were not changed because this PR is documentation-only.

## Platform consistency governance (SSOT)

- [x] EN/KO README and book mirrors were updated together.
- [x] pnpm docs:sync-check passed.
- [x] pnpm verify:platform-consistency-governance passed.
- [x] No platform contract or conformance claim changed.

## Risks

Low. The examples intentionally stay within the current public Discord renderer, module, transport, and notifications contracts.