### PR TITLE
Resolve #2679: Add CLI lifecycle and scaffold coverage

### DIFF
--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -1459,6 +1459,64 @@ void bootstrap();
     expect(appTestFile).toContain('InMemoryLoopbackTransport');
   });
 
+  it('refuses to scaffold into a non-empty target without --force', async () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-'));
+    createdDirectories.push(workspaceDirectory);
+    const targetDirectory = join(workspaceDirectory, 'existing-app');
+    const existingFile = join(targetDirectory, 'keep.txt');
+    const stderrBuffer: string[] = [];
+    mkdirSync(targetDirectory, { recursive: true });
+    writeFileSync(existingFile, 'keep me\n');
+
+    const exitCode = await runCli([
+      'new',
+      'starter-app',
+      '--target-directory',
+      targetDirectory,
+      '--no-install',
+      '--no-git',
+    ], {
+      cwd: workspaceDirectory,
+      stderr: { write: (message) => stderrBuffer.push(message) },
+      stdout: { write: () => undefined },
+    });
+
+    expect(exitCode).toBe(1);
+    expect(stderrBuffer.join('')).toContain(`Target directory "${targetDirectory}" is not empty.`);
+    expect(stderrBuffer.join('')).toContain('use --force to overwrite');
+    expect(readFileSync(existingFile, 'utf8')).toBe('keep me\n');
+    expect(existsSync(join(targetDirectory, 'package.json'))).toBe(false);
+  });
+
+  it('overwrites generated scaffold files in a non-empty target with --force', async () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-'));
+    createdDirectories.push(workspaceDirectory);
+    const targetDirectory = join(workspaceDirectory, 'existing-app');
+    const existingFile = join(targetDirectory, 'keep.txt');
+    mkdirSync(targetDirectory, { recursive: true });
+    writeFileSync(existingFile, 'keep me\n');
+    writeFileSync(join(targetDirectory, 'package.json'), '{"name":"stale-app"}\n');
+
+    const exitCode = await runCli([
+      'new',
+      'starter-app',
+      '--target-directory',
+      targetDirectory,
+      '--force',
+      '--no-install',
+      '--no-git',
+    ], {
+      cwd: workspaceDirectory,
+      stderr: { write: () => undefined },
+      stdout: { write: () => undefined },
+    });
+
+    expect(exitCode).toBe(0);
+    expect(readFileSync(join(targetDirectory, 'package.json'), 'utf8')).toContain('"name": "starter-app"');
+    expect(readFileSync(join(targetDirectory, 'package.json'), 'utf8')).not.toContain('stale-app');
+    expect(readFileSync(existingFile, 'utf8')).toBe('keep me\n');
+  });
+
   it('prints an application scaffold plan without writing files, installing dependencies, or initializing git', async () => {
     const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-'));
     createdDirectories.push(workspaceDirectory);
@@ -1501,6 +1559,36 @@ void bootstrap();
     expect(output).not.toContain('Skipping dependency installation.');
     expect(output).not.toContain('Done.');
     expect(existsSync(join(workspaceDirectory, 'starter-app'))).toBe(false);
+  });
+
+  it('keeps --print-plan side-effect free for a non-empty target even with --force', async () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-'));
+    createdDirectories.push(workspaceDirectory);
+    const targetDirectory = join(workspaceDirectory, 'existing-app');
+    const packageJsonPath = join(targetDirectory, 'package.json');
+    const stdoutBuffer: string[] = [];
+    mkdirSync(targetDirectory, { recursive: true });
+    writeFileSync(packageJsonPath, '{"name":"existing-app"}\n');
+
+    const exitCode = await runCli([
+      'new',
+      'starter-app',
+      '--target-directory',
+      targetDirectory,
+      '--force',
+      '--print-plan',
+      '--no-install',
+      '--no-git',
+    ], {
+      cwd: workspaceDirectory,
+      stderr: { write: () => undefined },
+      stdout: { write: (message) => stdoutBuffer.push(message) },
+    });
+
+    expect(exitCode).toBe(0);
+    expect(stdoutBuffer.join('')).toContain('Side effects: none.');
+    expect(readFileSync(packageJsonPath, 'utf8')).toBe('{"name":"existing-app"}\n');
+    expect(existsSync(join(targetDirectory, 'src'))).toBe(false);
   });
 
   it('prints a microservice scaffold plan with resolved defaults and no scaffold side effects', async () => {
@@ -2460,6 +2548,9 @@ void bootstrap();
     const injectedEpochs: Array<string | undefined> = [];
     const lifecycleEpochs: Array<string | undefined> = [];
     const watchListeners: Array<(event: string, filename: string | Buffer | null) => void> = [];
+    const restartScheduler = createManualRestartScheduler();
+    let watcherCloseCalls = 0;
+    let runPromise: Promise<number> | undefined;
 
     const originalFetch = globalThis.fetch;
     globalThis.fetch = async (_input, init) => {
@@ -2473,8 +2564,7 @@ void bootstrap();
     };
 
     try {
-      const runPromise = runNodeRestartRunner({
-        debounceMs: 1,
+      runPromise = runNodeRestartRunner({
         env: {
           FLUO_STUDIO: '1',
           FLUO_STUDIO_APP_ID: 'test-app',
@@ -2484,6 +2574,7 @@ void bootstrap();
           FLUO_STUDIO_URL: 'http://127.0.0.1:49152',
         },
         projectDirectory: workspaceDirectory,
+        restartScheduler,
         signalTarget: signalTarget.target,
         spawnChild: (_command, args) => {
           const injectedSource = decodeURIComponent(String(args[2]).replace('data:text/javascript,', ''));
@@ -2495,7 +2586,9 @@ void bootstrap();
         },
         watchTarget: (_target, optionsOrListener, listener) => {
           watchListeners.push(typeof optionsOrListener === 'function' ? optionsOrListener : listener ?? (() => undefined));
-          return { close: () => undefined } as never;
+          return { close: () => {
+            watcherCloseCalls += 1;
+          } } as never;
         },
       });
 
@@ -2506,9 +2599,10 @@ void bootstrap();
         listener('change', 'main.ts');
       }
 
-      await waitForCondition(() => children[0]?.killed === true);
-      children[0]?.emit('close', 0);
-      await waitForCondition(() => children.length === 2);
+      restartScheduler.flush();
+      expect(children[0]?.killed).toBe(true);
+      await flushMicrotasks();
+      expect(children).toHaveLength(2);
 
       expect(injectedEpochs[1]).toBeDefined();
       expect(injectedEpochs[1]).not.toBe('epoch-1');
@@ -2516,8 +2610,17 @@ void bootstrap();
 
       children[1]?.emit('close', 0);
       await expect(runPromise).resolves.toBe(0);
+      expect(watcherCloseCalls).toBeGreaterThan(0);
     } finally {
       globalThis.fetch = originalFetch;
+      const childBeforeCleanup = children.at(-1);
+      childBeforeCleanup?.emit('close', 0);
+      await flushMicrotasks();
+      const childAfterCleanup = children.at(-1);
+      if (childAfterCleanup !== childBeforeCleanup) {
+        childAfterCleanup?.emit('close', 0);
+      }
+      await runPromise;
     }
   });
 
@@ -3848,14 +3951,29 @@ exit 7
     expect(stdoutBuffer.join('')).toContain('Docs: https://github.com/fluojs/fluo/tree/main/docs/getting-started/quick-start.md');
   });
 
-  it('emits platform snapshot JSON for inspect by default', async () => {
+  it('emits platform snapshot JSON and closes the inspect context exactly once on success', async () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-inspect-lifecycle-'));
+    createdDirectories.push(workspaceDirectory);
+    const lifecycleLogPath = join(workspaceDirectory, 'close.log');
     const stdoutBuffer: string[] = [];
     const stderrBuffer: string[] = [];
-    const exitCode = await runCli(['inspect', inspectFixtureModulePath], {
-      cwd: process.cwd(),
-      stderr: { write: (message) => stderrBuffer.push(message) },
-      stdout: { write: (message) => stdoutBuffer.push(message) },
-    });
+    const previousLifecycleLogPath = process.env.FLUO_INSPECT_LIFECYCLE_LOG;
+    process.env.FLUO_INSPECT_LIFECYCLE_LOG = lifecycleLogPath;
+    let exitCode: number;
+
+    try {
+      exitCode = await runCli(['inspect', inspectFixtureModulePath], {
+        cwd: process.cwd(),
+        stderr: { write: (message) => stderrBuffer.push(message) },
+        stdout: { write: (message) => stdoutBuffer.push(message) },
+      });
+    } finally {
+      if (previousLifecycleLogPath === undefined) {
+        delete process.env.FLUO_INSPECT_LIFECYCLE_LOG;
+      } else {
+        process.env.FLUO_INSPECT_LIFECYCLE_LOG = previousLifecycleLogPath;
+      }
+    }
 
     const payload = JSON.parse(stdoutBuffer.join('')) as {
       components: unknown[];
@@ -3876,6 +3994,7 @@ exit 7
     expect(payload.diagnostics).toEqual([]);
     expect(payload.readiness.status).toBe('ready');
     expect(payload.health.status).toBe('healthy');
+    expect(readFileSync(lifecycleLogPath, 'utf8')).toBe('close\n');
   });
 
   it('loads TypeScript source modules for inspect without narrowing native JavaScript module support', async () => {

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -4,7 +4,7 @@ import { chmodSync, existsSync, type FSWatcher, mkdirSync, mkdtempSync, readFile
 import { tmpdir } from 'node:os';
 import { delimiter, dirname, join } from 'node:path';
 import { PassThrough } from 'node:stream';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
@@ -3957,8 +3957,11 @@ exit 7
     const lifecycleLogPath = join(workspaceDirectory, 'close.log');
     const stdoutBuffer: string[] = [];
     const stderrBuffer: string[] = [];
-    const previousLifecycleLogPath = process.env.FLUO_INSPECT_LIFECYCLE_LOG;
-    process.env.FLUO_INSPECT_LIFECYCLE_LOG = lifecycleLogPath;
+    const lifecycleFixture = await import(pathToFileURL(inspectFixtureModulePath).href) as {
+      configureInspectLifecycleLogPath(logPath: string): void;
+      resetInspectLifecycleLogPath(): void;
+    };
+    lifecycleFixture.configureInspectLifecycleLogPath(lifecycleLogPath);
     let exitCode: number;
 
     try {
@@ -3968,11 +3971,7 @@ exit 7
         stdout: { write: (message) => stdoutBuffer.push(message) },
       });
     } finally {
-      if (previousLifecycleLogPath === undefined) {
-        delete process.env.FLUO_INSPECT_LIFECYCLE_LOG;
-      } else {
-        process.env.FLUO_INSPECT_LIFECYCLE_LOG = previousLifecycleLogPath;
-      }
+      lifecycleFixture.resetInspectLifecycleLogPath();
     }
 
     const payload = JSON.parse(stdoutBuffer.join('')) as {

--- a/packages/cli/src/fixtures/inspect-app.module.mjs
+++ b/packages/cli/src/fixtures/inspect-app.module.mjs
@@ -4,9 +4,18 @@ import { defineModule } from '@fluojs/runtime';
 
 class SharedService {}
 
+let lifecycleLogPath;
+
+export function configureInspectLifecycleLogPath(logPath) {
+  lifecycleLogPath = logPath;
+}
+
+export function resetInspectLifecycleLogPath() {
+  lifecycleLogPath = undefined;
+}
+
 class InspectLifecycleRecorder {
   onModuleDestroy() {
-    const lifecycleLogPath = process.env.FLUO_INSPECT_LIFECYCLE_LOG;
     if (lifecycleLogPath) {
       appendFileSync(lifecycleLogPath, 'close\n');
     }

--- a/packages/cli/src/fixtures/inspect-bootstrap-failure.module.mjs
+++ b/packages/cli/src/fixtures/inspect-bootstrap-failure.module.mjs
@@ -2,9 +2,18 @@ import { appendFileSync } from 'node:fs';
 
 import { defineModule } from '@fluojs/runtime';
 
+let lifecycleLogPath;
+
+export function configureInspectLifecycleLogPath(logPath) {
+  lifecycleLogPath = logPath;
+}
+
+export function resetInspectLifecycleLogPath() {
+  lifecycleLogPath = undefined;
+}
+
 class InspectLifecycleRecorder {
   onModuleDestroy() {
-    const lifecycleLogPath = process.env.FLUO_INSPECT_LIFECYCLE_LOG;
     if (lifecycleLogPath) {
       appendFileSync(lifecycleLogPath, 'close\n');
     }

--- a/packages/cli/src/fixtures/inspect-bootstrap-failure.module.mjs
+++ b/packages/cli/src/fixtures/inspect-bootstrap-failure.module.mjs
@@ -2,8 +2,6 @@ import { appendFileSync } from 'node:fs';
 
 import { defineModule } from '@fluojs/runtime';
 
-class SharedService {}
-
 class InspectLifecycleRecorder {
   onModuleDestroy() {
     const lifecycleLogPath = process.env.FLUO_INSPECT_LIFECYCLE_LOG;
@@ -13,20 +11,16 @@ class InspectLifecycleRecorder {
   }
 }
 
-/**
- * Represents the shared module.
- */
-export class SharedModule {}
-defineModule(SharedModule, {
-  exports: [SharedService],
-  providers: [SharedService],
-});
+class FailingBootstrapService {
+  onApplicationBootstrap() {
+    throw new Error('inspect bootstrap fixture failed');
+  }
+}
 
 /**
- * Represents the app module.
+ * Represents an inspect fixture that fails after lifecycle resources are resolved.
  */
 export class AppModule {}
 defineModule(AppModule, {
-  imports: [SharedModule],
-  providers: [InspectLifecycleRecorder],
+  providers: [InspectLifecycleRecorder, FailingBootstrapService],
 });

--- a/packages/cli/src/public-api.test.ts
+++ b/packages/cli/src/public-api.test.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
@@ -177,8 +177,11 @@ describe('public CLI package API', () => {
     const lifecycleLogPath = join(workspaceDirectory, 'close.log');
     const stdoutBuffer: string[] = [];
     const stderrBuffer: string[] = [];
-    const previousLifecycleLogPath = process.env.FLUO_INSPECT_LIFECYCLE_LOG;
-    process.env.FLUO_INSPECT_LIFECYCLE_LOG = lifecycleLogPath;
+    const lifecycleFixture = await import(pathToFileURL(inspectBootstrapFailureFixtureModulePath).href) as {
+      configureInspectLifecycleLogPath(logPath: string): void;
+      resetInspectLifecycleLogPath(): void;
+    };
+    lifecycleFixture.configureInspectLifecycleLogPath(lifecycleLogPath);
     let exitCode: number;
 
     try {
@@ -188,11 +191,7 @@ describe('public CLI package API', () => {
         stdout: { write: (message) => stdoutBuffer.push(message) },
       });
     } finally {
-      if (previousLifecycleLogPath === undefined) {
-        delete process.env.FLUO_INSPECT_LIFECYCLE_LOG;
-      } else {
-        process.env.FLUO_INSPECT_LIFECYCLE_LOG = previousLifecycleLogPath;
-      }
+      lifecycleFixture.resetInspectLifecycleLogPath();
     }
 
     expect(exitCode).toBe(1);

--- a/packages/cli/src/public-api.test.ts
+++ b/packages/cli/src/public-api.test.ts
@@ -27,6 +27,11 @@ const inspectFixtureModulePath = join(
   'fixtures',
   'inspect-app.module.mjs',
 );
+const inspectBootstrapFailureFixtureModulePath = join(
+  dirname(fileURLToPath(import.meta.url)),
+  'fixtures',
+  'inspect-bootstrap-failure.module.mjs',
+);
 
 function expectNoEagerCommandLink(source: string, commandName: 'generate' | 'inspect' | 'new'): void {
   const eagerCommandLink = new RegExp(
@@ -164,5 +169,35 @@ describe('public CLI package API', () => {
     expect(payload.diagnostics).toEqual([]);
     expect(payload.readiness.status).toBe('ready');
     expect(payload.health.status).toBe('healthy');
+  });
+
+  it('closes the inspect context exactly once when bootstrap fails through the public facade', async () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-public-api-'));
+    tempDirectories.push(workspaceDirectory);
+    const lifecycleLogPath = join(workspaceDirectory, 'close.log');
+    const stdoutBuffer: string[] = [];
+    const stderrBuffer: string[] = [];
+    const previousLifecycleLogPath = process.env.FLUO_INSPECT_LIFECYCLE_LOG;
+    process.env.FLUO_INSPECT_LIFECYCLE_LOG = lifecycleLogPath;
+    let exitCode: number;
+
+    try {
+      exitCode = await runInspectCommand([inspectBootstrapFailureFixtureModulePath, '--json'], {
+        cwd: process.cwd(),
+        stderr: { write: (message) => stderrBuffer.push(message) },
+        stdout: { write: (message) => stdoutBuffer.push(message) },
+      });
+    } finally {
+      if (previousLifecycleLogPath === undefined) {
+        delete process.env.FLUO_INSPECT_LIFECYCLE_LOG;
+      } else {
+        process.env.FLUO_INSPECT_LIFECYCLE_LOG = previousLifecycleLogPath;
+      }
+    }
+
+    expect(exitCode).toBe(1);
+    expect(stdoutBuffer.join('')).toBe('');
+    expect(stderrBuffer.join('')).toContain('inspect bootstrap fixture failed');
+    expect(readFileSync(lifecycleLogPath, 'utf8')).toBe('close\n');
   });
 });


### PR DESCRIPTION
## Summary

`@fluojs/cli`의 문서화된 inspect lifecycle 및 scaffold overwrite 보호 계약을 직접 실행하는 회귀 테스트를 추가합니다. 또한 Studio epoch restart 테스트를 수동 scheduler와 `finally` cleanup으로 전환해 polling timeout과 누수 위험을 줄입니다.

Linked context: Closes #2679

## Changes

- inspect 성공 시 application context가 정확히 한 번 닫히는 fixture 및 assertion을 추가했습니다.
- inspect bootstrap 실패 시 이미 해석된 lifecycle resource가 정확히 한 번 정리되는 public facade 회귀 테스트를 추가했습니다.
- `fluo new`가 non-empty target을 기본 거부하고, `--force`에서 generated file만 덮어쓰며, `--print-plan --force`에서는 side effect를 만들지 않는 계약을 고정했습니다.
- Studio epoch restart 테스트에서 real-time polling을 제거하고 수동 restart scheduler 및 unconditional child/watcher cleanup을 적용했습니다.
- production implementation은 변경하지 않았습니다.

## Testing

- `pnpm install --frozen-lockfile` — 통과
- `pnpm --filter @fluojs/cli... build` — 통과
- `pnpm exec vitest run -c vitest.config.ts src/cli.test.ts src/public-api.test.ts src/commands/generate.test.ts` (in `packages/cli`) — 3 files, 246 tests 통과
- `pnpm exec vitest run -c vitest.config.ts --maxWorkers=1` (in `packages/cli`) — 13 files, 391 tests 통과
- `pnpm --filter @fluojs/cli typecheck` — 통과
- `pnpm exec biome lint packages/cli/src/cli.test.ts packages/cli/src/public-api.test.ts packages/cli/src/fixtures/inspect-app.module.mjs packages/cli/src/fixtures/inspect-bootstrap-failure.module.mjs` — 통과
- `pnpm lint` — exit 0; changed-mode public export TSDoc check 통과. 기존 unrelated files에서 31 warnings / 81 infos가 보고됨
- LSP diagnostics — TypeScript LSP가 설치되어 있지 않아 실행 불가; `tsc` typecheck로 대체 검증

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

No-release rationale: test와 test-only fixture만 변경하며 public API, runtime behavior, published package contents, release metadata를 변경하지 않으므로 changeset을 추가하지 않았습니다.

## Public export documentation

- [x] 해당 없음 — public export를 변경하지 않았습니다.
- [x] Changed public exports include a source-level summary. (N/A)
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable. (N/A)
- [x] Source `@example` blocks and README scenario examples still play complementary roles. (N/A; docs/examples unchanged)

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README. (N/A; existing README contracts의 regression coverage만 추가)
- [x] Intentional limitations are explicitly stated (not silently removed). (N/A; limitations unchanged)
- [x] Runtime invariants are covered by regression tests.

기존 `packages/cli/README.md`의 inspect bootstrap/close cycle, non-empty target protection, `--force`, `--print-plan` 계약을 보존하며 production behavior 변경은 없습니다.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. (N/A; governance docs unchanged)
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. (N/A; platform contract docs unchanged)
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests. (N/A; README 및 platform claims unchanged)

Platform consistency 영향 없음: CLI test-only coverage이며 runtime/platform adapter source 및 SSOT 문서를 변경하지 않았습니다.