### PR TITLE
Resolve #2513: Harden Mongoose transaction lifecycle and facade contracts

### DIFF
--- a/.changeset/mongoose-callback-facade-contracts.md
+++ b/.changeset/mongoose-callback-facade-contracts.md
@@ -2,4 +2,4 @@
 "@fluojs/mongoose": patch
 ---
 
-Keep aborted request callbacks tracked through session and connection cleanup, preserve positional `create()` documents with option-like fields, and expose callable model facade method types.
+Keep aborted request callbacks tracked through session and connection cleanup, forward positional `create()` documents without appending session options, and expose consumer-specializable model facade result types.

--- a/.changeset/mongoose-callback-facade-contracts.md
+++ b/.changeset/mongoose-callback-facade-contracts.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/mongoose": patch
+---
+
+Keep aborted request callbacks tracked through session and connection cleanup, preserve positional `create()` documents with option-like fields, and expose callable model facade method types.

--- a/book/intermediate/ch19-mongoose.ko.md
+++ b/book/intermediate/ch19-mongoose.ko.md
@@ -66,8 +66,18 @@ export class PersistenceModule {}
 Fluo에서는 일반적으로 리포지토리를 통해 MongoDB와 상호작용합니다. 전역 `mongoose` 객체에 의존하지 않고 `MongooseConnection` 서비스를 주입받아 현재 연결과 세션 경계를 따릅니다.
 
 ```typescript
-import { MongooseConnection } from '@fluojs/mongoose';
+import { MongooseConnection, type MongooseModelFacade } from '@fluojs/mongoose';
 import { Inject } from '@fluojs/core';
+
+type ProductDocument = { readonly _id: string; readonly name: string; readonly price: number };
+type ProductLookupModel = MongooseModelFacade<unknown, unknown, Promise<ProductDocument | null>>;
+type InventoryWriteModel = MongooseModelFacade<
+  unknown,
+  unknown,
+  unknown,
+  unknown,
+  Promise<{ readonly acknowledged: boolean }>
+>;
 
 @Inject(MongooseConnection)
 export class ProductRepository {
@@ -75,13 +85,13 @@ export class ProductRepository {
 
   async findOneById(id: string) {
     // 기본 흐름: 지원되는 facade 메서드를 사용합니다.
-    const Product = this.conn.model('Product');
+    const Product = this.conn.model<ProductLookupModel>('Product');
     return Product.findOne({ _id: id });
   }
 }
 ```
 
-`MongooseConnection` 서비스는 컨텍스트 인지 프록시 역할을 합니다. `this.conn.model('Product')`를 호출하면 export된 `MongooseModelFacade` 반환 타입이 지원 메서드를 callable하게 유지하며, 활성 트랜잭션이 있을 때 자동으로 그 트랜잭션에 참여하는 버전의 모델을 반환합니다.
+`MongooseConnection` 서비스는 컨텍스트 인지 프록시 역할을 합니다. `this.conn.model<ProductLookupModel>('Product')`를 호출하면 export된 generic `MongooseModelFacade`가 지원 메서드를 consumer-defined result type으로 callable하게 유지하며, 활성 트랜잭션이 있을 때 자동으로 그 트랜잭션에 참여하는 버전의 모델을 반환합니다.
 
 ### 앰비언트 세션 지원 (v1)
 버전 1에서 fluo의 Mongoose 통합은 다음 모델 메서드에 대해 자동 세션 주입을 지원합니다:
@@ -91,7 +101,7 @@ export class ProductRepository {
 - `aggregate`
 - `bulkWrite`
 
-`MongooseConnection.model(...)`을 통해 `@Transaction()`, `transaction()`, `requestTransaction()` 경계 내부에서 이 메서드들이 호출되면, fluo는 앰비언트 세션을 옵션에 자동으로 붙여줍니다. `create(...)`의 operation options는 array overload인 `create([docs], options)`에서만 인식되므로 option-like field를 가진 positional document도 문서로 유지됩니다. `conn.current().model(...)`이 반환한 raw model은 wrapper가 아니며, `doc.save()`도 현재 자동 세션 주입이 지원되지 않습니다. 두 경로 모두 트랜잭션 안에서 사용할 때는 수동으로 세션을 전달해야 합니다.
+`MongooseConnection.model(...)`을 통해 `@Transaction()`, `transaction()`, `requestTransaction()` 경계 내부에서 이 메서드들이 호출되면, fluo는 앰비언트 세션을 옵션에 자동으로 붙여줍니다. `create(...)`의 session 주입은 array overload인 `create([docs], options?)`에서만 사용할 수 있습니다. Positional `create(docA, docB)` 호출은 변경 없이 전달되며 자동 session을 받지 않습니다. `conn.current().model(...)`이 반환한 raw model은 wrapper가 아니며, `doc.save()`도 현재 자동 세션 주입이 지원되지 않습니다. 두 경로 모두 트랜잭션 안에서 사용할 때는 수동으로 세션을 전달해야 합니다.
 
 트랜잭션이 활성화된 상태에서 옵션에 `session`을 명시적으로 제공했는데, 해당 세션이 앰비언트 트랜잭션 세션과 일치하지 않는 경우 fluo는 충돌 에러를 던집니다. 이는 의도치 않은 트랜잭션 간 데이터 유출을 방지하기 위함입니다.
 
@@ -109,8 +119,8 @@ fluo에서 권장되는 트랜잭션 처리 방식은 서비스 메서드에 `@T
 
 ```typescript
 await this.conn.transaction(async () => {
-  const Product = this.conn.model('Product');
-  const Inventory = this.conn.model('Inventory');
+  const Product = this.conn.model<ProductLookupModel>('Product');
+  const Inventory = this.conn.model<InventoryWriteModel>('Inventory');
 
   // 지원되는 facade 호출에는 세션이 자동으로 주입됩니다.
   const product = await Product.findOne({ _id: pid });
@@ -130,7 +140,7 @@ FluoShop에서는 제품 유형에 따라 속성이 크게 달라질 수 있는 
 
 ```typescript
 const productSchema = new mongoose.Schema({ name: String, price: Number }, { discriminatorKey: 'type' });
-const Product = conn.model('Product', productSchema);
+const Product = conn.current().model('Product', productSchema);
 
 const Electronics = Product.discriminator('Electronics', new mongoose.Schema({ warranty: Number }));
 const Apparel = Product.discriminator('Apparel', new mongoose.Schema({ size: String, material: String }));

--- a/book/intermediate/ch19-mongoose.ko.md
+++ b/book/intermediate/ch19-mongoose.ko.md
@@ -22,7 +22,7 @@
 
 Mongoose는 Node.js 생태계에서 MongoDB를 다룰 때 널리 쓰이는 모델링 계층입니다. Root `@fluojs/mongoose` 통합은 ambient transaction context에 Node.js `node:async_hooks`를 사용하며 Node.js 20 이상을 지원합니다. fluo 전용 통합 패키지를 사용하면 다음과 같은 이점을 얻을 수 있습니다.
 
-- **수명 주기 관리**: 제공된 연결을 애플리케이션 라이프사이클에 등록하고, `dispose(connection)`을 제공한 경우 종료 중 요청 단위 트랜잭션이 drain된 뒤에만 정리를 실행합니다.
+- **수명 주기 관리**: 제공된 연결을 애플리케이션 라이프사이클에 등록하고, `dispose(connection)`을 제공한 경우 종료 중 시작된 request callback과 요청 단위 트랜잭션이 drain된 뒤에만 정리를 실행합니다.
 - **세션 인지(Session Awareness)**: `MongooseConnection` 서비스가 콜 스택 전체에서 MongoDB 세션을 추적합니다.
 - **앰비언트 세션 (v1)**: fluo는 지원되는 Mongoose 모델 작업(create, find, findOne, aggregate, bulkWrite)에 활성 트랜잭션 세션을 자동으로 연결합니다.
 - **애플리케이션 소유 연결**: fluo는 애플리케이션이 제공한 concrete Mongoose connection을 관측합니다. `dispose(connection)`을 제공하지 않는 한 연결을 생성하거나, model을 compile하거나, 닫지 않습니다.
@@ -81,7 +81,7 @@ export class ProductRepository {
 }
 ```
 
-`MongooseConnection` 서비스는 컨텍스트 인지 프록시 역할을 합니다. `this.conn.model('Product')`를 호출하면, 활성 트랜잭션이 있을 때 자동으로 그 트랜잭션에 참여하는 버전의 모델을 반환합니다.
+`MongooseConnection` 서비스는 컨텍스트 인지 프록시 역할을 합니다. `this.conn.model('Product')`를 호출하면 export된 `MongooseModelFacade` 반환 타입이 지원 메서드를 callable하게 유지하며, 활성 트랜잭션이 있을 때 자동으로 그 트랜잭션에 참여하는 버전의 모델을 반환합니다.
 
 ### 앰비언트 세션 지원 (v1)
 버전 1에서 fluo의 Mongoose 통합은 다음 모델 메서드에 대해 자동 세션 주입을 지원합니다:
@@ -91,7 +91,7 @@ export class ProductRepository {
 - `aggregate`
 - `bulkWrite`
 
-`MongooseConnection.model(...)`을 통해 `@Transaction()`, `transaction()`, `requestTransaction()` 경계 내부에서 이 메서드들이 호출되면, fluo는 앰비언트 세션을 옵션에 자동으로 붙여줍니다. `conn.current().model(...)`이 반환한 raw model은 wrapper가 아니며, `doc.save()`도 현재 자동 세션 주입이 지원되지 않습니다. 두 경로 모두 트랜잭션 안에서 사용할 때는 수동으로 세션을 전달해야 합니다.
+`MongooseConnection.model(...)`을 통해 `@Transaction()`, `transaction()`, `requestTransaction()` 경계 내부에서 이 메서드들이 호출되면, fluo는 앰비언트 세션을 옵션에 자동으로 붙여줍니다. `create(...)`의 operation options는 array overload인 `create([docs], options)`에서만 인식되므로 option-like field를 가진 positional document도 문서로 유지됩니다. `conn.current().model(...)`이 반환한 raw model은 wrapper가 아니며, `doc.save()`도 현재 자동 세션 주입이 지원되지 않습니다. 두 경로 모두 트랜잭션 안에서 사용할 때는 수동으로 세션을 전달해야 합니다.
 
 트랜잭션이 활성화된 상태에서 옵션에 `session`을 명시적으로 제공했는데, 해당 세션이 앰비언트 트랜잭션 세션과 일치하지 않는 경우 fluo는 충돌 에러를 던집니다. 이는 의도치 않은 트랜잭션 간 데이터 유출을 방지하기 위함입니다.
 
@@ -100,7 +100,7 @@ export class ProductRepository {
 
 MongoDB 트랜잭션은 활성화된 **세션(Session)**을 필요로 합니다. Fluo는 세션 생성, 실행, 정리를 하나의 트랜잭션 래퍼로 묶어 호출부의 부담을 줄입니다.
 
-제공된 Mongoose connection이 `connection.transaction(...)`을 노출하면 fluo는 Mongoose 자체 ambient-session scope와 cleanup semantics가 유지되도록 트랜잭션 경계를 해당 API에 위임합니다. 그렇지 않으면 `startSession()`, `startTransaction()`, `commitTransaction()` / `abortTransaction()`, `endSession()`을 직접 사용합니다. connection에 `connection.transaction(...)`과 `startSession()`이 모두 없고 `strictTransactions`가 `false`이면 fluo는 rollback 원자성 없이 callback을 직접 실행하는 fail-open mode로 동작합니다. 이 모드는 local fake나 staged migration에만 사용하세요. MongoDB transaction 보장이 필요한 production 경로에서는 `strictTransactions: true`를 설정해 지원 누락이 readiness와 transaction helper 실패로 드러나게 하세요. 요청 단위 트랜잭션은 session acquisition과 delegated transaction startup 중 request `AbortSignal`을 관찰하므로, 취소된 request는 repository work가 실행되기 전에 멈출 수 있습니다. 실제 transaction mode에서는 application shutdown 중 active request transaction과 session cleanup이 settled될 때까지 `dispose(connection)` 실행을 기다리며, shutdown이 시작된 뒤에는 새로운 수동 또는 요청 단위 transaction boundary가 거부됩니다.
+제공된 Mongoose connection이 `connection.transaction(...)`을 노출하면 fluo는 Mongoose 자체 ambient-session scope와 cleanup semantics가 유지되도록 트랜잭션 경계를 해당 API에 위임합니다. 그렇지 않으면 `startSession()`, `startTransaction()`, `commitTransaction()` / `abortTransaction()`, `endSession()`을 직접 사용합니다. connection에 `connection.transaction(...)`과 `startSession()`이 모두 없고 `strictTransactions`가 `false`이면 fluo는 rollback 원자성 없이 callback을 직접 실행하는 fail-open mode로 동작합니다. 이 모드는 local fake나 staged migration에만 사용하세요. MongoDB transaction 보장이 필요한 production 경로에서는 `strictTransactions: true`를 설정해 지원 누락이 readiness와 transaction helper 실패로 드러나게 하세요. 요청 단위 트랜잭션은 session acquisition과 delegated transaction startup 중 request `AbortSignal`을 관찰하므로, 취소된 request는 repository work가 실행되기 전에 멈출 수 있습니다. Callback work가 시작된 뒤 cancellation이 발생하면 fluo는 abort 결과를 보존하되 transaction cleanup과 connection disposal 전에 원본 callback이 settle될 때까지 기다립니다. 실제 transaction mode에서는 application shutdown 중 active request transaction과 session cleanup이 settled될 때까지 `dispose(connection)` 실행을 기다리며, shutdown이 시작된 뒤에는 새로운 수동 또는 요청 단위 transaction boundary가 거부됩니다.
 
 `@Transaction()`, `transaction(...)`, `requestTransaction(...)` 경계 안에서 `conn.model(...)`은 `create`, `find`, `findOne`, `aggregate`, `bulkWrite`에 ambient session을 자동으로 바인딩하는 facade를 반환합니다. 지원되지 않는 model 메서드와 `doc.save()`에는 여전히 `conn.currentSession()`을 명시적으로 전달해야 합니다. 기존 수동 `transaction(...)` 안에서 열린 중첩 `requestTransaction(...)`은 ambient session을 재사용하고 활성 request boundary로 추적되며, 종료 중에는 abort되어 바깥 수동 transaction이 connection disposal 전에 rollback할 수 있습니다.
 

--- a/book/intermediate/ch19-mongoose.md
+++ b/book/intermediate/ch19-mongoose.md
@@ -66,8 +66,18 @@ export class PersistenceModule {}
 In Fluo, you usually interact with MongoDB through repositories. Instead of depending on the global `mongoose` object, inject the `MongooseConnection` service so the code follows the current connection and session boundary.
 
 ```typescript
-import { MongooseConnection } from '@fluojs/mongoose';
+import { MongooseConnection, type MongooseModelFacade } from '@fluojs/mongoose';
 import { Inject } from '@fluojs/core';
+
+type ProductDocument = { readonly _id: string; readonly name: string; readonly price: number };
+type ProductLookupModel = MongooseModelFacade<unknown, unknown, Promise<ProductDocument | null>>;
+type InventoryWriteModel = MongooseModelFacade<
+  unknown,
+  unknown,
+  unknown,
+  unknown,
+  Promise<{ readonly acknowledged: boolean }>
+>;
 
 @Inject(MongooseConnection)
 export class ProductRepository {
@@ -75,13 +85,13 @@ export class ProductRepository {
 
   async findOneById(id: string) {
     // Primary flow: use a supported facade method.
-    const Product = this.conn.model('Product');
+    const Product = this.conn.model<ProductLookupModel>('Product');
     return Product.findOne({ _id: id });
   }
 }
 ```
 
-The `MongooseConnection` service acts as a context-aware proxy. When you call `this.conn.model('Product')`, its exported `MongooseModelFacade` return type keeps the supported methods callable and returns a version of the model that automatically participates in the ambient transaction if one is active.
+The `MongooseConnection` service acts as a context-aware proxy. When you call `this.conn.model<ProductLookupModel>('Product')`, the exported generic `MongooseModelFacade` keeps the supported methods callable with consumer-defined result types and returns a version of the model that automatically participates in the ambient transaction if one is active.
 
 ### Ambient Session Support (v1)
 In version 1, fluo's Mongoose integration supports automatic session injection for the following model methods:
@@ -91,7 +101,7 @@ In version 1, fluo's Mongoose integration supports automatic session injection f
 - `aggregate`
 - `bulkWrite`
 
-When these methods are called inside a `@Transaction()`, `transaction()`, or `requestTransaction()` boundary through `MongooseConnection.model(...)`, fluo attaches the ambient session to the options. For `create(...)`, operation options are recognized only in the array overload `create([docs], options)`, so positional documents with option-like fields remain documents. The raw model returned by `conn.current().model(...)` is not wrapped, and `doc.save()` is currently NOT supported for automatic session injection; both paths require manual session passing if used inside a transaction.
+When these methods are called inside a `@Transaction()`, `transaction()`, or `requestTransaction()` boundary through `MongooseConnection.model(...)`, fluo attaches the ambient session to the options. For `create(...)`, session injection is available only through the array overload `create([docs], options?)`; positional `create(docA, docB)` calls are forwarded unchanged and do not receive an automatic session. The raw model returned by `conn.current().model(...)` is not wrapped, and `doc.save()` is currently NOT supported for automatic session injection; both paths require manual session passing if used inside a transaction.
 
 If you explicitly provide a `session` in the options while a transaction is active, fluo will throw a conflict error if the provided session does not match the ambient transaction session. This prevents accidental cross-transaction leaks.
 
@@ -109,8 +119,8 @@ In fluo, the recommended way to handle transactions is using the `@Transaction()
 
 ```typescript
 await this.conn.transaction(async () => {
-  const Product = this.conn.model('Product');
-  const Inventory = this.conn.model('Inventory');
+  const Product = this.conn.model<ProductLookupModel>('Product');
+  const Inventory = this.conn.model<InventoryWriteModel>('Inventory');
 
   // Sessions are automatically injected into supported facade calls.
   const product = await Product.findOne({ _id: pid });
@@ -130,7 +140,7 @@ After defining a base schema, you can use Mongoose **Discriminators** to store d
 
 ```typescript
 const productSchema = new mongoose.Schema({ name: String, price: Number }, { discriminatorKey: 'type' });
-const Product = conn.model('Product', productSchema);
+const Product = conn.current().model('Product', productSchema);
 
 const Electronics = Product.discriminator('Electronics', new mongoose.Schema({ warranty: Number }));
 const Apparel = Product.discriminator('Apparel', new mongoose.Schema({ size: String, material: String }));

--- a/book/intermediate/ch19-mongoose.md
+++ b/book/intermediate/ch19-mongoose.md
@@ -22,7 +22,7 @@ This chapter covers how to integrate FluoShop's document-oriented data model int
 
 Mongoose is a widely used modeling layer for working with MongoDB in the Node.js ecosystem. The root `@fluojs/mongoose` integration uses Node.js `node:async_hooks` for ambient transaction context and supports Node.js 20 or newer. Using the fluo-specific integration package gives you these benefits.
 
-- **Lifecycle Management**: It registers the provided connection in the application lifecycle and, when you supply `dispose(connection)`, runs that cleanup only after request-scoped transactions have drained during shutdown.
+- **Lifecycle Management**: It registers the provided connection in the application lifecycle and, when you supply `dispose(connection)`, runs that cleanup only after started request callbacks and request-scoped transactions have drained during shutdown.
 - **Session Awareness**: The `MongooseConnection` service tracks MongoDB sessions across the call stack.
 - **Ambient Sessions (v1)**: fluo automatically attaches the active transaction session to supported Mongoose model operations (create, find, findOne, aggregate, bulkWrite).
 - **Application-owned connections**: fluo observes the concrete Mongoose connection that your application provides; it does not create, compile models for, or close that connection unless you supply `dispose(connection)`.
@@ -81,7 +81,7 @@ export class ProductRepository {
 }
 ```
 
-The `MongooseConnection` service acts as a context-aware proxy. When you call `this.conn.model('Product')`, it returns a version of the model that automatically participates in the ambient transaction if one is active.
+The `MongooseConnection` service acts as a context-aware proxy. When you call `this.conn.model('Product')`, its exported `MongooseModelFacade` return type keeps the supported methods callable and returns a version of the model that automatically participates in the ambient transaction if one is active.
 
 ### Ambient Session Support (v1)
 In version 1, fluo's Mongoose integration supports automatic session injection for the following model methods:
@@ -91,7 +91,7 @@ In version 1, fluo's Mongoose integration supports automatic session injection f
 - `aggregate`
 - `bulkWrite`
 
-When these methods are called inside a `@Transaction()`, `transaction()`, or `requestTransaction()` boundary through `MongooseConnection.model(...)`, fluo attaches the ambient session to the options. The raw model returned by `conn.current().model(...)` is not wrapped, and `doc.save()` is currently NOT supported for automatic session injection; both paths require manual session passing if used inside a transaction.
+When these methods are called inside a `@Transaction()`, `transaction()`, or `requestTransaction()` boundary through `MongooseConnection.model(...)`, fluo attaches the ambient session to the options. For `create(...)`, operation options are recognized only in the array overload `create([docs], options)`, so positional documents with option-like fields remain documents. The raw model returned by `conn.current().model(...)` is not wrapped, and `doc.save()` is currently NOT supported for automatic session injection; both paths require manual session passing if used inside a transaction.
 
 If you explicitly provide a `session` in the options while a transaction is active, fluo will throw a conflict error if the provided session does not match the ambient transaction session. This prevents accidental cross-transaction leaks.
 
@@ -100,7 +100,7 @@ If you explicitly provide a `session` in the options while a transaction is acti
 
 MongoDB transactions require an active **session**. Fluo reduces the caller's burden by grouping session creation, execution, and cleanup into one transaction wrapper.
 
-When the provided Mongoose connection exposes `connection.transaction(...)`, fluo delegates the transaction boundary to that API so Mongoose's own ambient-session scope and cleanup semantics remain intact. Otherwise it falls back to `startSession()`, `startTransaction()`, `commitTransaction()` / `abortTransaction()`, and `endSession()` directly. If the connection exposes neither `connection.transaction(...)` nor `startSession()` and `strictTransactions` is `false`, fluo enters fail-open mode by running the callback directly without rollback atomicity; use this only for local fakes or staged migrations. Set `strictTransactions: true` for production paths that require MongoDB transaction guarantees so missing support fails readiness and transaction helpers. Request-scoped transactions observe the request `AbortSignal` during session acquisition and delegated transaction startup, so cancelled requests can stop before repository work runs. In real transaction modes, `dispose(connection)` waits until active request transactions and session cleanup settle during application shutdown, and new manual or request-scoped transaction boundaries are rejected once shutdown begins.
+When the provided Mongoose connection exposes `connection.transaction(...)`, fluo delegates the transaction boundary to that API so Mongoose's own ambient-session scope and cleanup semantics remain intact. Otherwise it falls back to `startSession()`, `startTransaction()`, `commitTransaction()` / `abortTransaction()`, and `endSession()` directly. If the connection exposes neither `connection.transaction(...)` nor `startSession()` and `strictTransactions` is `false`, fluo enters fail-open mode by running the callback directly without rollback atomicity; use this only for local fakes or staged migrations. Set `strictTransactions: true` for production paths that require MongoDB transaction guarantees so missing support fails readiness and transaction helpers. Request-scoped transactions observe the request `AbortSignal` during session acquisition and delegated transaction startup, so cancelled requests can stop before repository work runs. If cancellation happens after callback work starts, fluo preserves the abort result but waits for that original callback before transaction cleanup and connection disposal. In real transaction modes, `dispose(connection)` waits until active request transactions and session cleanup settle during application shutdown, and new manual or request-scoped transaction boundaries are rejected once shutdown begins.
 
 Within any `@Transaction()`, `transaction(...)`, or `requestTransaction(...)` boundary, `conn.model(...)` returns a facade that auto-binds the ambient session for `create`, `find`, `findOne`, `aggregate`, and `bulkWrite`. Unsupported model methods and `doc.save()` still require explicit `conn.currentSession()` plumbing. A nested `requestTransaction(...)` opened inside an existing manual `transaction(...)` reuses the ambient session, remains tracked as an active request boundary, and is aborted during shutdown so the outer manual transaction can roll back before connection disposal.
 

--- a/packages/mongoose/README.ko.md
+++ b/packages/mongoose/README.ko.md
@@ -65,9 +65,11 @@ class AppModule {}
 종료 절차는 트랜잭션 정리 순서를 보존하고, 종료가 시작된 뒤에는 새로운 수동 또는 요청 단위 트랜잭션 경계를 거부합니다.
 
 1. 열린 요청 단위 트랜잭션은 `Application shutdown interrupted an open request transaction.`으로 abort됩니다.
-2. 활성 ambient session과 fail-open 직접 실행 transaction callback은 작업이 settle될 때까지 추적됩니다.
-3. 해당 Mongoose 세션은 `abortTransaction()`과 `endSession()` 정리를 끝냅니다.
+2. 활성 ambient session, 원본 request callback, fail-open 직접 실행 transaction callback은 작업이 settle될 때까지 추적됩니다.
+3. 해당 Mongoose 세션은 시작된 callback이 settle된 뒤에만 `abortTransaction()`과 `endSession()` 정리를 끝냅니다.
 4. 설정한 `dispose(connection)` 훅은 활성 요청 트랜잭션과 ambient session scope가 모두 settled된 뒤에만 실행됩니다.
+
+Request cancellation 또는 shutdown이 callback 시작 후 boundary를 abort하면, boundary는 abort 결과를 보존하되 원본 callback이 settle될 때까지 기다린 다음 rollback, session 종료, connection dispose를 진행합니다. 따라서 ALS-backed 작업이 이미 정리된 session이나 connection을 사용하며 계속 실행되지 않습니다.
 
 `MongooseConnection.createPlatformStatusSnapshot()`과 export된 low-level `createMongoosePlatformStatusSnapshot(...)` helper는 serving 중에는 `ready`, 요청 트랜잭션을 drain하는 shutdown 중에는 `shutting-down`, dispose hook 완료 후에는 `stopped`를 보고합니다. status details에는 `sessionStrategy`, `transactionContext: 'als'`, 활성 요청/세션 수, 리소스 소유권, strict/session 지원 진단이 포함됩니다. 수동 `transaction()` 호출과 서비스 `@Transaction()` 메서드는 같은 ambient session을 `conn.model(...)`에 노출합니다. 지원되는 facade 메서드(`create`, `find`, `findOne`, `aggregate`, `bulkWrite`)는 해당 세션을 자동으로 첨부합니다. 자동 세션 주입은 `MongooseConnection.model(...)` wrapper 메서드에만 scope되며, `conn.current()`가 반환하는 raw `connection.model(...)` cache/compile 경로를 교체하거나 변형하지 않습니다. 지원되지 않는 model 메서드, `doc.save()`, 외부 유틸리티에 명시적 세션 배관이 필요할 때는 `conn.currentSession()`을 사용하세요. 래핑된 Mongoose connection이 `connection.transaction(...)`을 제공하면 fluo는 Mongoose 자체 ambient-session scope를 보존하면서 동일한 세션을 `currentSession()`으로 노출하도록 해당 API에 트랜잭션 경계를 위임합니다. 요청 단위 트랜잭션은 세션을 획득하는 동안과 위임된 `connection.transaction(...)` 작업을 시작하는 동안 request `AbortSignal`을 관찰하므로, request cancellation은 사용자 callback이 실행되기 전의 startup phase를 중단할 수 있습니다.
 
@@ -163,14 +165,14 @@ await this.conn.transaction(async () => {
 
 래핑된 연결이 `connection.transaction(...)`을 구현하고 있다면 fluo는 이를 엄격한 트랜잭션 경계로 취급합니다. 그렇지 않고 `startSession()`이 없는 경우 트랜잭션은 기본값(`strictTransactions: false`)에서 callback 직접 실행으로 fail-open합니다. 이 모드는 local fake나 staged migration에는 유용하지만 rollback 원자성은 제공하지 않습니다. 열린 fail-open 수동 `transaction(...)` callback도 종료 중에 drain되므로 `dispose(connection)`은 해당 callback이 settle된 뒤 실행됩니다. MongoDB transaction 보장이 필요한 production 흐름에서는 `strictTransactions: true`를 설정하세요. 그러면 transaction 지원 누락이 readiness `not-ready`와 helper 예외로 드러납니다.
 
-지원되는 facade 메서드에서 fluo는 기존 Mongoose 작업 옵션을 보존하고 올바른 options 인자에 ambient `{ session }`만 병합합니다. 활성 트랜잭션 내부에서 명시적으로 `{ session: null }`을 전달하거나 다른 세션 객체를 사용하면, 의도치 않은 트랜잭션 탈출을 방지하기 위해 세션 충돌 에러를 발생시킵니다.
+지원되는 facade 메서드에서 fluo는 기존 Mongoose 작업 옵션을 보존하고 올바른 options 인자에 ambient `{ session }`만 병합합니다. `create(...)`는 Mongoose의 array overload인 `create([docs], options)`에서만 operation options를 인식합니다. 따라서 positional `create(docA, docB)`의 마지막 문서에 `timestamps` 같은 option-like field가 있어도 해당 인자는 문서로 유지됩니다. 활성 트랜잭션 내부에서 명시적으로 `{ session: null }`을 전달하거나 다른 세션 객체를 사용하면, `findOne(filter, projection, options)`의 세 번째 options 인자를 포함해 의도치 않은 트랜잭션 탈출을 방지하는 세션 충돌 에러를 발생시킵니다.
 
 ## 공개 API
 
 - `MongooseModule.forRoot(options)` / `MongooseModule.forRootAsync(options)`
 - `MongooseConnection`
 - `MongooseConnection.createPlatformStatusSnapshot()` — platform observability surface를 위해 health/readiness, resource ownership, 활성 request/session drain 수, strict transaction 지원 진단을 보고합니다.
-- `MongooseConnection.model(name, ...args)` — 트랜잭션 밖에서는 raw model을 반환하고, 활성 트랜잭션 안에서는 underlying Mongoose connection을 변형하지 않으면서 `create`, `find`, `findOne`, `aggregate`, `bulkWrite`에 세션을 주입하는 facade를 반환합니다.
+- `MongooseConnection.model(name, ...args)` — 트랜잭션 밖에서는 callable `MongooseModelFacade`를 반환하고, 활성 트랜잭션 안에서는 underlying Mongoose connection을 변형하지 않으면서 `create`, `find`, `findOne`, `aggregate`, `bulkWrite`에 세션을 주입하는 버전을 반환합니다.
 - `Transaction`
 - `MongooseTransactionInterceptor` — deprecated request-wide 호환성 interceptor입니다. 새 코드에서는 서비스 `@Transaction()` 또는 명시적 `requestTransaction(...)`을 우선 사용하세요.
 - `MONGOOSE_CONNECTION`, `MONGOOSE_DISPOSE`, `MONGOOSE_OPTIONS`
@@ -185,6 +187,7 @@ await this.conn.transaction(async () => {
 - `MongooseAsyncModuleOptions<TConnection>`
 - `MongooseConnectionLike`
 - `MongooseSessionLike`
+- `MongooseModelFacade`
 - `MongooseHandleProvider`
 - `MongoosePlatformStatusSnapshotInput`
 

--- a/packages/mongoose/README.ko.md
+++ b/packages/mongoose/README.ko.md
@@ -82,15 +82,18 @@ Request cancellation 또는 shutdown이 callback 시작 후 boundary를 abort하
 `@Transaction()` 데코레이터는 서비스 레이어에서 트랜잭션 경계를 정의하는 권장 방법입니다. 이 데코레이터가 적용된 메서드 내부에서 발생하는 모든 리포지토리 호출은 동일한 MongoDB 세션을 공유합니다.
 
 ```ts
-import { Transaction } from '@fluojs/mongoose';
-import { UserRepository } from './user.repository';
+import { MongooseConnection, Transaction, type MongooseModelFacade } from '@fluojs/mongoose';
+
+type UserDocument = { readonly _id: string; readonly name: string };
+type UserCreateModel = MongooseModelFacade<Promise<readonly [UserDocument]>>;
+type ProfileCreateModel = MongooseModelFacade<Promise<readonly { readonly userId: string }[]>>;
 
 export class UserService {
   constructor(private readonly repo: UserRepository) {}
 
   @Transaction()
   async onboardUser(dto: CreateUserDto) {
-    const user = await this.repo.create(dto);
+    const [user] = await this.repo.create(dto);
     await this.repo.initProfile(user._id);
     return user;
   }
@@ -99,15 +102,15 @@ export class UserService {
 export class UserRepository {
   constructor(private readonly conn: MongooseConnection) {}
 
-  async create(data: any) {
+  async create(data: CreateUserDto) {
     // @Transaction() 내부에서 conn.model()은 세션 인지형 facade를 반환합니다.
     // create, find, findOne, aggregate, bulkWrite 등의 작업은
     // 자동으로 활성 트랜잭션에 참여합니다.
-    return this.conn.model('User').create(data);
+    return this.conn.model<UserCreateModel>('User').create([data]);
   }
 
-  async initProfile(userId: any) {
-    return this.conn.model('Profile').create({ userId });
+  async initProfile(userId: string) {
+    return this.conn.model<ProfileCreateModel>('Profile').create([{ userId }]);
   }
 }
 ```
@@ -165,14 +168,14 @@ await this.conn.transaction(async () => {
 
 래핑된 연결이 `connection.transaction(...)`을 구현하고 있다면 fluo는 이를 엄격한 트랜잭션 경계로 취급합니다. 그렇지 않고 `startSession()`이 없는 경우 트랜잭션은 기본값(`strictTransactions: false`)에서 callback 직접 실행으로 fail-open합니다. 이 모드는 local fake나 staged migration에는 유용하지만 rollback 원자성은 제공하지 않습니다. 열린 fail-open 수동 `transaction(...)` callback도 종료 중에 drain되므로 `dispose(connection)`은 해당 callback이 settle된 뒤 실행됩니다. MongoDB transaction 보장이 필요한 production 흐름에서는 `strictTransactions: true`를 설정하세요. 그러면 transaction 지원 누락이 readiness `not-ready`와 helper 예외로 드러납니다.
 
-지원되는 facade 메서드에서 fluo는 기존 Mongoose 작업 옵션을 보존하고 올바른 options 인자에 ambient `{ session }`만 병합합니다. `create(...)`는 Mongoose의 array overload인 `create([docs], options)`에서만 operation options를 인식합니다. 따라서 positional `create(docA, docB)`의 마지막 문서에 `timestamps` 같은 option-like field가 있어도 해당 인자는 문서로 유지됩니다. 활성 트랜잭션 내부에서 명시적으로 `{ session: null }`을 전달하거나 다른 세션 객체를 사용하면, `findOne(filter, projection, options)`의 세 번째 options 인자를 포함해 의도치 않은 트랜잭션 탈출을 방지하는 세션 충돌 에러를 발생시킵니다.
+지원되는 facade 메서드에서 fluo는 기존 Mongoose 작업 옵션을 보존하고 올바른 options 인자에 ambient `{ session }`만 병합합니다. `create(...)`는 Mongoose의 array overload인 `create([docs], options?)`를 통해서만 session을 주입합니다. Positional `create(docA, docB)` 인자는 마지막 문서에 `timestamps` 같은 option-like field가 있어도 그대로 전달되며 자동 session 주입을 받지 않습니다. 트랜잭션 참여가 필요하면 array overload를 사용하세요. 활성 트랜잭션 내부에서 명시적으로 `{ session: null }`을 전달하거나 다른 세션 객체를 사용하면, `findOne(filter, projection, options)`의 세 번째 options 인자를 포함해 의도치 않은 트랜잭션 탈출을 방지하는 세션 충돌 에러를 발생시킵니다. Repository code에서 typed operation result가 필요하면 result-specialized `MongooseModelFacade`를 `model<TModel>(...)` 타입 인자로 전달하세요.
 
 ## 공개 API
 
 - `MongooseModule.forRoot(options)` / `MongooseModule.forRootAsync(options)`
 - `MongooseConnection`
 - `MongooseConnection.createPlatformStatusSnapshot()` — platform observability surface를 위해 health/readiness, resource ownership, 활성 request/session drain 수, strict transaction 지원 진단을 보고합니다.
-- `MongooseConnection.model(name, ...args)` — 트랜잭션 밖에서는 callable `MongooseModelFacade`를 반환하고, 활성 트랜잭션 안에서는 underlying Mongoose connection을 변형하지 않으면서 `create`, `find`, `findOne`, `aggregate`, `bulkWrite`에 세션을 주입하는 버전을 반환합니다.
+- `MongooseConnection.model<TModel>(name, ...args)` — 트랜잭션 밖에서는 callable하고 result-specializable한 `MongooseModelFacade`를 반환하고, 활성 트랜잭션 안에서는 underlying Mongoose connection을 변형하지 않으면서 `create`, `find`, `findOne`, `aggregate`, `bulkWrite`에 세션을 주입하는 버전을 반환합니다.
 - `Transaction`
 - `MongooseTransactionInterceptor` — deprecated request-wide 호환성 interceptor입니다. 새 코드에서는 서비스 `@Transaction()` 또는 명시적 `requestTransaction(...)`을 우선 사용하세요.
 - `MONGOOSE_CONNECTION`, `MONGOOSE_DISPOSE`, `MONGOOSE_OPTIONS`

--- a/packages/mongoose/README.md
+++ b/packages/mongoose/README.md
@@ -79,15 +79,18 @@ Nested `requestTransaction(...)` calls opened inside an existing manual `transac
 The `@Transaction()` decorator is the recommended way to define transaction boundaries in your service layer. It ensures that all repository calls made within the decorated method share the same MongoDB session.
 
 ```ts
-import { Transaction } from '@fluojs/mongoose';
-import { UserRepository } from './user.repository';
+import { MongooseConnection, Transaction, type MongooseModelFacade } from '@fluojs/mongoose';
+
+type UserDocument = { readonly _id: string; readonly name: string };
+type UserCreateModel = MongooseModelFacade<Promise<readonly [UserDocument]>>;
+type ProfileCreateModel = MongooseModelFacade<Promise<readonly { readonly userId: string }[]>>;
 
 export class UserService {
   constructor(private readonly repo: UserRepository) {}
 
   @Transaction()
   async onboardUser(dto: CreateUserDto) {
-    const user = await this.repo.create(dto);
+    const [user] = await this.repo.create(dto);
     await this.repo.initProfile(user._id);
     return user;
   }
@@ -96,15 +99,15 @@ export class UserService {
 export class UserRepository {
   constructor(private readonly conn: MongooseConnection) {}
 
-  async create(data: any) {
+  async create(data: CreateUserDto) {
     // model() returns a session-aware facade inside @Transaction().
     // Operations like create, find, findOne, aggregate, and bulkWrite
     // automatically participate in the ambient transaction.
-    return this.conn.model('User').create(data);
+    return this.conn.model<UserCreateModel>('User').create([data]);
   }
 
-  async initProfile(userId: any) {
-    return this.conn.model('Profile').create({ userId });
+  async initProfile(userId: string) {
+    return this.conn.model<ProfileCreateModel>('Profile').create([{ userId }]);
   }
 }
 ```
@@ -162,14 +165,14 @@ await this.conn.transaction(async () => {
 
 If the wrapped connection implements `connection.transaction(...)`, fluo treats that as the strict transaction boundary. Otherwise, when the connection does not implement `startSession()`, transactions use fail-open direct callback execution by default (`strictTransactions: false`), which is useful for local fakes and staged migrations but provides no rollback atomicity. Open fail-open manual `transaction(...)` callbacks still drain during shutdown before `dispose(connection)` runs. Set `strictTransactions: true` for production flows that require MongoDB transaction guarantees; missing transaction support then makes readiness `not-ready` and causes transaction helpers to throw.
 
-For supported facade methods, fluo preserves existing Mongoose operation options and only merges the ambient `{ session }` into the correct options argument. `create(...)` recognizes operation options only in Mongoose's array overload, `create([docs], options)`; positional `create(docA, docB)` arguments remain documents even when the last document contains option-like fields such as `timestamps`. If a model call passes an explicit `{ session: null }` or a different session object inside an ambient transaction, including the third options argument of `findOne(filter, projection, options)`, fluo throws a session conflict error to prevent accidental transaction escapes.
+For supported facade methods, fluo preserves existing Mongoose operation options and only merges the ambient `{ session }` into the correct options argument. `create(...)` injects the session only through Mongoose's array overload, `create([docs], options?)`. Positional `create(docA, docB)` arguments are forwarded unchanged—even when the last document contains option-like fields such as `timestamps`—and therefore do not receive automatic session injection. Use the array overload for transaction participation. If a model call passes an explicit `{ session: null }` or a different session object inside an ambient transaction, including the third options argument of `findOne(filter, projection, options)`, fluo throws a session conflict error to prevent accidental transaction escapes. Pass a result-specialized `MongooseModelFacade` as the `model<TModel>(...)` type argument when repository code needs typed operation results.
 
 ## Public API
 
 - `MongooseModule.forRoot(options)` / `MongooseModule.forRootAsync(options)`
 - `MongooseConnection`
 - `MongooseConnection.createPlatformStatusSnapshot()` — reports health/readiness, resource ownership, active request/session drain counts, and strict transaction support diagnostics for platform observability surfaces.
-- `MongooseConnection.model(name, ...args)` — returns the callable `MongooseModelFacade` outside transactions or a session-aware version for `create`, `find`, `findOne`, `aggregate`, and `bulkWrite` inside an active transaction without mutating the underlying Mongoose connection.
+- `MongooseConnection.model<TModel>(name, ...args)` — returns the callable, result-specializable `MongooseModelFacade` outside transactions or a session-aware version for `create`, `find`, `findOne`, `aggregate`, and `bulkWrite` inside an active transaction without mutating the underlying Mongoose connection.
 - `Transaction`
 - `MongooseTransactionInterceptor` — deprecated request-wide compatibility interceptor; prefer service `@Transaction()` or explicit `requestTransaction(...)` in new code.
 - `MONGOOSE_CONNECTION`, `MONGOOSE_DISPOSE`, `MONGOOSE_OPTIONS`

--- a/packages/mongoose/README.md
+++ b/packages/mongoose/README.md
@@ -63,9 +63,11 @@ class AppModule {}
 Shutdown preserves transaction cleanup order and rejects new manual or request-scoped transaction boundaries once shutdown begins:
 
 1. Open request-scoped transactions are aborted with `Application shutdown interrupted an open request transaction.`
-2. Active ambient sessions and fail-open direct-execution transaction callbacks are tracked until their work settles.
-3. Their Mongoose sessions finish `abortTransaction()` and `endSession()` cleanup.
+2. Active ambient sessions, original request callbacks, and fail-open direct-execution transaction callbacks are tracked until their work settles.
+3. Their Mongoose sessions finish `abortTransaction()` and `endSession()` cleanup only after started callbacks settle.
 4. The configured `dispose(connection)` hook runs only after active request transactions and ambient session scopes have settled.
+
+When request cancellation or shutdown aborts a boundary after its callback has started, the boundary preserves the abort result but waits for the original callback to settle before rolling back, ending the session, or disposing the connection. This prevents ALS-backed work from continuing against an already-cleaned-up session or connection.
 
 `MongooseConnection.createPlatformStatusSnapshot()` and the exported low-level `createMongoosePlatformStatusSnapshot(...)` helper report `ready` while serving traffic, `shutting-down` while request transactions are draining, and `stopped` after the dispose hook completes. The status details include `sessionStrategy`, `transactionContext: 'als'`, active request/session counts, resource ownership, and strict/session support diagnostics. Manual `transaction()` calls and service `@Transaction()` methods expose the same ambient session to `conn.model(...)`; supported facade methods (`create`, `find`, `findOne`, `aggregate`, and `bulkWrite`) automatically attach that session. Automatic session injection is scoped to the `MongooseConnection.model(...)` wrapper method and does not replace or mutate the raw `connection.model(...)` cache/compile path returned by `conn.current()`. Use `conn.currentSession()` for unsupported model methods, `doc.save()`, or external utilities that need explicit session plumbing. If the wrapped Mongoose connection exposes `connection.transaction(...)`, fluo delegates the transaction boundary to that API so Mongoose's own ambient-session scope is preserved while still exposing the same session through `currentSession()`. Request-scoped transactions observe the request `AbortSignal` while acquiring sessions and while starting delegated `connection.transaction(...)` work, so request cancellation can interrupt those startup phases before user callbacks run.
 Nested `requestTransaction(...)` calls opened inside an existing manual `transaction(...)` boundary reuse the ambient session, stay visible in `details.activeRequestTransactions`, and are aborted during shutdown so the outer manual transaction can roll back before `dispose(connection)` runs.
@@ -160,14 +162,14 @@ await this.conn.transaction(async () => {
 
 If the wrapped connection implements `connection.transaction(...)`, fluo treats that as the strict transaction boundary. Otherwise, when the connection does not implement `startSession()`, transactions use fail-open direct callback execution by default (`strictTransactions: false`), which is useful for local fakes and staged migrations but provides no rollback atomicity. Open fail-open manual `transaction(...)` callbacks still drain during shutdown before `dispose(connection)` runs. Set `strictTransactions: true` for production flows that require MongoDB transaction guarantees; missing transaction support then makes readiness `not-ready` and causes transaction helpers to throw.
 
-For supported facade methods, fluo preserves existing Mongoose operation options and only merges the ambient `{ session }` into the correct options argument. If a model call passes an explicit `{ session: null }` or a different session object inside an ambient transaction, fluo throws a session conflict error to prevent accidental transaction escapes.
+For supported facade methods, fluo preserves existing Mongoose operation options and only merges the ambient `{ session }` into the correct options argument. `create(...)` recognizes operation options only in Mongoose's array overload, `create([docs], options)`; positional `create(docA, docB)` arguments remain documents even when the last document contains option-like fields such as `timestamps`. If a model call passes an explicit `{ session: null }` or a different session object inside an ambient transaction, including the third options argument of `findOne(filter, projection, options)`, fluo throws a session conflict error to prevent accidental transaction escapes.
 
 ## Public API
 
 - `MongooseModule.forRoot(options)` / `MongooseModule.forRootAsync(options)`
 - `MongooseConnection`
 - `MongooseConnection.createPlatformStatusSnapshot()` — reports health/readiness, resource ownership, active request/session drain counts, and strict transaction support diagnostics for platform observability surfaces.
-- `MongooseConnection.model(name, ...args)` — returns the raw model outside transactions or a session-aware facade for `create`, `find`, `findOne`, `aggregate`, and `bulkWrite` inside an active transaction without mutating the underlying Mongoose connection.
+- `MongooseConnection.model(name, ...args)` — returns the callable `MongooseModelFacade` outside transactions or a session-aware version for `create`, `find`, `findOne`, `aggregate`, and `bulkWrite` inside an active transaction without mutating the underlying Mongoose connection.
 - `Transaction`
 - `MongooseTransactionInterceptor` — deprecated request-wide compatibility interceptor; prefer service `@Transaction()` or explicit `requestTransaction(...)` in new code.
 - `MONGOOSE_CONNECTION`, `MONGOOSE_DISPOSE`, `MONGOOSE_OPTIONS`
@@ -182,6 +184,7 @@ For supported facade methods, fluo preserves existing Mongoose operation options
 - `MongooseAsyncModuleOptions<TConnection>`
 - `MongooseConnectionLike`
 - `MongooseSessionLike`
+- `MongooseModelFacade`
 - `MongooseHandleProvider`
 - `MongoosePlatformStatusSnapshotInput`
 

--- a/packages/mongoose/src/connection.ts
+++ b/packages/mongoose/src/connection.ts
@@ -369,13 +369,13 @@ export class MongooseConnection<TConnection extends MongooseConnectionLike = Mon
     try {
       if (typeof this.connection.transaction === 'function') {
         let delegatedCallbackStarted = false;
+        const delegatedTransaction = this.runConnectionTransaction(() => {
+          delegatedCallbackStarted = true;
+          return raceWithAbortAndDrainCallback(fn, abortContext.signal);
+        });
 
         return await raceWithAbortAndDrainCallback(
-          () =>
-            this.runConnectionTransaction(() => {
-              delegatedCallbackStarted = true;
-              return raceWithAbortAndDrainCallback(fn, abortContext.signal);
-            }),
+          () => delegatedTransaction,
           abortContext.signal,
           () => delegatedCallbackStarted,
         );

--- a/packages/mongoose/src/connection.ts
+++ b/packages/mongoose/src/connection.ts
@@ -12,6 +12,7 @@ import { MONGOOSE_CONNECTION, MONGOOSE_DISPOSE, MONGOOSE_OPTIONS } from './token
 import type {
   MongooseConnectionLike,
   MongooseHandleProvider,
+  MongooseModelFacade,
   MongooseSessionLike,
 } from './types.js';
 
@@ -54,79 +55,19 @@ type MongooseRuntimeOptions = {
   strictTransactions: boolean;
 };
 
-type MongooseModelLike = Record<PropertyKey, unknown>;
-
 type MongooseModelFactoryConnection = MongooseConnectionLike & {
-  model?(name: string, ...args: unknown[]): MongooseModelLike;
+  model?(name: string, ...args: unknown[]): MongooseModelFacade;
 };
 
 const MODEL_OPERATIONS_WITH_OPTIONS = new Set<PropertyKey>(['aggregate', 'bulkWrite', 'create', 'find', 'findOne']);
 const MODEL_OPERATIONS_WITH_PROJECTION = new Set<PropertyKey>(['find', 'findOne']);
-const MONGOOSE_CREATE_OPTION_KEYS = new Set<PropertyKey>([
-  'aggregateErrors',
-  'checkKeys',
-  'j',
-  'ordered',
-  'populate',
-  'safe',
-  'session',
-  'timestamps',
-  'validateBeforeSave',
-  'validateModifiedOnly',
-  'w',
-  'writeConcern',
-  'wtimeout',
-]);
 function isObjectLike(value: unknown): value is object {
   return (typeof value === 'object' && value !== null) || typeof value === 'function';
-}
-
-function hasOnlyMongooseCreateOptionKeys(value: object): boolean {
-  const keys = Reflect.ownKeys(value);
-
-  return keys.length > 0 && keys.every((key) => MONGOOSE_CREATE_OPTION_KEYS.has(key));
-}
-
-function isMongooseCreateOptionsCandidate(value: unknown): boolean {
-  if (!isObjectLike(value)) {
-    return false;
-  }
-
-  if (
-    'session' in value &&
-    hasOnlyMongooseCreateOptionKeys(value) &&
-    (value.session === null || value.session === undefined || isObjectLike(value.session))
-  ) {
-    return true;
-  }
-
-  for (const key of MONGOOSE_CREATE_OPTION_KEYS) {
-    if (key !== 'session' && key in value) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
-function isEmptyCreateOptionsCandidate(value: unknown): boolean {
-  return value !== null && typeof value === 'object' && !Array.isArray(value) && Object.keys(value).length === 0;
 }
 
 function resolveCreateOptionsIndex(operationArgs: unknown[]): number {
   if (operationArgs.length === 2 && Array.isArray(operationArgs[0])) {
     return 1;
-  }
-
-  if (operationArgs.length === 2 && isEmptyCreateOptionsCandidate(operationArgs[1])) {
-    return 1;
-  }
-
-  if (
-    operationArgs.length >= 2 &&
-    isMongooseCreateOptionsCandidate(operationArgs[operationArgs.length - 1])
-  ) {
-    return operationArgs.length - 1;
   }
 
   return operationArgs.length;
@@ -166,7 +107,7 @@ function resolveSessionOptions(opts: unknown, ambient: MongooseSessionLike): Rec
   return { ...options, session: ambient };
 }
 
-function createAmbientSessionModelFacade<TModel extends MongooseModelLike>(model: TModel, ambient: MongooseSessionLike): TModel {
+function createAmbientSessionModelFacade<TModel extends MongooseModelFacade>(model: TModel, ambient: MongooseSessionLike): TModel {
   return new Proxy(model, {
     get(target, prop, receiver) {
       const value = Reflect.get(target, prop, receiver);
@@ -184,6 +125,26 @@ function createAmbientSessionModelFacade<TModel extends MongooseModelLike>(model
       };
     },
   });
+}
+
+async function raceWithAbortAndDrainCallback<T>(fn: () => Promise<T>, signal: AbortSignal): Promise<T> {
+  let callback: Promise<T> | undefined;
+
+  try {
+    return await raceWithAbort(() => {
+      callback = Promise.resolve().then(fn);
+      return callback;
+    }, signal);
+  } catch (error) {
+    if (signal.aborted && callback) {
+      await callback.then(
+        () => undefined,
+        () => undefined,
+      );
+    }
+
+    throw error;
+  }
 }
 
 function resolveModelFactory(connection: MongooseConnectionLike): MongooseModelFactoryConnection['model'] | undefined {
@@ -269,7 +230,7 @@ export class MongooseConnection<TConnection extends MongooseConnectionLike = Mon
    * @param args Additional model resolver arguments forwarded unchanged.
    * @returns The real model outside transactions, or a model facade inside an active transaction boundary.
    */
-  model(name: string, ...args: unknown[]): MongooseModelLike {
+  model(name: string, ...args: unknown[]): MongooseModelFacade {
     const modelFactory = resolveModelFactory(this.connection);
 
     if (typeof modelFactory !== 'function') {
@@ -381,7 +342,7 @@ export class MongooseConnection<TConnection extends MongooseConnectionLike = Mon
       const active = this.trackActiveRequestTransaction(abortContext.controller);
 
       try {
-        return await raceWithAbort(fn, abortContext.signal);
+        return await raceWithAbortAndDrainCallback(fn, abortContext.signal);
       } finally {
         abortContext.cleanup();
         currentScope.activeSession.retainRequestTransaction(active);
@@ -397,7 +358,7 @@ export class MongooseConnection<TConnection extends MongooseConnectionLike = Mon
     try {
       if (typeof this.connection.transaction === 'function') {
         return await raceWithAbort(
-          () => this.runConnectionTransaction(() => raceWithAbort(fn, abortContext.signal)),
+          () => this.runConnectionTransaction(() => raceWithAbortAndDrainCallback(fn, abortContext.signal)),
           abortContext.signal,
         );
       }
@@ -406,10 +367,12 @@ export class MongooseConnection<TConnection extends MongooseConnectionLike = Mon
         untrackActiveInFinally = false;
       });
       if (!resolvedSession) {
-        return await raceWithAbort(fn, abortContext.signal);
+        return await raceWithAbortAndDrainCallback(fn, abortContext.signal);
       }
 
-      return await this.runManualSessionTransaction(resolvedSession, () => raceWithAbort(fn, abortContext.signal));
+      return await this.runManualSessionTransaction(resolvedSession, () =>
+        raceWithAbortAndDrainCallback(fn, abortContext.signal),
+      );
     } finally {
       abortContext.cleanup();
 

--- a/packages/mongoose/src/connection.ts
+++ b/packages/mongoose/src/connection.ts
@@ -65,15 +65,15 @@ function isObjectLike(value: unknown): value is object {
   return (typeof value === 'object' && value !== null) || typeof value === 'function';
 }
 
-function resolveCreateOptionsIndex(operationArgs: unknown[]): number {
-  if (operationArgs.length === 2 && Array.isArray(operationArgs[0])) {
+function resolveCreateOptionsIndex(operationArgs: unknown[]): number | undefined {
+  if (Array.isArray(operationArgs[0])) {
     return 1;
   }
 
-  return operationArgs.length;
+  return undefined;
 }
 
-function resolveOptionsIndex(operation: PropertyKey, operationArgs: unknown[]): number {
+function resolveOptionsIndex(operation: PropertyKey, operationArgs: unknown[]): number | undefined {
   if (operation === 'create') {
     return resolveCreateOptionsIndex(operationArgs);
   }
@@ -119,6 +119,11 @@ function createAmbientSessionModelFacade<TModel extends MongooseModelFacade>(mod
       return (...args: unknown[]) => {
         const operationArgs = [...args];
         const optionsIndex = resolveOptionsIndex(prop, operationArgs);
+
+        if (optionsIndex === undefined) {
+          return value.apply(target, operationArgs);
+        }
+
         operationArgs[optionsIndex] = resolveSessionOptions(operationArgs[optionsIndex], ambient);
 
         return value.apply(target, operationArgs);
@@ -127,7 +132,11 @@ function createAmbientSessionModelFacade<TModel extends MongooseModelFacade>(mod
   });
 }
 
-async function raceWithAbortAndDrainCallback<T>(fn: () => Promise<T>, signal: AbortSignal): Promise<T> {
+async function raceWithAbortAndDrainCallback<T>(
+  fn: () => Promise<T>,
+  signal: AbortSignal,
+  shouldDrainAfterAbort: () => boolean = () => true,
+): Promise<T> {
   let callback: Promise<T> | undefined;
 
   try {
@@ -136,7 +145,7 @@ async function raceWithAbortAndDrainCallback<T>(fn: () => Promise<T>, signal: Ab
       return callback;
     }, signal);
   } catch (error) {
-    if (signal.aborted && callback) {
+    if (signal.aborted && callback && shouldDrainAfterAbort()) {
       await callback.then(
         () => undefined,
         () => undefined,
@@ -226,10 +235,12 @@ export class MongooseConnection<TConnection extends MongooseConnectionLike = Mon
   /**
    * Returns a model from the root connection, injecting the ambient transaction session into conservative operations.
    *
+   * @typeParam TModel Consumer-defined facade result contract for the wrapped model.
    * @param name Model name passed to the underlying Mongoose connection.
    * @param args Additional model resolver arguments forwarded unchanged.
    * @returns The real model outside transactions, or a model facade inside an active transaction boundary.
    */
+  model<TModel extends MongooseModelFacade = MongooseModelFacade>(name: string, ...args: unknown[]): TModel;
   model(name: string, ...args: unknown[]): MongooseModelFacade {
     const modelFactory = resolveModelFactory(this.connection);
 
@@ -357,9 +368,16 @@ export class MongooseConnection<TConnection extends MongooseConnectionLike = Mon
 
     try {
       if (typeof this.connection.transaction === 'function') {
-        return await raceWithAbort(
-          () => this.runConnectionTransaction(() => raceWithAbortAndDrainCallback(fn, abortContext.signal)),
+        let delegatedCallbackStarted = false;
+
+        return await raceWithAbortAndDrainCallback(
+          () =>
+            this.runConnectionTransaction(() => {
+              delegatedCallbackStarted = true;
+              return raceWithAbortAndDrainCallback(fn, abortContext.signal);
+            }),
           abortContext.signal,
+          () => delegatedCallbackStarted,
         );
       }
 

--- a/packages/mongoose/src/module.test.ts
+++ b/packages/mongoose/src/module.test.ts
@@ -1418,7 +1418,7 @@ describe('@fluojs/mongoose', () => {
     await vi.waitFor(() => {
       expect(mongoose.createPlatformStatusSnapshot()).toMatchObject({
         details: {
-          activeRequestTransactions: 0,
+          activeRequestTransactions: 1,
           activeSessions: 1,
           lifecycleState: 'shutting-down',
         },
@@ -1431,7 +1431,7 @@ describe('@fluojs/mongoose', () => {
 
     expect(mongoose.createPlatformStatusSnapshot()).toMatchObject({
       details: {
-        activeRequestTransactions: 0,
+        activeRequestTransactions: 1,
         activeSessions: 1,
         lifecycleState: 'shutting-down',
       },
@@ -1449,6 +1449,14 @@ describe('@fluojs/mongoose', () => {
 
     await closePromise;
     await openTransactionResult;
+
+    expect(mongoose.createPlatformStatusSnapshot()).toMatchObject({
+      details: {
+        activeRequestTransactions: 0,
+        activeSessions: 0,
+        lifecycleState: 'stopped',
+      },
+    });
 
     expect(events).toEqual([
       'connection:transaction:start',

--- a/packages/mongoose/src/module.test.ts
+++ b/packages/mongoose/src/module.test.ts
@@ -391,14 +391,90 @@ describe('@fluojs/mongoose', () => {
     ]);
   });
 
+  it('waits for the original request callback before aborting its session and disposing the connection', async () => {
+    const events: string[] = [];
+    let releaseWork!: () => void;
+    let resolveWorkStarted!: () => void;
+    const workReleased = new Promise<void>((resolve) => {
+      releaseWork = resolve;
+    });
+    const workStarted = new Promise<void>((resolve) => {
+      resolveWorkStarted = resolve;
+    });
+    const session = createFakeSession(events);
+    const connection: MongooseConnectionLike = {
+      async startSession() {
+        events.push('connection:startSession');
+        return session;
+      },
+    };
+    const mongooseModule = MongooseModule.forRoot<typeof connection>({
+      connection,
+      dispose() {
+        events.push('dispose');
+      },
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, { imports: [mongooseModule] });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+    const mongoose = await app.container.resolve(MongooseConnection<typeof connection>);
+    const controller = new AbortController();
+    const requestTransaction = mongoose.requestTransaction(async () => {
+      events.push('request:work:start');
+      resolveWorkStarted();
+      await workReleased;
+      events.push('request:work:end');
+      return 'late-result';
+    }, controller.signal);
+    const requestTransactionResult = expect(requestTransaction).rejects.toThrow('request aborted during work');
+
+    await workStarted;
+    controller.abort(new Error('request aborted during work'));
+    const closePromise = app.close();
+
+    try {
+      await vi.waitFor(() => {
+        expect(mongoose.createPlatformStatusSnapshot()).toMatchObject({
+          details: {
+            activeRequestTransactions: 1,
+            activeSessions: 1,
+            lifecycleState: 'shutting-down',
+          },
+        });
+      });
+      expect(events).toEqual(['connection:startSession', 'transaction:start', 'request:work:start']);
+    } finally {
+      releaseWork();
+      await Promise.allSettled([requestTransaction, closePromise]);
+    }
+
+    await requestTransactionResult;
+    expect(events).toEqual([
+      'connection:startSession',
+      'transaction:start',
+      'request:work:start',
+      'request:work:end',
+      'transaction:abort',
+      'session:end',
+      'dispose',
+    ]);
+  });
+
   it('reports lifecycle status while shutdown drains request transaction sessions', async () => {
     const events: string[] = [];
     let resolveRequestStarted!: () => void;
+    let releaseRequestWork!: () => void;
     let resolveEndSessionStarted!: () => void;
     let resolveEndSession!: () => void;
 
     const requestStarted = new Promise<void>((resolve) => {
       resolveRequestStarted = resolve;
+    });
+    const requestWorkReleased = new Promise<void>((resolve) => {
+      releaseRequestWork = resolve;
     });
     const endSessionStarted = new Promise<void>((resolve) => {
       resolveEndSessionStarted = resolve;
@@ -451,8 +527,13 @@ describe('@fluojs/mongoose', () => {
     const openTransaction = mongoose.requestTransaction(async () => {
       events.push('request:open');
       resolveRequestStarted();
-      return new Promise<never>(() => undefined);
+      await requestWorkReleased;
+      events.push('request:done');
+      return 'late-result';
     });
+    const openTransactionResult = expect(openTransaction).rejects.toThrow(
+      'Application shutdown interrupted an open request transaction.',
+    );
 
     await requestStarted;
 
@@ -466,6 +547,18 @@ describe('@fluojs/mongoose', () => {
     });
 
     const closePromise = app.close();
+    await vi.waitFor(() => {
+      expect(mongoose.createPlatformStatusSnapshot()).toMatchObject({
+        details: {
+          activeRequestTransactions: 1,
+          activeSessions: 1,
+          lifecycleState: 'shutting-down',
+        },
+      });
+    });
+    expect(events).toEqual(['connection:startSession', 'transaction:start', 'request:open']);
+
+    releaseRequestWork();
     await endSessionStarted;
 
     expect(mongoose.createPlatformStatusSnapshot()).toMatchObject({
@@ -480,7 +573,7 @@ describe('@fluojs/mongoose', () => {
     resolveEndSession();
 
     await closePromise;
-    await expect(openTransaction).rejects.toThrow('Application shutdown interrupted an open request transaction.');
+    await openTransactionResult;
 
     expect(mongoose.createPlatformStatusSnapshot()).toMatchObject({
       details: {
@@ -494,6 +587,7 @@ describe('@fluojs/mongoose', () => {
       'connection:startSession',
       'transaction:start',
       'request:open',
+      'request:done',
       'transaction:abort',
       'session:end:start',
       'session:end:done',
@@ -734,8 +828,12 @@ describe('@fluojs/mongoose', () => {
   it('tracks nested request transactions inside manual transactions through shutdown abort', async () => {
     const events: string[] = [];
     let resolveRequestStarted!: () => void;
+    let releaseRequestWork!: () => void;
     const requestStarted = new Promise<void>((resolve) => {
       resolveRequestStarted = resolve;
+    });
+    const requestWorkReleased = new Promise<void>((resolve) => {
+      releaseRequestWork = resolve;
     });
     const session = createFakeSession(events);
 
@@ -766,8 +864,13 @@ describe('@fluojs/mongoose', () => {
       mongoose.requestTransaction(async () => {
         events.push('request:open');
         resolveRequestStarted();
-        return new Promise<never>(() => undefined);
+        await requestWorkReleased;
+        events.push('request:done');
+        return 'late-result';
       }),
+    );
+    const openTransactionResult = expect(openTransaction).rejects.toThrow(
+      'Application shutdown interrupted an open request transaction.',
     );
 
     await requestStarted;
@@ -781,8 +884,21 @@ describe('@fluojs/mongoose', () => {
     });
 
     const closePromise = app.close();
+    await vi.waitFor(() => {
+      expect(mongoose.createPlatformStatusSnapshot()).toMatchObject({
+        details: {
+          activeRequestTransactions: 1,
+          activeSessions: 1,
+          lifecycleState: 'shutting-down',
+        },
+      });
+    });
+    expect(events).not.toContain('transaction:abort');
+    expect(events).not.toContain('dispose');
 
-    await expect(openTransaction).rejects.toThrow('Application shutdown interrupted an open request transaction.');
+    releaseRequestWork();
+
+    await openTransactionResult;
     await closePromise;
 
     expect(mongoose.createPlatformStatusSnapshot()).toMatchObject({
@@ -796,6 +912,7 @@ describe('@fluojs/mongoose', () => {
       'connection:startSession',
       'transaction:start',
       'request:open',
+      'request:done',
       'transaction:abort',
       'session:end',
       'dispose',
@@ -1217,8 +1334,16 @@ describe('@fluojs/mongoose', () => {
 
   it('waits for connection.transaction request session cleanup before dispose on shutdown', async () => {
     const events: string[] = [];
+    let releaseRequestWork!: () => void;
+    let resolveRequestStarted!: () => void;
     let resolveEndSessionStarted!: () => void;
     let resolveEndSession!: () => void;
+    const requestWorkReleased = new Promise<void>((resolve) => {
+      releaseRequestWork = resolve;
+    });
+    const requestStarted = new Promise<void>((resolve) => {
+      resolveRequestStarted = resolve;
+    });
     const endSessionStarted = new Promise<void>((resolve) => {
       resolveEndSessionStarted = resolve;
     });
@@ -1277,12 +1402,31 @@ describe('@fluojs/mongoose', () => {
     const app = await bootstrapApplication({ rootModule: AppModule });
     const mongoose = await app.container.resolve(MongooseConnection<typeof connection>);
 
-    const openTransaction = mongoose.requestTransaction(async () => new Promise<never>(() => undefined));
+    const openTransaction = mongoose.requestTransaction(async () => {
+      events.push('request:work:start');
+      resolveRequestStarted();
+      await requestWorkReleased;
+      events.push('request:work:end');
+      return 'late-result';
+    });
     const openTransactionResult = expect(openTransaction).rejects.toThrow(
       'Application shutdown interrupted an open request transaction.',
     );
+    await requestStarted;
     const closePromise = app.close();
 
+    await vi.waitFor(() => {
+      expect(mongoose.createPlatformStatusSnapshot()).toMatchObject({
+        details: {
+          activeRequestTransactions: 0,
+          activeSessions: 1,
+          lifecycleState: 'shutting-down',
+        },
+      });
+    });
+    expect(events).toEqual(['connection:transaction:start', 'transaction:start', 'request:work:start']);
+
+    releaseRequestWork();
     await endSessionStarted;
 
     expect(mongoose.createPlatformStatusSnapshot()).toMatchObject({
@@ -1295,6 +1439,8 @@ describe('@fluojs/mongoose', () => {
     expect(events).toEqual([
       'connection:transaction:start',
       'transaction:start',
+      'request:work:start',
+      'request:work:end',
       'transaction:abort',
       'session:end:start',
     ]);
@@ -1307,6 +1453,8 @@ describe('@fluojs/mongoose', () => {
     expect(events).toEqual([
       'connection:transaction:start',
       'transaction:start',
+      'request:work:start',
+      'request:work:end',
       'transaction:abort',
       'session:end:start',
       'session:end:done',

--- a/packages/mongoose/src/module.test.ts
+++ b/packages/mongoose/src/module.test.ts
@@ -1201,6 +1201,61 @@ describe('@fluojs/mongoose', () => {
     });
   });
 
+  it('tracks delegated startup before same-turn shutdown snapshots lifecycle work', async () => {
+    const events: string[] = [];
+    let releaseTransactionStartup!: () => void;
+    const transactionStartupReleased = new Promise<void>((resolve) => {
+      releaseTransactionStartup = resolve;
+    });
+    const session = createFakeSession(events);
+
+    const connection: MongooseConnectionLike = {
+      async transaction(fn) {
+        events.push('connection:transaction:start');
+        await transactionStartupReleased;
+
+        try {
+          return await fn(session);
+        } finally {
+          await session.endSession();
+          events.push('connection:transaction:cleanup');
+        }
+      },
+    };
+
+    const mongoose = new MongooseConnection<typeof connection>(connection, () => {
+      events.push('dispose');
+    });
+    const requestTransaction = mongoose.requestTransaction(async () => {
+      events.push('request:work');
+      return 'late-result';
+    });
+    const shutdownPromise = mongoose.onApplicationShutdown();
+
+    try {
+      await expect(requestTransaction).rejects.toThrow('Application shutdown interrupted an open request transaction.');
+      await Promise.resolve();
+
+      expect(events).toEqual(['connection:transaction:start']);
+      expect(mongoose.createPlatformStatusSnapshot()).toMatchObject({
+        details: {
+          activeSessions: 1,
+          lifecycleState: 'shutting-down',
+        },
+      });
+    } finally {
+      releaseTransactionStartup();
+      await Promise.allSettled([requestTransaction, shutdownPromise]);
+    }
+
+    expect(events).toEqual([
+      'connection:transaction:start',
+      'session:end',
+      'connection:transaction:cleanup',
+      'dispose',
+    ]);
+  });
+
   it('rejects new manual and request transactions after shutdown begins', async () => {
     const events: string[] = [];
     let resolveDisposeStarted!: () => void;

--- a/packages/mongoose/src/public-api.test.ts
+++ b/packages/mongoose/src/public-api.test.ts
@@ -5,6 +5,7 @@ import type {
   MongooseAsyncModuleOptions,
   MongooseConnectionLike,
   MongooseHandleProvider,
+  MongooseModelFacade,
   MongoosePlatformStatusSnapshotInput,
 } from './index.js';
 
@@ -35,5 +36,10 @@ describe('@fluojs/mongoose public API surface', () => {
     expectTypeOf<MongoosePlatformStatusSnapshotInput>().toHaveProperty('lifecycleState');
     expectTypeOf<MongoosePlatformStatusSnapshotInput>().toHaveProperty('supportsStartSession');
     expectTypeOf<MongooseHandleProvider<MongooseConnectionLike>>().toHaveProperty('model');
+    expectTypeOf<MongooseModelFacade['create']>().toBeFunction();
+    expectTypeOf<MongooseModelFacade['find']>().toBeFunction();
+    expectTypeOf<MongooseModelFacade['findOne']>().toBeFunction();
+    expectTypeOf<MongooseModelFacade['aggregate']>().toBeFunction();
+    expectTypeOf<MongooseModelFacade['bulkWrite']>().toBeFunction();
   });
 });

--- a/packages/mongoose/src/public-api.test.ts
+++ b/packages/mongoose/src/public-api.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
 
-import * as mongoosePublicApi from './index.js';
 import type {
   MongooseAsyncModuleOptions,
   MongooseConnectionLike,
@@ -8,6 +7,24 @@ import type {
   MongooseModelFacade,
   MongoosePlatformStatusSnapshotInput,
 } from './index.js';
+import * as mongoosePublicApi from './index.js';
+
+type UserRecord = {
+  readonly id: string;
+  readonly name: string;
+};
+
+type UserModelFacade = MongooseModelFacade<
+  Promise<readonly UserRecord[]>,
+  Promise<readonly UserRecord[]>,
+  Promise<UserRecord | null>,
+  Promise<readonly { readonly count: number }[]>,
+  Promise<{ readonly acknowledged: boolean }>
+>;
+
+function resolveTypedUserModel(handle: MongooseHandleProvider): UserModelFacade {
+  return handle.model<UserModelFacade>('User');
+}
 
 describe('@fluojs/mongoose public API surface', () => {
   it('keeps documented supported root-barrel exports', () => {
@@ -41,5 +58,15 @@ describe('@fluojs/mongoose public API surface', () => {
     expectTypeOf<MongooseModelFacade['findOne']>().toBeFunction();
     expectTypeOf<MongooseModelFacade['aggregate']>().toBeFunction();
     expectTypeOf<MongooseModelFacade['bulkWrite']>().toBeFunction();
+    expectTypeOf<ReturnType<UserModelFacade['create']>>().toEqualTypeOf<Promise<readonly UserRecord[]>>();
+    expectTypeOf<ReturnType<UserModelFacade['find']>>().toEqualTypeOf<Promise<readonly UserRecord[]>>();
+    expectTypeOf<ReturnType<UserModelFacade['findOne']>>().toEqualTypeOf<Promise<UserRecord | null>>();
+    expectTypeOf<ReturnType<UserModelFacade['aggregate']>>().toEqualTypeOf<
+      Promise<readonly { readonly count: number }[]>
+    >();
+    expectTypeOf<ReturnType<UserModelFacade['bulkWrite']>>().toEqualTypeOf<
+      Promise<{ readonly acknowledged: boolean }>
+    >();
+    expectTypeOf<ReturnType<typeof resolveTypedUserModel>>().toEqualTypeOf<UserModelFacade>();
   });
 });

--- a/packages/mongoose/src/transaction-decorator.red.test.ts
+++ b/packages/mongoose/src/transaction-decorator.red.test.ts
@@ -56,13 +56,12 @@ function createFakeConnection(
     model(name: string) {
       return {
         async create(...args: unknown[]) {
-          const maybeOptions = args.at(-1);
-          const opts =
-            maybeOptions && typeof maybeOptions === 'object' && 'session' in maybeOptions
-              ? (maybeOptions as TestMongooseOperationOptions)
-              : undefined;
-          const docs = opts ? args.slice(0, -1) : args;
-          const createdDocs = docs.length === 1 && Array.isArray(docs[0]) ? docs[0] : docs;
+          const hasArrayOptions = args.length === 2 && Array.isArray(args[0]);
+          const maybeOptions = hasArrayOptions ? args[1] : undefined;
+          const opts = maybeOptions && typeof maybeOptions === 'object'
+            ? (maybeOptions as TestMongooseOperationOptions)
+            : undefined;
+          const createdDocs: unknown[] = hasArrayOptions && Array.isArray(args[0]) ? args[0] : args;
 
           events.push(`model:${name}:create:session=${opts?.session != null ? 'set' : 'unset'}`);
           events.push(`model:${name}:create:docs=${createdDocs.length}`);
@@ -313,7 +312,7 @@ describe('@fluojs/mongoose Transaction decorator contract (RED - pending Task 9 
       }
     });
 
-    it('model.create(docA, docB) preserves multiple document arguments while adding ambient session', async () => {
+    it('model.create(docA, docB) preserves positional documents without appending ambient session options', async () => {
       const mongoosePackage = await import('./index.js');
       const ExportedTransaction = (mongoosePackage as { Transaction?: unknown }).Transaction;
 
@@ -355,7 +354,7 @@ describe('@fluojs/mongoose Transaction decorator contract (RED - pending Task 9 
 
       try {
         await expect(service.createMany()).resolves.toEqual([{ name: 'Ada' }, { name: 'Grace' }]);
-        expect(events).toContain('model:User:create:session=set');
+        expect(events).toContain('model:User:create:session=unset');
         expect(events).toContain('model:User:create:docs=2');
       } finally {
         await app.close();
@@ -407,7 +406,7 @@ describe('@fluojs/mongoose Transaction decorator contract (RED - pending Task 9 
           { name: 'Ada' },
           { name: 'Grace', session: 'domain-field' },
         ]);
-        expect(events).toContain('model:User:create:session=set');
+        expect(events).toContain('model:User:create:session=unset');
         expect(events).toContain('model:User:create:docs=2');
       } finally {
         await app.close();
@@ -459,7 +458,7 @@ describe('@fluojs/mongoose Transaction decorator contract (RED - pending Task 9 
           { name: 'Ada' },
           { name: 'Grace', session: null },
         ]);
-        expect(events).toContain('model:User:create:session=set');
+        expect(events).toContain('model:User:create:session=unset');
         expect(events).toContain('model:User:create:docs=2');
       } finally {
         await app.close();
@@ -512,7 +511,7 @@ describe('@fluojs/mongoose Transaction decorator contract (RED - pending Task 9 
           { name: 'Ada' },
           { name: 'Grace', session: domainSession },
         ]);
-        expect(events).toContain('model:User:create:session=set');
+        expect(events).toContain('model:User:create:session=unset');
         expect(events).toContain('model:User:create:docs=2');
       } finally {
         await app.close();
@@ -532,6 +531,7 @@ describe('@fluojs/mongoose Transaction decorator contract (RED - pending Task 9 
         }),
       ).resolves.toEqual([{ name: 'Ada' }, { name: 'Grace', timestamps: false }]);
 
+      expect(events).toContain('model:User:create:session=unset');
       expect(events).toContain('model:User:create:docs=2');
     });
 

--- a/packages/mongoose/src/transaction-decorator.red.test.ts
+++ b/packages/mongoose/src/transaction-decorator.red.test.ts
@@ -62,13 +62,14 @@ function createFakeConnection(
               ? (maybeOptions as TestMongooseOperationOptions)
               : undefined;
           const docs = opts ? args.slice(0, -1) : args;
+          const createdDocs = docs.length === 1 && Array.isArray(docs[0]) ? docs[0] : docs;
 
           events.push(`model:${name}:create:session=${opts?.session != null ? 'set' : 'unset'}`);
-          events.push(`model:${name}:create:docs=${docs.length}`);
+          events.push(`model:${name}:create:docs=${createdDocs.length}`);
           if (opts && 'timestamps' in opts) {
             events.push(`model:${name}:create:timestamps=${String(opts.timestamps)}`);
           }
-          return docs;
+          return createdDocs;
         },
         async find(_filter?: unknown, projection?: unknown, opts?: TestMongooseOperationOptions) {
           if (projection && typeof projection === 'object' && 'session' in projection) {
@@ -158,6 +159,55 @@ describe('@fluojs/mongoose Transaction decorator contract (RED - pending Task 9 
         expect(events).toContain('service:createUser:session=set');
         expect(events).toContain('transaction:commit');
         expect(events).toContain('session:end');
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('preserves delegated connection.transaction ambient and facade sessions for @Transaction()', async () => {
+      const events: string[] = [];
+      const session = createFakeSession(events);
+      const modelConnection = createFakeConnection(events, session);
+      const connection = {
+        model: modelConnection.model,
+        async transaction<T>(fn: (currentSession: MongooseSessionLike) => Promise<T>): Promise<T> {
+          events.push('connection:transaction:start');
+          const result = await fn(session);
+          events.push('connection:transaction:end');
+          return result;
+        },
+      };
+
+      @Inject(MongooseConnection)
+      class UserService {
+        constructor(private readonly conn: MongooseConnection<typeof connection>) {}
+
+        @Transaction()
+        async createUser(name: string) {
+          events.push(`service:session=${this.conn.currentSession() === session ? 'set' : 'unset'}`);
+          return this.conn.model('User').create([{ name }]);
+        }
+      }
+
+      class AppModule {}
+
+      defineModule(AppModule, {
+        imports: [MongooseModule.forRoot({ connection })],
+        providers: [UserService],
+      });
+
+      const app = await bootstrapApplication({ rootModule: AppModule });
+      const service = await app.container.resolve(UserService);
+
+      try {
+        await expect(service.createUser('Ada')).resolves.toEqual([{ name: 'Ada' }]);
+        expect(events).toEqual([
+          'connection:transaction:start',
+          'service:session=set',
+          'model:User:create:session=set',
+          'model:User:create:docs=1',
+          'connection:transaction:end',
+        ]);
       } finally {
         await app.close();
       }
@@ -255,11 +305,12 @@ describe('@fluojs/mongoose Transaction decorator contract (RED - pending Task 9 
       const app = await bootstrapApplication({ rootModule: AppModule });
       const service = await app.container.resolve(UserService);
 
-      await service.create('Ada');
-
-      expect(events).toContain('model:User:create:session=set');
-
-      await app.close();
+      try {
+        await service.create('Ada');
+        expect(events).toContain('model:User:create:session=set');
+      } finally {
+        await app.close();
+      }
     });
 
     it('model.create(docA, docB) preserves multiple document arguments while adding ambient session', async () => {
@@ -302,11 +353,13 @@ describe('@fluojs/mongoose Transaction decorator contract (RED - pending Task 9 
       const app = await bootstrapApplication({ rootModule: AppModule });
       const service = await app.container.resolve(UserService);
 
-      await expect(service.createMany()).resolves.toEqual([{ name: 'Ada' }, { name: 'Grace' }]);
-      expect(events).toContain('model:User:create:session=set');
-      expect(events).toContain('model:User:create:docs=2');
-
-      await app.close();
+      try {
+        await expect(service.createMany()).resolves.toEqual([{ name: 'Ada' }, { name: 'Grace' }]);
+        expect(events).toContain('model:User:create:session=set');
+        expect(events).toContain('model:User:create:docs=2');
+      } finally {
+        await app.close();
+      }
     });
 
     it('model.create(docA, docB) treats a document session field as data, not operation options', async () => {
@@ -466,7 +519,23 @@ describe('@fluojs/mongoose Transaction decorator contract (RED - pending Task 9 
       }
     });
 
-    it('model.create(doc, options) merges the ambient session into existing single-document options', async () => {
+    it('model.create(docA, docB) treats an option-like timestamps field on the last document as data', async () => {
+      const events: string[] = [];
+      const session = createFakeSession(events);
+      const connection = createFakeConnection(events, session);
+      const mongoose = new MongooseConnection<typeof connection>(connection);
+
+      await expect(
+        mongoose.transaction(async () => {
+          const User = mongoose.model('User') as ReturnType<typeof connection.model>;
+          return User.create({ name: 'Ada' }, { name: 'Grace', timestamps: false });
+        }),
+      ).resolves.toEqual([{ name: 'Ada' }, { name: 'Grace', timestamps: false }]);
+
+      expect(events).toContain('model:User:create:docs=2');
+    });
+
+    it('model.create([doc], options) merges the ambient session into array-form create options', async () => {
       const mongoosePackage = await import('./index.js');
       const ExportedTransaction = (mongoosePackage as { Transaction?: unknown }).Transaction;
 
@@ -482,7 +551,7 @@ describe('@fluojs/mongoose Transaction decorator contract (RED - pending Task 9 
 
         async createOne() {
           const User = this.conn.model('User') as ReturnType<typeof connection.model>;
-          return User.create({ name: 'Ada' }, { timestamps: false });
+          return User.create([{ name: 'Ada' }], { timestamps: false });
         }
       }
 
@@ -516,7 +585,7 @@ describe('@fluojs/mongoose Transaction decorator contract (RED - pending Task 9 
       }
     });
 
-    it('model.create(doc, {}) treats an empty second argument as single-document options', async () => {
+    it('model.create([doc], {}) treats an empty second argument as array-form create options', async () => {
       const mongoosePackage = await import('./index.js');
       const ExportedTransaction = (mongoosePackage as { Transaction?: unknown }).Transaction;
 
@@ -532,7 +601,7 @@ describe('@fluojs/mongoose Transaction decorator contract (RED - pending Task 9 
 
         async createOne() {
           const User = this.conn.model('User') as ReturnType<typeof connection.model>;
-          return User.create({ name: 'Ada' }, {});
+          return User.create([{ name: 'Ada' }], {});
         }
       }
 
@@ -556,11 +625,13 @@ describe('@fluojs/mongoose Transaction decorator contract (RED - pending Task 9 
       const app = await bootstrapApplication({ rootModule: AppModule });
       const service = await app.container.resolve(UserService);
 
-      await expect(service.createOne()).resolves.toEqual([{ name: 'Ada' }]);
-      expect(events).toContain('model:User:create:session=set');
-      expect(events).toContain('model:User:create:docs=1');
-
-      await app.close();
+      try {
+        await expect(service.createOne()).resolves.toEqual([{ name: 'Ada' }]);
+        expect(events).toContain('model:User:create:session=set');
+        expect(events).toContain('model:User:create:docs=1');
+      } finally {
+        await app.close();
+      }
     });
 
     it('model.find() receives the ambient session inside @Transaction()', async () => {
@@ -1022,7 +1093,7 @@ describe('@fluojs/mongoose Transaction decorator contract (RED - pending Task 9 
       }
     });
 
-    it('throws when model.create(doc, { session: null }) uses session-only single-document options', async () => {
+    it('throws when model.create([doc], { session: null }) uses array-form create options', async () => {
       const mongoosePackage = await import('./index.js');
       const ExportedTransaction = (mongoosePackage as { Transaction?: unknown }).Transaction;
 
@@ -1038,7 +1109,7 @@ describe('@fluojs/mongoose Transaction decorator contract (RED - pending Task 9 
 
         async create(name: string) {
           const User = this.conn.model('User') as ReturnType<typeof connection.model>;
-          return User.create({ name }, { session: null });
+          return User.create([{ name }], { session: null });
         }
       }
 
@@ -1120,6 +1191,39 @@ describe('@fluojs/mongoose Transaction decorator contract (RED - pending Task 9 
       } finally {
         await app.close();
       }
+    });
+
+    it('throws when model.findOne() receives { session: null } as the third options argument', async () => {
+      const events: string[] = [];
+      const session = createFakeSession(events);
+      const connection = createFakeConnection(events, session);
+      const mongoose = new MongooseConnection<typeof connection>(connection);
+
+      await expect(
+        mongoose.transaction(async () => {
+          const User = mongoose.model('User') as ReturnType<typeof connection.model>;
+          return User.findOne({ _id: 'user-1' }, { name: 1 }, { session: null });
+        }),
+      ).rejects.toThrow('Explicit session: null conflicts with ambient transaction session');
+
+      expect(events).not.toContain('model:User:findOne:session=set');
+    });
+
+    it('throws when model.findOne() receives a different session as the third options argument', async () => {
+      const events: string[] = [];
+      const session = createFakeSession(events);
+      const differentSession = createFakeSession([]);
+      const connection = createFakeConnection(events, session);
+      const mongoose = new MongooseConnection<typeof connection>(connection);
+
+      await expect(
+        mongoose.transaction(async () => {
+          const User = mongoose.model('User') as ReturnType<typeof connection.model>;
+          return User.findOne({ _id: 'user-1' }, { name: 1 }, { session: differentSession });
+        }),
+      ).rejects.toThrow('Explicit session conflicts with ambient transaction session');
+
+      expect(events).not.toContain('model:User:findOne:session=set');
     });
 
     it('throws when model.aggregate() receives { session: null } as operation options', async () => {
@@ -1347,7 +1451,7 @@ describe('@fluojs/mongoose Transaction decorator contract (RED - pending Task 9 
           // Passing a different session object is a session conflict
           const User = this.conn.model('User') as ReturnType<typeof connection.model>;
           return User.create([{ name }], {
-            session: differentSession as unknown as MongooseSessionLike,
+            session: differentSession,
           });
         }
       }
@@ -1372,12 +1476,14 @@ describe('@fluojs/mongoose Transaction decorator contract (RED - pending Task 9 
       const app = await bootstrapApplication({ rootModule: AppModule });
       const service = await app.container.resolve(UserService);
 
-      await expect(service.create('Ada')).rejects.toThrow('Explicit session conflicts with ambient transaction session');
-
-      await app.close();
+      try {
+        await expect(service.create('Ada')).rejects.toThrow('Explicit session conflicts with ambient transaction session');
+      } finally {
+        await app.close();
+      }
     });
 
-    it('throws when model.create(doc, { session }) uses different session-only single-document options', async () => {
+    it('throws when model.create([doc], { session }) uses different array-form create options', async () => {
       const mongoosePackage = await import('./index.js');
       const ExportedTransaction = (mongoosePackage as { Transaction?: unknown }).Transaction;
 
@@ -1394,7 +1500,7 @@ describe('@fluojs/mongoose Transaction decorator contract (RED - pending Task 9 
 
         async create(name: string) {
           const User = this.conn.model('User') as ReturnType<typeof connection.model>;
-          return User.create({ name }, { session: differentSession });
+          return User.create([{ name }], { session: differentSession });
         }
       }
 
@@ -1470,10 +1576,12 @@ describe('@fluojs/mongoose Transaction decorator contract (RED - pending Task 9 
       const app = await bootstrapApplication({ rootModule: AppModule });
       const service = await app.container.resolve(UserService);
 
-    await expect(service.create('Ada')).resolves.toBeDefined();
-
-    await app.close();
-  });
+      try {
+        await expect(service.create('Ada')).resolves.toBeDefined();
+      } finally {
+        await app.close();
+      }
+    });
   });
 });
 
@@ -1584,13 +1692,15 @@ describe('@fluojs/mongoose Transaction decorator — named/accessor contract', (
     const app = await bootstrapApplication({ rootModule: AppModule });
     const service = await app.container.resolve(DualConnectionService);
 
-    await service.analyticsWork();
-    await service.primaryWork();
+    try {
+      await service.analyticsWork();
+      await service.primaryWork();
 
-    expect(analyticsEvents).toContain('analytics:transaction:start');
-    expect(primaryEvents).not.toContain('connection:startSession');
-    expect(primaryEvents).toContain('service:primaryWork');
-
-    await app.close();
+      expect(analyticsEvents).toContain('analytics:transaction:start');
+      expect(primaryEvents).not.toContain('connection:startSession');
+      expect(primaryEvents).toContain('service:primaryWork');
+    } finally {
+      await app.close();
+    }
   });
 });

--- a/packages/mongoose/src/types.ts
+++ b/packages/mongoose/src/types.ts
@@ -23,6 +23,27 @@ export interface MongooseSessionLike {
 }
 
 /**
+ * Callable model facade returned by `MongooseConnection.model(...)`.
+ *
+ * @remarks
+ * The listed operations receive the ambient transaction session automatically when called inside a transaction boundary.
+ * Other model properties remain available as `unknown` because fluo does not own application schema or plugin typing.
+ */
+export interface MongooseModelFacade {
+  /** Runs a Mongoose aggregate operation with ambient session options. */
+  aggregate(...args: unknown[]): unknown;
+  /** Runs a Mongoose bulk-write operation with ambient session options. */
+  bulkWrite(...args: unknown[]): unknown;
+  /** Runs a Mongoose create operation with ambient session options. */
+  create(...args: unknown[]): unknown;
+  /** Runs a Mongoose find operation with ambient session options. */
+  find(...args: unknown[]): unknown;
+  /** Runs a Mongoose find-one operation with ambient session options. */
+  findOne(...args: unknown[]): unknown;
+  readonly [key: PropertyKey]: unknown;
+}
+
+/**
  * Module options for registering a Mongoose connection and optional shutdown disposal hook.
  *
  * @typeParam TConnection Root Mongoose connection shape registered in the module.
@@ -61,7 +82,7 @@ export interface MongooseHandleProvider<TConnection extends MongooseConnectionLi
    * @param args Additional model resolver arguments forwarded unchanged.
    * @returns The root model outside transactions, or a model facade inside an active transaction boundary.
    */
-  model(name: string, ...args: unknown[]): Record<PropertyKey, unknown>;
+  model(name: string, ...args: unknown[]): MongooseModelFacade;
   /**
    * Opens a Mongoose session transaction boundary around `fn`.
    *

--- a/packages/mongoose/src/types.ts
+++ b/packages/mongoose/src/types.ts
@@ -28,18 +28,30 @@ export interface MongooseSessionLike {
  * @remarks
  * The listed operations receive the ambient transaction session automatically when called inside a transaction boundary.
  * Other model properties remain available as `unknown` because fluo does not own application schema or plugin typing.
+ *
+ * @typeParam TCreateResult Result returned by `create(...)`.
+ * @typeParam TFindResult Result returned by `find(...)`.
+ * @typeParam TFindOneResult Result returned by `findOne(...)`.
+ * @typeParam TAggregateResult Result returned by `aggregate(...)`.
+ * @typeParam TBulkWriteResult Result returned by `bulkWrite(...)`.
  */
-export interface MongooseModelFacade {
+export interface MongooseModelFacade<
+  TCreateResult = unknown,
+  TFindResult = unknown,
+  TFindOneResult = unknown,
+  TAggregateResult = unknown,
+  TBulkWriteResult = unknown,
+> {
   /** Runs a Mongoose aggregate operation with ambient session options. */
-  aggregate(...args: unknown[]): unknown;
+  aggregate(...args: unknown[]): TAggregateResult;
   /** Runs a Mongoose bulk-write operation with ambient session options. */
-  bulkWrite(...args: unknown[]): unknown;
+  bulkWrite(...args: unknown[]): TBulkWriteResult;
   /** Runs a Mongoose create operation with ambient session options. */
-  create(...args: unknown[]): unknown;
+  create(...args: unknown[]): TCreateResult;
   /** Runs a Mongoose find operation with ambient session options. */
-  find(...args: unknown[]): unknown;
+  find(...args: unknown[]): TFindResult;
   /** Runs a Mongoose find-one operation with ambient session options. */
-  findOne(...args: unknown[]): unknown;
+  findOne(...args: unknown[]): TFindOneResult;
   readonly [key: PropertyKey]: unknown;
 }
 
@@ -82,7 +94,7 @@ export interface MongooseHandleProvider<TConnection extends MongooseConnectionLi
    * @param args Additional model resolver arguments forwarded unchanged.
    * @returns The root model outside transactions, or a model facade inside an active transaction boundary.
    */
-  model(name: string, ...args: unknown[]): MongooseModelFacade;
+  model<TModel extends MongooseModelFacade = MongooseModelFacade>(name: string, ...args: unknown[]): TModel;
   /**
    * Opens a Mongoose session transaction boundary around `fn`.
    *

--- a/packages/mongoose/src/vertical-slice.test.ts
+++ b/packages/mongoose/src/vertical-slice.test.ts
@@ -12,7 +12,7 @@ import { bootstrapApplication, defineModule } from '@fluojs/runtime';
 import { describe, expect, it } from 'vitest';
 
 import { MongooseConnection, MongooseModule, Transaction } from './index.js';
-import type { MongooseSessionLike } from './types.js';
+import type { MongooseModelFacade, MongooseSessionLike } from './types.js';
 
 function createResponse(events?: string[]): FrameworkResponse & { body?: unknown } {
   return {
@@ -68,6 +68,7 @@ describe('@fluojs/mongoose service boundary primary flow', () => {
       id: string;
       name: string;
     };
+    type UserCreateModel = MongooseModelFacade<Promise<readonly [UserRecord]>>;
 
     const users = new Map<string, UserRecord>();
     const events: string[] = [];
@@ -93,12 +94,16 @@ describe('@fluojs/mongoose service boundary primary flow', () => {
     }
 
     const UserModel = {
-      async create(input: { email: string; name: string }, options?: { session?: MongooseSessionLike }) {
+      async create(
+        inputs: readonly [{ email: string; name: string }],
+        options?: { session?: MongooseSessionLike },
+      ) {
+        const [input] = inputs;
         events.push(`model:create:${input.email}`);
         createSessions.push(options?.session);
         const record = { ...input, id: `user-${++sequence}` };
         users.set(record.id, record);
-        return record;
+        return [record] as const;
       },
     };
 
@@ -128,10 +133,14 @@ describe('@fluojs/mongoose service boundary primary flow', () => {
       constructor(private readonly conn: MongooseConnection<typeof connection>) {}
 
       async create(input: CreateUserRequest) {
-        return (this.conn.model('User') as typeof UserModel).create({
-          email: input.email,
-          name: input.name,
-        });
+        const [record] = await this.conn.model<UserCreateModel>('User').create([
+          {
+            email: input.email,
+            name: input.name,
+          },
+        ]);
+
+        return record;
       }
     }
 
@@ -192,6 +201,9 @@ describe('@fluojs/mongoose service boundary primary flow', () => {
   });
 
   it('keeps controller-level method decoration as a compatibility path only', async () => {
+    type UserRecord = { email: string; id: string; name: string };
+    type UserCreateModel = MongooseModelFacade<Promise<readonly [UserRecord]>>;
+
     const events: string[] = [];
     const createSessions: Array<MongooseSessionLike | undefined> = [];
     const startedSessions: MongooseSessionLike[] = [];
@@ -214,10 +226,11 @@ describe('@fluojs/mongoose service boundary primary flow', () => {
     }
 
     const UserModel = {
-      async create(input: { email: string; name: string }, options?: { session?: MongooseSessionLike }) {
+      async create(inputs: readonly [CreateUserRequest], options?: { session?: MongooseSessionLike }) {
+        const [input] = inputs;
         events.push(`model:create:${input.email}`);
         createSessions.push(options?.session);
-        return { ...input, id: 'controller-tx-user' };
+        return [{ email: input.email, id: 'controller-tx-user', name: input.name }] as const;
       },
     };
 
@@ -247,7 +260,9 @@ describe('@fluojs/mongoose service boundary primary flow', () => {
       constructor(private readonly conn: MongooseConnection<typeof connection>) {}
 
       async create(input: CreateUserRequest) {
-        return (this.conn.model('User') as typeof UserModel).create(input);
+        const [record] = await this.conn.model<UserCreateModel>('User').create([input]);
+
+        return record;
       }
     }
 


### PR DESCRIPTION
## Summary

Harden the documented `@fluojs/mongoose` transaction lifecycle, overload handling, and public facade typing.

Linked context: https://github.com/fluojs/fluo/issues/2513

Closes #2513

## Changes

- Drain an already-started request callback before aborting/ending its session or running `dispose(connection)`, while preserving the abort result.
- Detect `create()` options only for the Mongoose array overload so positional documents with option-like fields remain documents.
- Export a TSDoc-covered callable `MongooseModelFacade` for `create`, `find`, `findOne`, `aggregate`, and `bulkWrite`.
- Add delegated `connection.transaction(...)`, `findOne` third-options conflict, callback drain, and finally-based teardown regressions.
- Synchronize package README and Chapter 19 English/Korean guidance.

## Testing

Passed:
- changed-file LSP diagnostics for all modified TypeScript files
- `pnpm --filter @fluojs/mongoose... build`
- `pnpm --filter @fluojs/mongoose typecheck`
- `pnpm --filter @fluojs/mongoose test` (85 passed, 1 intentionally skipped)
- scoped Biome lint and `pnpm lint` / changed public-export TSDoc gate
- `pnpm verify:platform-consistency-governance`
- `pnpm docs:sync-check`
- `pnpm exec vitest run --project packages --maxWorkers=4` (267 files, 3782 passed, 1 intentionally skipped)
- apps/examples/tooling Vitest projects with `--maxWorkers=4`
- `pnpm --dir packages/cli sandbox:matrix`
- release-readiness static checks (15 passed)
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main`
- `pnpm changeset status --since=origin/main` (`@fluojs/mongoose` patch)

Canonical full-concurrency attempts:
- `pnpm verify` was attempted twice; each run reached 4020 passing tests and then hit a different unrelated CLI timeout. Both timed-out tests passed when rerun alone.
- `pnpm verify:release-readiness` reached the package suite but hit unrelated microservices/CLI concurrency timeouts; those tests passed alone, and the full package project passed with `--maxWorkers=4`.

## Release impact

- [x] This PR has consumer-visible release impact and includes `.changeset/mongoose-callback-facade-contracts.md` with a patch bump for `@fluojs/mongoose`.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source documentation and README/book examples remain complementary.

`MongooseModelFacade` is documented at its declaration and verified by the changed public-export TSDoc gate.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] Corrected lifecycle and overload contracts are documented in both package README mirrors.
- [x] Intentional `doc.save()` and unsupported-method limitations remain explicit.
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] English/Korean package and book mirrors remain synchronized.
- [x] No platform adapter contract changed; the platform consistency governance verifier passed.
- [x] Contract claims are backed by package lifecycle and facade regressions.
