### PR TITLE
Resolve #2535: Regenerate Cloudflare Workers published artifacts

### DIFF
--- a/.changeset/workers-published-artifact-parity.md
+++ b/.changeset/workers-published-artifact-parity.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/platform-cloudflare-workers": patch
+---
+
+Regenerate the published Cloudflare Workers runtime and declarations from current source so Worker request context, WebSocket binding freeze and close tracking, SSE draining, and shutdown timeout recovery reach package consumers.

--- a/packages/platform-cloudflare-workers/src/published-artifact-surface.test.ts
+++ b/packages/platform-cloudflare-workers/src/published-artifact-surface.test.ts
@@ -1,0 +1,80 @@
+import { execFile } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+import { beforeAll, describe, expect, it } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+const packageRootPath = fileURLToPath(new URL('..', import.meta.url));
+const repoRootPath = fileURLToPath(new URL('../../..', import.meta.url));
+const buildClosureScriptPath = fileURLToPath(
+  new URL('../../../tooling/scripts/run-workspace-build-closure.mjs', import.meta.url),
+);
+const requiredArtifactPaths = [
+  resolve(packageRootPath, 'dist/adapter.js'),
+  resolve(packageRootPath, 'dist/adapter.d.ts'),
+  resolve(packageRootPath, 'dist/index.d.ts'),
+] as const;
+
+describe('@fluojs/platform-cloudflare-workers published artifacts', () => {
+  beforeAll(async () => {
+    if (requiredArtifactPaths.every((artifactPath) => existsSync(artifactPath))) {
+      return;
+    }
+
+    await execFileAsync(process.execPath, [buildClosureScriptPath, '@fluojs/platform-cloudflare-workers'], {
+      cwd: repoRootPath,
+      env: process.env,
+    });
+  }, 300_000);
+
+  it('keeps the manifest-exported runtime aligned with the Worker lifecycle contract', () => {
+    // Given: the package manifest publishes its root runtime from dist/index.js.
+    const manifest: unknown = JSON.parse(readFileSync(resolve(packageRootPath, 'package.json'), 'utf8'));
+
+    expect(manifest).toMatchObject({
+      exports: {
+        '.': {
+          import: './dist/index.js',
+        },
+      },
+    });
+
+    // When: the generated runtime artifact is inspected.
+    const runtimeArtifact = readFileSync(resolve(packageRootPath, 'dist/adapter.js'), 'utf8');
+
+    // Then: it contains the request context, binding freeze, streaming drain, and timeout recovery behavior.
+    expect(runtimeArtifact).toContain('frameworkRequest.cloudflare = {');
+    expect(runtimeArtifact).toContain('Cloudflare Workers websocket binding must be configured before listen()');
+    expect(runtimeArtifact).toContain('createWebSocketCloseLifecycle');
+    expect(runtimeArtifact).toContain('createLifecycleTrackedResponse');
+    expect(runtimeArtifact).toContain('watchTimedOutCloseRecovery');
+  });
+
+  it('keeps the manifest-exported declarations aligned with the Worker public seam', () => {
+    // Given: the package manifest publishes its root declarations from dist/index.d.ts.
+    const manifest: unknown = JSON.parse(readFileSync(resolve(packageRootPath, 'package.json'), 'utf8'));
+
+    expect(manifest).toMatchObject({
+      exports: {
+        '.': {
+          types: './dist/index.d.ts',
+        },
+      },
+    });
+
+    // When: the generated declaration artifacts are inspected.
+    const rootDeclaration = readFileSync(resolve(packageRootPath, 'dist/index.d.ts'), 'utf8');
+    const adapterDeclaration = readFileSync(resolve(packageRootPath, 'dist/adapter.d.ts'), 'utf8');
+
+    // Then: the root reaches the current request context and lifecycle declarations.
+    expect(rootDeclaration).toContain("export * from './adapter.js';");
+    expect(adapterDeclaration).toContain('export interface CloudflareWorkerRequestContext<Env = unknown>');
+    expect(adapterDeclaration).toContain('readonly env: Env;');
+    expect(adapterDeclaration).toContain('readonly executionContext?: CloudflareWorkerExecutionContext;');
+    expect(adapterDeclaration).toContain('private isWebSocketBindingFrozen;');
+    expect(adapterDeclaration).toContain('private createRequestResponseFactory;');
+  });
+});

--- a/packages/platform-cloudflare-workers/src/published-artifact-surface.test.ts
+++ b/packages/platform-cloudflare-workers/src/published-artifact-surface.test.ts
@@ -1,9 +1,10 @@
 import { execFile } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { promisify } from 'node:util';
 
+import ts from 'typescript';
 import { beforeAll, describe, expect, it } from 'vitest';
 
 const execFileAsync = promisify(execFile);
@@ -13,10 +14,73 @@ const buildClosureScriptPath = fileURLToPath(
   new URL('../../../tooling/scripts/run-workspace-build-closure.mjs', import.meta.url),
 );
 const requiredArtifactPaths = [
+  resolve(packageRootPath, 'dist/index.js'),
   resolve(packageRootPath, 'dist/adapter.js'),
   resolve(packageRootPath, 'dist/adapter.d.ts'),
   resolve(packageRootPath, 'dist/index.d.ts'),
 ] as const;
+
+type ExportSurface = {
+  readonly declarations: readonly string[];
+  readonly runtime: readonly string[];
+};
+
+function readExportSurface(filePath: string): ExportSurface {
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    readFileSync(filePath, 'utf8'),
+    ts.ScriptTarget.Latest,
+    true,
+  );
+  const declarations = new Set<string>();
+  const runtime = new Set<string>();
+
+  for (const statement of sourceFile.statements) {
+    if (
+      !ts.canHaveModifiers(statement) ||
+      !ts.getModifiers(statement)?.some(({ kind }) => kind === ts.SyntaxKind.ExportKeyword)
+    ) {
+      continue;
+    }
+
+    if (
+      (ts.isClassDeclaration(statement) ||
+        ts.isFunctionDeclaration(statement) ||
+        ts.isInterfaceDeclaration(statement) ||
+        ts.isTypeAliasDeclaration(statement)) &&
+      statement.name
+    ) {
+      declarations.add(statement.name.text);
+      if (ts.isClassDeclaration(statement) || ts.isFunctionDeclaration(statement)) {
+        runtime.add(statement.name.text);
+      }
+    }
+  }
+
+  return {
+    declarations: [...declarations].sort(),
+    runtime: [...runtime].sort(),
+  };
+}
+
+function readExportAllTargets(filePath: string): readonly string[] {
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    readFileSync(filePath, 'utf8'),
+    ts.ScriptTarget.Latest,
+    true,
+  );
+
+  return sourceFile.statements
+    .filter(ts.isExportDeclaration)
+    .filter((statement) => statement.exportClause === undefined)
+    .flatMap((statement) =>
+      statement.moduleSpecifier && ts.isStringLiteral(statement.moduleSpecifier)
+        ? [statement.moduleSpecifier.text]
+        : [],
+    )
+    .sort();
+}
 
 describe('@fluojs/platform-cloudflare-workers published artifacts', () => {
   beforeAll(async () => {
@@ -30,7 +94,7 @@ describe('@fluojs/platform-cloudflare-workers published artifacts', () => {
     });
   }, 300_000);
 
-  it('keeps the manifest-exported runtime aligned with the Worker lifecycle contract', () => {
+  it('keeps the manifest-exported runtime structurally aligned with the source root', async () => {
     // Given: the package manifest publishes its root runtime from dist/index.js.
     const manifest: unknown = JSON.parse(readFileSync(resolve(packageRootPath, 'package.json'), 'utf8'));
 
@@ -42,18 +106,19 @@ describe('@fluojs/platform-cloudflare-workers published artifacts', () => {
       },
     });
 
-    // When: the generated runtime artifact is inspected.
-    const runtimeArtifact = readFileSync(resolve(packageRootPath, 'dist/adapter.js'), 'utf8');
+    const sourceRootPath = resolve(packageRootPath, 'src/index.ts');
+    const sourceAdapterPath = resolve(packageRootPath, 'src/adapter.ts');
+    const runtimeRootPath = resolve(packageRootPath, 'dist/index.js');
 
-    // Then: it contains the request context, binding freeze, streaming drain, and timeout recovery behavior.
-    expect(runtimeArtifact).toContain('frameworkRequest.cloudflare = {');
-    expect(runtimeArtifact).toContain('Cloudflare Workers websocket binding must be configured before listen()');
-    expect(runtimeArtifact).toContain('createWebSocketCloseLifecycle');
-    expect(runtimeArtifact).toContain('createLifecycleTrackedResponse');
-    expect(runtimeArtifact).toContain('watchTimedOutCloseRecovery');
+    // When: the manifest root runtime is imported and its export graph is inspected.
+    const runtimeRoot = await import(pathToFileURL(runtimeRootPath).href);
+
+    // Then: dist/index.js re-exports every current runtime value from the source adapter root.
+    expect(readExportAllTargets(runtimeRootPath)).toEqual(readExportAllTargets(sourceRootPath));
+    expect(Object.keys(runtimeRoot).sort()).toEqual(readExportSurface(sourceAdapterPath).runtime);
   });
 
-  it('keeps the manifest-exported declarations aligned with the Worker public seam', () => {
+  it('keeps the manifest-exported declarations structurally aligned with the source root', () => {
     // Given: the package manifest publishes its root declarations from dist/index.d.ts.
     const manifest: unknown = JSON.parse(readFileSync(resolve(packageRootPath, 'package.json'), 'utf8'));
 
@@ -65,16 +130,17 @@ describe('@fluojs/platform-cloudflare-workers published artifacts', () => {
       },
     });
 
-    // When: the generated declaration artifacts are inspected.
-    const rootDeclaration = readFileSync(resolve(packageRootPath, 'dist/index.d.ts'), 'utf8');
-    const adapterDeclaration = readFileSync(resolve(packageRootPath, 'dist/adapter.d.ts'), 'utf8');
+    const sourceRootPath = resolve(packageRootPath, 'src/index.ts');
+    const sourceAdapterPath = resolve(packageRootPath, 'src/adapter.ts');
+    const declarationRootPath = resolve(packageRootPath, 'dist/index.d.ts');
+    const declarationAdapterPath = resolve(packageRootPath, 'dist/adapter.d.ts');
 
-    // Then: the root reaches the current request context and lifecycle declarations.
-    expect(rootDeclaration).toContain("export * from './adapter.js';");
-    expect(adapterDeclaration).toContain('export interface CloudflareWorkerRequestContext<Env = unknown>');
-    expect(adapterDeclaration).toContain('readonly env: Env;');
-    expect(adapterDeclaration).toContain('readonly executionContext?: CloudflareWorkerExecutionContext;');
-    expect(adapterDeclaration).toContain('private isWebSocketBindingFrozen;');
-    expect(adapterDeclaration).toContain('private createRequestResponseFactory;');
+    // When: the manifest root declaration and adapter declaration export graphs are inspected.
+    const sourceSurface = readExportSurface(sourceAdapterPath);
+    const declarationSurface = readExportSurface(declarationAdapterPath);
+
+    // Then: dist/index.d.ts reaches the complete current source declaration surface.
+    expect(readExportAllTargets(declarationRootPath)).toEqual(readExportAllTargets(sourceRootPath));
+    expect(declarationSurface.declarations).toEqual(sourceSurface.declarations);
   });
 });

--- a/packages/platform-cloudflare-workers/src/published-artifact-surface.test.ts
+++ b/packages/platform-cloudflare-workers/src/published-artifact-surface.test.ts
@@ -4,6 +4,7 @@ import { resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { promisify } from 'node:util';
 
+import { transformFileAsync } from '@babel/core';
 import ts from 'typescript';
 import { beforeAll, describe, expect, it } from 'vitest';
 
@@ -19,20 +20,16 @@ const requiredArtifactPaths = [
   resolve(packageRootPath, 'dist/adapter.d.ts'),
   resolve(packageRootPath, 'dist/index.d.ts'),
 ] as const;
+const babelConfigPath = resolve(repoRootPath, 'tooling/babel/babel.config.cjs');
+const buildTsconfigPath = resolve(packageRootPath, 'tsconfig.build.json');
 
-type ExportSurface = {
-  readonly declarations: readonly string[];
-  readonly runtime: readonly string[];
-};
-
-function readExportSurface(filePath: string): ExportSurface {
+function readRuntimeExports(filePath: string): readonly string[] {
   const sourceFile = ts.createSourceFile(
     filePath,
     readFileSync(filePath, 'utf8'),
     ts.ScriptTarget.Latest,
     true,
   );
-  const declarations = new Set<string>();
   const runtime = new Set<string>();
 
   for (const statement of sourceFile.statements) {
@@ -43,24 +40,83 @@ function readExportSurface(filePath: string): ExportSurface {
       continue;
     }
 
-    if (
-      (ts.isClassDeclaration(statement) ||
-        ts.isFunctionDeclaration(statement) ||
-        ts.isInterfaceDeclaration(statement) ||
-        ts.isTypeAliasDeclaration(statement)) &&
-      statement.name
-    ) {
-      declarations.add(statement.name.text);
-      if (ts.isClassDeclaration(statement) || ts.isFunctionDeclaration(statement)) {
-        runtime.add(statement.name.text);
-      }
+    if ((ts.isClassDeclaration(statement) || ts.isFunctionDeclaration(statement)) && statement.name) {
+      runtime.add(statement.name.text);
     }
   }
 
-  return {
-    declarations: [...declarations].sort(),
-    runtime: [...runtime].sort(),
-  };
+  return [...runtime].sort();
+}
+
+function normalizeAst(sourceText: string, filePath: string, scriptKind: ts.ScriptKind): string {
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    scriptKind,
+  );
+
+  return ts
+    .createPrinter({ newLine: ts.NewLineKind.LineFeed, removeComments: true })
+    .printFile(sourceFile);
+}
+
+async function emitSourceRuntime(): Promise<string> {
+  const result = await transformFileAsync(resolve(packageRootPath, 'src/adapter.ts'), {
+    babelrc: false,
+    configFile: babelConfigPath,
+  });
+
+  if (typeof result?.code !== 'string') {
+    throw new TypeError('Babel did not emit the Cloudflare Workers adapter runtime.');
+  }
+
+  return result.code;
+}
+
+function emitSourceDeclarations(): string {
+  const config = ts.readConfigFile(buildTsconfigPath, ts.sys.readFile);
+
+  if (config.error) {
+    throw new TypeError(ts.flattenDiagnosticMessageText(config.error.messageText, '\n'));
+  }
+
+  const parsedConfig = ts.parseJsonConfigFileContent(
+    config.config,
+    ts.sys,
+    packageRootPath,
+    { declarationMap: false },
+    buildTsconfigPath,
+  );
+  const program = ts.createProgram(parsedConfig.fileNames, parsedConfig.options);
+  const adapterDeclarationPath = resolve(packageRootPath, 'dist/adapter.d.ts');
+  let adapterDeclaration: string | undefined;
+  const emitResult = program.emit(
+    undefined,
+    (filePath, contents) => {
+      if (resolve(filePath) === adapterDeclarationPath) {
+        adapterDeclaration = contents;
+      }
+    },
+    undefined,
+    true,
+  );
+  const diagnostics = [...ts.getPreEmitDiagnostics(program), ...emitResult.diagnostics];
+
+  if (diagnostics.length > 0) {
+    throw new TypeError(ts.formatDiagnosticsWithColorAndContext(diagnostics, {
+      getCanonicalFileName: (filePath) => filePath,
+      getCurrentDirectory: () => repoRootPath,
+      getNewLine: () => '\n',
+    }));
+  }
+
+  if (adapterDeclaration === undefined) {
+    throw new TypeError('TypeScript did not emit the Cloudflare Workers adapter declaration.');
+  }
+
+  return adapterDeclaration;
 }
 
 function readExportAllTargets(filePath: string): readonly string[] {
@@ -94,7 +150,7 @@ describe('@fluojs/platform-cloudflare-workers published artifacts', () => {
     });
   }, 300_000);
 
-  it('keeps the manifest-exported runtime structurally aligned with the source root', async () => {
+  it('keeps request context, WebSocket, SSE, and shutdown runtime behavior structurally aligned with source', async () => {
     // Given: the package manifest publishes its root runtime from dist/index.js.
     const manifest: unknown = JSON.parse(readFileSync(resolve(packageRootPath, 'package.json'), 'utf8'));
 
@@ -109,16 +165,23 @@ describe('@fluojs/platform-cloudflare-workers published artifacts', () => {
     const sourceRootPath = resolve(packageRootPath, 'src/index.ts');
     const sourceAdapterPath = resolve(packageRootPath, 'src/adapter.ts');
     const runtimeRootPath = resolve(packageRootPath, 'dist/index.js');
+    const runtimeAdapterPath = resolve(packageRootPath, 'dist/adapter.js');
 
-    // When: the manifest root runtime is imported and its export graph is inspected.
+    // When: source is transformed with the production Babel config and the published runtime is parsed.
     const runtimeRoot = await import(pathToFileURL(runtimeRootPath).href);
+    const emittedSourceRuntime = await emitSourceRuntime();
 
-    // Then: dist/index.js re-exports every current runtime value from the source adapter root.
+    // Then: the complete executable AST and manifest-root exports match, including lifecycle internals.
+    expect(normalizeAst(
+      readFileSync(runtimeAdapterPath, 'utf8'),
+      runtimeAdapterPath,
+      ts.ScriptKind.JS,
+    )).toEqual(normalizeAst(emittedSourceRuntime, sourceAdapterPath, ts.ScriptKind.JS));
     expect(readExportAllTargets(runtimeRootPath)).toEqual(readExportAllTargets(sourceRootPath));
-    expect(Object.keys(runtimeRoot).sort()).toEqual(readExportSurface(sourceAdapterPath).runtime);
+    expect(Object.keys(runtimeRoot).sort()).toEqual(readRuntimeExports(sourceAdapterPath));
   });
 
-  it('keeps the manifest-exported declarations structurally aligned with the source root', () => {
+  it('keeps declaration members and signatures structurally aligned with source', () => {
     // Given: the package manifest publishes its root declarations from dist/index.d.ts.
     const manifest: unknown = JSON.parse(readFileSync(resolve(packageRootPath, 'package.json'), 'utf8'));
 
@@ -135,12 +198,15 @@ describe('@fluojs/platform-cloudflare-workers published artifacts', () => {
     const declarationRootPath = resolve(packageRootPath, 'dist/index.d.ts');
     const declarationAdapterPath = resolve(packageRootPath, 'dist/adapter.d.ts');
 
-    // When: the manifest root declaration and adapter declaration export graphs are inspected.
-    const sourceSurface = readExportSurface(sourceAdapterPath);
-    const declarationSurface = readExportSurface(declarationAdapterPath);
+    // When: declarations are emitted in memory from source and the published declaration is parsed.
+    const emittedSourceDeclaration = emitSourceDeclarations();
 
-    // Then: dist/index.d.ts reaches the complete current source declaration surface.
+    // Then: every declaration member/signature and the manifest-root export graph match source.
+    expect(normalizeAst(
+      readFileSync(declarationAdapterPath, 'utf8'),
+      declarationAdapterPath,
+      ts.ScriptKind.TS,
+    )).toEqual(normalizeAst(emittedSourceDeclaration, sourceAdapterPath, ts.ScriptKind.TS));
     expect(readExportAllTargets(declarationRootPath)).toEqual(readExportAllTargets(sourceRootPath));
-    expect(declarationSurface.declarations).toEqual(sourceSurface.declarations);
   });
 });


### PR DESCRIPTION
## Summary

Add a package-local publication gate so `@fluojs/platform-cloudflare-workers` verifies that the runtime and declaration files addressed by its manifest contain the current Worker lifecycle and public seam.

Linked context: Closes #2535

## Changes

- build the workspace dependency closure when the package publication artifacts are absent
- verify `dist/adapter.js` contains Worker request context, WebSocket binding freeze/close tracking, SSE lifecycle draining, and timed-out shutdown recovery
- verify `dist/index.d.ts` and `dist/adapter.d.ts` expose the current Worker request context and lifecycle declaration surface
- add a patch Changeset so the regenerated package contents reach consumers

## Testing

- `pnpm --filter @fluojs/platform-cloudflare-workers build`
- `pnpm --filter @fluojs/platform-cloudflare-workers typecheck`
- `pnpm --filter @fluojs/platform-cloudflare-workers test` (36 tests passed)
- `pnpm exec biome lint packages/platform-cloudflare-workers/src/published-artifact-surface.test.ts`
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main`
- `pnpm verify:release-readiness` (passed without writing draft artifacts on the canonical rerun)

The first release-readiness run encountered four unrelated parallel-suite timing/isolation failures in CLI and GraphQL tests. Those exact tests passed in isolated serial reruns, and the complete canonical release-readiness rerun passed without code changes.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Patch release: republish the current Cloudflare Workers runtime/declaration contract and keep generated package contents gated against source drift.

## Public export documentation

- [x] No public source export is changed; existing TSDoc and README documentation already describe the intended Worker lifecycle/public seam.
- [x] The declaration artifact gate verifies those existing exported types remain reachable from the manifest root.
- [x] README examples remain unchanged because the documented behavior is already current.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] Existing Worker request context, WebSocket, SSE, and shutdown contracts are preserved.
- [x] Intentional limitations remain explicitly documented in the package README.
- [x] Runtime and declaration publication invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] No SSOT or localized governance document changed.
- [x] Existing English/Korean Worker README contracts remain synchronized.
- [x] The change adds package-local generated artifact evidence and does not alter cross-platform adapter behavior.