### PR TITLE
Resolve #2529: Regenerate Bun published declarations from current source

### DIFF
--- a/.changeset/bun-published-declaration-parity.md
+++ b/.changeset/bun-published-declaration-parity.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/platform-bun': major
+---
+
+Regenerate the published Bun declarations from current source and verify declaration artifacts structurally before release. `BunWebSocketBinding.fetch(...)` now exposes the documented upgrade-only `BunWebSocketUpgradeHost`; move direct server `fetch(...)`, `stop(...)`, or lifecycle access into the surrounding `Bun.serve(...)` host.

--- a/packages/platform-bun/src/published-declaration-surface.test.ts
+++ b/packages/platform-bun/src/published-declaration-surface.test.ts
@@ -1,0 +1,138 @@
+import { execFile } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+import ts from 'typescript';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+const packageRootPath = fileURLToPath(new URL('..', import.meta.url));
+const repoRootPath = fileURLToPath(new URL('../../..', import.meta.url));
+const buildClosureScriptPath = fileURLToPath(
+  new URL('../../../tooling/scripts/run-workspace-build-closure.mjs', import.meta.url),
+);
+const requiredArtifactPaths = [
+  resolve(packageRootPath, 'dist/adapter.d.ts'),
+  resolve(packageRootPath, 'dist/index.d.ts'),
+] as const;
+const buildTsconfigPath = resolve(packageRootPath, 'tsconfig.build.json');
+
+function normalizeAst(sourceText: string, filePath: string): string {
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+
+  return ts
+    .createPrinter({ newLine: ts.NewLineKind.LineFeed, removeComments: true })
+    .printFile(sourceFile);
+}
+
+function emitSourceDeclarations(): string {
+  const config = ts.readConfigFile(buildTsconfigPath, ts.sys.readFile);
+
+  if (config.error) {
+    throw new TypeError(ts.flattenDiagnosticMessageText(config.error.messageText, '\n'));
+  }
+
+  const parsedConfig = ts.parseJsonConfigFileContent(
+    config.config,
+    ts.sys,
+    packageRootPath,
+    { declarationMap: false },
+    buildTsconfigPath,
+  );
+  const program = ts.createProgram(parsedConfig.fileNames, parsedConfig.options);
+  const adapterDeclarationPath = resolve(packageRootPath, 'dist/adapter.d.ts');
+  let adapterDeclaration: string | undefined;
+  const emitResult = program.emit(
+    undefined,
+    (filePath, contents) => {
+      if (resolve(filePath) === adapterDeclarationPath) {
+        adapterDeclaration = contents;
+      }
+    },
+    undefined,
+    true,
+  );
+  const diagnostics = [...ts.getPreEmitDiagnostics(program), ...emitResult.diagnostics];
+
+  if (diagnostics.length > 0) {
+    throw new TypeError(ts.formatDiagnosticsWithColorAndContext(diagnostics, {
+      getCanonicalFileName: (filePath) => filePath,
+      getCurrentDirectory: () => repoRootPath,
+      getNewLine: () => '\n',
+    }));
+  }
+
+  if (adapterDeclaration === undefined) {
+    throw new TypeError('TypeScript did not emit the Bun adapter declaration.');
+  }
+
+  return adapterDeclaration;
+}
+
+function readExportAllTargets(filePath: string): readonly string[] {
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    readFileSync(filePath, 'utf8'),
+    ts.ScriptTarget.Latest,
+    true,
+  );
+
+  return sourceFile.statements
+    .filter(ts.isExportDeclaration)
+    .filter((statement) => statement.exportClause === undefined)
+    .flatMap((statement) =>
+      statement.moduleSpecifier && ts.isStringLiteral(statement.moduleSpecifier)
+        ? [statement.moduleSpecifier.text]
+        : [],
+    )
+    .sort();
+}
+
+describe('@fluojs/platform-bun published declarations', () => {
+  beforeAll(async () => {
+    if (requiredArtifactPaths.every((artifactPath) => existsSync(artifactPath))) {
+      return;
+    }
+
+    await execFileAsync(process.execPath, [buildClosureScriptPath, '@fluojs/platform-bun'], {
+      cwd: repoRootPath,
+      env: process.env,
+    });
+  }, 300_000);
+
+  it('keeps declaration members and signatures structurally aligned with source', () => {
+    // Given: the package manifest publishes its root declarations from dist/index.d.ts.
+    const manifest: unknown = JSON.parse(readFileSync(resolve(packageRootPath, 'package.json'), 'utf8'));
+
+    expect(manifest).toMatchObject({
+      exports: {
+        '.': {
+          types: './dist/index.d.ts',
+        },
+      },
+    });
+
+    const sourceRootPath = resolve(packageRootPath, 'src/index.ts');
+    const sourceAdapterPath = resolve(packageRootPath, 'src/adapter.ts');
+    const declarationRootPath = resolve(packageRootPath, 'dist/index.d.ts');
+    const declarationAdapterPath = resolve(packageRootPath, 'dist/adapter.d.ts');
+
+    // When: declarations are emitted in memory from source and the published declaration is parsed.
+    const emittedSourceDeclaration = emitSourceDeclarations();
+
+    // Then: every declaration member/signature and the manifest-root export graph match source.
+    expect(normalizeAst(
+      readFileSync(declarationAdapterPath, 'utf8'),
+      declarationAdapterPath,
+    )).toEqual(normalizeAst(emittedSourceDeclaration, sourceAdapterPath));
+    expect(readExportAllTargets(declarationRootPath)).toEqual(readExportAllTargets(sourceRootPath));
+  });
+});


### PR DESCRIPTION
## Summary

Restore release-time confidence that `@fluojs/platform-bun` publishes declarations generated from its current source contract rather than stale `dist` types.

Linked context: Closes #2529

## Changes

- add a package-local structural parity test for `dist/adapter.d.ts` and the manifest-root `dist/index.d.ts` export graph
- build the Bun workspace closure when declaration artifacts are absent, while preserving stale artifacts so the test can detect drift
- add a major Changeset with migration guidance for the published `BunWebSocketBinding.fetch(...)` host narrowing to `BunWebSocketUpgradeHost`

## Testing

- simulated the reported stale declaration (`BunServerLike` instead of `BunWebSocketUpgradeHost`) and confirmed the new test fails with the exact signature diff
- `pnpm --filter @fluojs/platform-bun build`
- `pnpm --filter @fluojs/platform-bun test -- published-declaration-surface.test.ts` — 52 passed
- `pnpm --filter @fluojs/platform-bun typecheck`
- `pnpm lint` — completed; changed public-export TSDoc gate passed
- `pnpm verify` — 297 test files passed, 4064 tests passed, 1 skipped
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main`
- `pnpm verify:release-readiness`
- changed-file LSP diagnostics — no diagnostics
- TypeScript no-excuse audit — no violations; new test is 116 pure LOC

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

The Changeset is `major` because `@fluojs/platform-bun` is 1.0+ and manifest consumers that relied on the stale broader host declaration must move lifecycle/raw fetch access to the surrounding Bun host. Maintainer approval is required before merge.

## Public export documentation

- [x] No source public exports changed; current source TSDoc already documents `BunWebSocketUpgradeHost`.
- [x] Exported function `@param` / `@returns` documentation is unaffected.
- [x] Existing EN/KO README scenarios remain aligned with the intended upgrade-only host contract.

## Behavioral contract

- [x] No documented behavioral contracts were removed.
- [x] The existing package README remains the intended contract; this PR restores generated declaration parity with it.
- [x] The upgrade-only realtime host limitation remains explicit.
- [x] Structural regression coverage compares every emitted adapter declaration member/signature and the root export graph.

## Platform consistency governance (SSOT)

- [x] No governance or package README text changed, so EN/KO mirror structure is unchanged.
- [x] The package-local parity test provides release regression evidence for the Bun declaration surface.
- [x] Existing Bun HTTP/WebSocket conformance coverage remains unchanged and passed through `pnpm verify`.