### PR TITLE
Resolve #2533: Replace unsupported Node-only Deno testing guidance

### DIFF
--- a/book/intermediate/ch23-deno.ko.md
+++ b/book/intermediate/ch23-deno.ko.md
@@ -1,4 +1,4 @@
-<!-- packages: @fluojs/platform-deno, @fluojs/runtime, @fluojs/http, @fluojs/testing -->
+<!-- packages: @fluojs/platform-deno, @fluojs/runtime, @fluojs/http -->
 <!-- project-state: FluoShop v2.5.0 -->
 
 # Chapter 23. Porting to Deno
@@ -58,10 +58,10 @@ await runDenoApplication(AppModule, {
 이 애플리케이션을 실행하려면 필요한 권한을 명시적으로 제공해야 합니다. Deno에서는 이 권한 목록이 운영 계약의 일부가 됩니다.
 
 ```bash
-deno run --allow-net --allow-read --allow-env main.ts
+deno run --allow-net --allow-env main.ts
 ```
 
-플래그를 빠뜨리면 Deno는 실행 시 프롬프트를 띄우거나 명확한 에러와 함께 종료합니다. 권한 누락은 배포 전에 드러나는 설정 문제로 다루는 편이 안전합니다. 따라서 실행 명령 자체가 애플리케이션이 접근할 수 있는 리소스를 설명하는 문서 역할을 합니다.
+플래그를 빠뜨리면 Deno는 실행 시 프롬프트를 띄우거나 명확한 에러와 함께 종료합니다. 권한 누락은 배포 전에 드러나는 설정 문제로 다루는 편이 안전합니다. 따라서 실행 명령 자체가 애플리케이션이 접근할 수 있는 리소스를 설명하는 문서 역할을 합니다. Canonical starter에는 파일 시스템 접근이 필요하지 않으므로 `--allow-read`를 부여하지 않습니다. 애플리케이션 코드가 인증서, 설정 파일, 정적 자산을 실제로 읽을 때만 `--allow-read=./static`처럼 대상 경로를 한정한 권한을 추가하세요.
 
 ## 23.3 Web Standards and Request Dispatching
 
@@ -211,24 +211,29 @@ import { Client } from "https://deno.land/x/postgres/mod.ts";
 
 ## 23.9 Testing in Deno
 
-Deno의 내장 테스트 러너는 별도 Jest나 Vitest 의존성 없이 사용할 수 있습니다. fluo 테스트 유틸리티를 `Deno.test`와 함께 사용할 때는 권한 플래그와 임포트 경로까지 테스트 환경에 포함하세요. 운영 실행과 같은 권한 모델로 테스트하면 배포 전에 런타임 제약을 더 일찍 확인할 수 있습니다. 라우트 수준 단언에는 `@fluojs/testing`의 `createTestApp({ rootModule })`을 사용하고, HTTP 디스패치 없이 DI와 lifecycle hook만 필요한 테스트에는 `fluoFactory.createApplicationContext(AppModule)`을 사용하세요.
+Deno의 내장 테스트 러너는 별도 Jest나 Vitest 의존성 없이 사용할 수 있습니다. 배포된 `@fluojs/testing` 패키지는 `engines.node >=20.0.0`을 선언하므로 Deno 테스트 경로에서 import하지 마세요. 대신 `Deno.test`, Deno 표준 assertion 라이브러리, public Deno fetch handler를 조합하면 서버를 시작하지 않고 실제 Web `Request`에서 `Response`까지의 경계를 검증할 수 있습니다.
 
 ```typescript
-import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
-import { createTestApp } from "npm:@fluojs/testing";
+import { assertEquals } from "jsr:@std/assert";
+import { createDenoAdapter, createDenoFetchHandler } from "npm:@fluojs/platform-deno";
+import { fluoFactory } from "npm:@fluojs/runtime";
 import { AppModule } from "./app.module.ts";
 
 Deno.test("ProductService should return products", async () => {
-  const app = await createTestApp({ rootModule: AppModule });
+  const adapter = createDenoAdapter();
+  const app = await fluoFactory.create(AppModule, { adapter });
+  const handler = createDenoFetchHandler({ dispatcher: app.dispatcher });
 
   try {
-    const response = await app.request("GET", "/api/v1/products").send();
+    const response = await handler(new Request("http://localhost/api/v1/products"));
     assertEquals(response.status, 200);
   } finally {
     await app.close();
   }
 });
 ```
+
+이 테스트는 process 내부에서 dispatch하므로 파일 시스템 권한이 필요하지 않습니다. `--allow-read` 없이 실행하세요. Import된 애플리케이션 그래프가 환경 변수를 읽거나 외부 서비스에 연결한다면 `deno test --allow-env=DATABASE_URL --allow-net=database.host:5432`처럼 필요한 key나 destination만 허용하세요. Fixture를 의도적으로 읽는 테스트라면 `--allow-read=./test/fixtures`처럼 fixture 경로에만 한정된 권한을 추가할 수 있습니다.
 
 ## 23.10 Summary: The Deno Advantage
 

--- a/book/intermediate/ch23-deno.md
+++ b/book/intermediate/ch23-deno.md
@@ -1,4 +1,4 @@
-<!-- packages: @fluojs/platform-deno, @fluojs/runtime, @fluojs/http, @fluojs/testing -->
+<!-- packages: @fluojs/platform-deno, @fluojs/runtime, @fluojs/http -->
 <!-- project-state: FluoShop v2.5.0 -->
 
 # Chapter 23. Porting to Deno
@@ -58,10 +58,10 @@ await runDenoApplication(AppModule, {
 To run this application, you must explicitly provide the required permissions. In Deno, this permission list becomes part of the operational contract.
 
 ```bash
-deno run --allow-net --allow-read --allow-env main.ts
+deno run --allow-net --allow-env main.ts
 ```
 
-If a flag is missing, Deno prompts at runtime or exits with a clear error. It is safer to treat missing permissions as configuration problems that should surface before deployment. The run command itself becomes documentation for the resources the application is allowed to access.
+If a flag is missing, Deno prompts at runtime or exits with a clear error. It is safer to treat missing permissions as configuration problems that should surface before deployment. The run command itself becomes documentation for the resources the application is allowed to access. The canonical starter does not need filesystem access, so it does not grant `--allow-read`. Add a scoped grant such as `--allow-read=./static` only when application code actually reads certificates, configuration files, or static assets from that path.
 
 ## 23.3 Web Standards and Request Dispatching
 
@@ -211,24 +211,29 @@ import { Client } from "https://deno.land/x/postgres/mod.ts";
 
 ## 23.9 Testing in Deno
 
-Deno's built-in test runner can be used without separate Jest or Vitest dependencies. When using fluo testing utilities with `Deno.test`, include permission flags and import paths in the test environment as well. Use `createTestApp({ rootModule })` from `@fluojs/testing` for route-level assertions, or `fluoFactory.createApplicationContext(AppModule)` when the test only needs DI and lifecycle hooks without HTTP dispatch.
+Deno's built-in test runner can be used without separate Jest or Vitest dependencies. The published `@fluojs/testing` package declares `engines.node >=20.0.0`, so do not import it into the Deno test path. Instead, combine `Deno.test`, Deno's standard assertion library, and the public Deno fetch handler to exercise the real Web `Request` to `Response` boundary without starting a server.
 
 ```typescript
-import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
-import { createTestApp } from "npm:@fluojs/testing";
+import { assertEquals } from "jsr:@std/assert";
+import { createDenoAdapter, createDenoFetchHandler } from "npm:@fluojs/platform-deno";
+import { fluoFactory } from "npm:@fluojs/runtime";
 import { AppModule } from "./app.module.ts";
 
 Deno.test("ProductService should return products", async () => {
-  const app = await createTestApp({ rootModule: AppModule });
+  const adapter = createDenoAdapter();
+  const app = await fluoFactory.create(AppModule, { adapter });
+  const handler = createDenoFetchHandler({ dispatcher: app.dispatcher });
 
   try {
-    const response = await app.request("GET", "/api/v1/products").send();
+    const response = await handler(new Request("http://localhost/api/v1/products"));
     assertEquals(response.status, 200);
   } finally {
     await app.close();
   }
 });
 ```
+
+This test performs in-process dispatch and needs no filesystem permission. Run it without `--allow-read`; if the imported application graph reads environment variables or contacts an external service, grant only the required keys or destinations, for example `deno test --allow-env=DATABASE_URL --allow-net=database.host:5432`. Tests that intentionally load fixtures may add a fixture-only scope such as `--allow-read=./test/fixtures`.
 
 ## 23.10 Summary: The Deno Advantage
 


### PR DESCRIPTION
## Summary

Align the bilingual Deno learning path with the supported runtime boundary and the canonical starter permission set.

Linked context: Closes #2533

## Changes

- Replace the unsupported `@fluojs/testing` Deno example with `Deno.test`, `jsr:@std/assert`, and the public `createDenoFetchHandler(...)` path.
- State the `@fluojs/testing` Node.js `>=20.0.0` boundary explicitly.
- Remove the unconditional `--allow-read` grant from the starter command and document scoped read permissions for real filesystem or fixture access.
- Keep the English and Korean chapter mirrors synchronized.

## Testing

- `pnpm verify:platform-consistency-governance` — passed.
- `pnpm docs:sync-check` — passed.
- `pnpm verify:docs` — passed, including docs typecheck and production build.
- `pnpm vitest run packages/platform-deno/src/fetch-handler.test.ts` — passed (8 tests).
- Exact-scope Node assertions confirmed both chapters removed the unsupported import and broad permission command while retaining the required runtime boundary and scoped permission guidance.
- `git diff --check` — passed.
- Local Deno execution was not run because the Deno binary is unavailable in this environment; the documented handler pattern is covered by the package test above.

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact. It changes book documentation only, so no `.changeset/*.md` is required.

## Public export documentation

Not applicable: no package source or public exports changed. The chapter now consumes existing public exports within their documented runtime boundaries.

## Behavioral contract

- [x] No documented behavioral contracts were removed.
- [x] The existing Node-only `@fluojs/testing` limitation is stated explicitly.
- [x] The Deno-native fetch-handler example follows the existing public runtime contract.
- [x] No runtime implementation changed; package regression coverage remains green.

## Platform consistency governance (SSOT)

- [x] English/Korean chapter mirrors remain synchronized.
- [x] The Deno guidance matches the canonical starter `--allow-env --allow-net` baseline.
- [x] Scoped `--allow-read` guidance preserves least privilege without changing platform behavior.
- [x] `pnpm verify:platform-consistency-governance` passes.