### PR TITLE
Resolve #2546: Cover config watcher failure paths

### DIFF
--- a/packages/config/src/load.test.ts
+++ b/packages/config/src/load.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { existsSync, mkdtempSync, readFileSync, watch, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, renameSync, watch, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { basename, dirname, join } from 'node:path';
 import { getModuleMetadata } from '@fluojs/core/internal';
@@ -932,6 +932,7 @@ describe('loadConfig', () => {
   it('watches the parent directory when the env file exists so atomic replacements trigger reloads', async () => {
     const cwd = mkdtempSync(join(tmpdir(), 'fluo-config-watch-existing-parent-'));
     const envPath = join(cwd, '.env.dev');
+    const replacementPath = join(cwd, '.env.dev.next');
 
     writeFileSync(envPath, 'PORT=4000\n');
 
@@ -957,7 +958,8 @@ describe('loadConfig', () => {
         }
       });
 
-      writeFileSync(envPath, 'PORT=4100\n');
+      writeFileSync(replacementPath, 'PORT=4100\n');
+      renameSync(replacementPath, envPath);
       emitWatchChange();
 
       await waitForCondition(() => updates.includes('4100'));
@@ -1063,7 +1065,7 @@ describe('loadConfig', () => {
     }
   });
 
-  it('drops queued reentrant reloads when the active notification rolls back', () => {
+  it('restores the previous snapshot, reports the error, and drops queued reloads when a watch listener fails', () => {
     const cwd = mkdtempSync(join(tmpdir(), 'fluo-config-reload-serialized-rollback-'));
     const envPath = join(cwd, '.env.dev');
 
@@ -1073,22 +1075,33 @@ describe('loadConfig', () => {
       cwd,
       envFile: envPath,
       processEnv: {},
+      watch: true,
     });
 
     try {
-      reloader.subscribe((_snapshot, reason) => {
-        if (reason !== 'manual') {
+      const errors: string[] = [];
+      const updates: string[] = [];
+
+      reloader.subscribe((snapshot, reason) => {
+        if (reason !== 'watch') {
           return;
         }
 
+        updates.push(`${reason}:${String(snapshot['PORT'])}`);
         writeFileSync(envPath, 'PORT=4300\n');
         reloader.reload();
         throw new Error('listener failed after nested reload');
       });
+      reloader.subscribeError((error, reason) => {
+        const message = error instanceof Error ? error.message : String(error);
+        errors.push(`${reason}:${message}`);
+      });
 
       writeFileSync(envPath, 'PORT=4100\n');
+      emitWatchChange();
 
-      expect(() => reloader.reload()).toThrow('listener failed after nested reload');
+      expect(errors).toEqual(['watch:listener failed after nested reload']);
+      expect(updates).toEqual(['watch:4100']);
       expect(reloader.current()['PORT']).toBe('4000');
     } finally {
       reloader.close();


### PR DESCRIPTION
## Summary

Strengthen `@fluojs/config` regression coverage for the documented watcher atomic-replacement and listener-failure rollback contracts.

Linked context: Closes #2546

## Changes

- Replace the existing direct env-file overwrite with a real temporary-file `renameSync(...)` replacement before emitting the watch event.
- Exercise a watch listener that queues a nested manual reload and then fails.
- Assert the previous snapshot is restored, the queued reload is discarded, and the watch failure is reported with the correct reason.

## Testing

- `pnpm --filter @fluojs/config test -- load.test.ts` — 8 files passed, 80 tests passed.
- `pnpm --filter @fluojs/config typecheck` — passed after workspace build artifacts were available.
- `pnpm verify` — passed; 290 test files passed, 4020 tests passed, 1 skipped.
- LSP diagnostics for `packages/config/src/load.test.ts` — no diagnostics.

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

Test-only coverage of an existing documented contract; no package behavior, API surface, package contents, or release metadata changes. No changeset is required.

## Public export documentation

- [x] Not applicable: no public exports or source-level API documentation changed.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] No new behavioral contracts were introduced; this locks the existing `packages/config/README.md` watcher serialization and rollback contract.
- [x] Intentional limitations remain unchanged.
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] No governance docs or English/Korean mirrors changed.
- [x] No platform contract or conformance claim changed.
- [x] Existing package README claims are backed by the strengthened package-level tests.