### PR TITLE
Resolve #2687: Bound Passport in-memory refresh-token retention

### DIFF
--- a/.changeset/bounded-passport-memory-store.md
+++ b/.changeset/bounded-passport-memory-store.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/passport': patch
+---
+
+Evict expired records from the development-only in-memory refresh-token store during normal store operations.

--- a/packages/passport/src/refresh/jwt-refresh-token-adapter.test.ts
+++ b/packages/passport/src/refresh/jwt-refresh-token-adapter.test.ts
@@ -1,5 +1,12 @@
-import { DefaultJwtSigner, DefaultJwtVerifier, JwtConfigurationError, JwtInvalidTokenError, type RefreshTokenStore } from '@fluojs/jwt';
-import { describe, expect, it } from 'vitest';
+import {
+  DefaultJwtSigner,
+  DefaultJwtVerifier,
+  JwtConfigurationError,
+  JwtInvalidTokenError,
+  type RefreshTokenRecord,
+  type RefreshTokenStore,
+} from '@fluojs/jwt';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { JwtRefreshTokenAdapter } from './jwt-refresh-token-adapter.js';
 
@@ -17,7 +24,31 @@ function createVerifier(): DefaultJwtVerifier {
   } as unknown as DefaultJwtVerifier;
 }
 
+function createInMemoryStore(): RefreshTokenStore {
+  const adapter = new JwtRefreshTokenAdapter(createSigner(), createVerifier(), {
+    secret: 'refresh-secret',
+    store: 'memory',
+  });
+
+  return adapter['service']['options'].store;
+}
+
+function createRecord(id: string, expiresAt: Date): RefreshTokenRecord {
+  return {
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    expiresAt,
+    family: `family-${id}`,
+    id,
+    subject: 'user-1',
+    used: false,
+  };
+}
+
 describe('JwtRefreshTokenAdapter', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   function createRotationCapableStore(): RefreshTokenStore {
     return {
       async consume() {
@@ -48,6 +79,62 @@ describe('JwtRefreshTokenAdapter', () => {
         store: 'memory',
       }),
     ).not.toThrow();
+  });
+
+  it('evicts expired records before saving a new in-memory token', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+    const store = createInMemoryStore();
+    await store.save(createRecord('expired', new Date('2026-01-01T00:00:01.000Z')));
+
+    vi.setSystemTime(new Date('2026-01-01T00:00:01.000Z'));
+    await store.save(createRecord('active', new Date('2026-01-01T00:00:02.000Z')));
+
+    await expect(store.find('expired')).resolves.toBeUndefined();
+    await expect(store.find('active')).resolves.toMatchObject({ id: 'active' });
+  });
+
+  it('evicts an expired record after returning it from an in-memory lookup', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+    const store = createInMemoryStore();
+    await store.save(createRecord('expired', new Date('2026-01-01T00:00:01.000Z')));
+
+    vi.setSystemTime(new Date('2026-01-01T00:00:01.000Z'));
+
+    await expect(store.find('expired')).resolves.toMatchObject({ id: 'expired' });
+    await expect(store.find('expired')).resolves.toBeUndefined();
+  });
+
+  it('evicts expired records when the in-memory store consumes a token', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+    const store = createInMemoryStore();
+    await store.save(createRecord('consumed', new Date('2026-01-01T00:00:01.000Z')));
+    await store.save(createRecord('unrelated', new Date('2026-01-01T00:00:01.000Z')));
+
+    vi.setSystemTime(new Date('2026-01-01T00:00:01.000Z'));
+    await expect(store.consume?.({
+      family: 'family-consumed',
+      now: new Date(),
+      subject: 'user-1',
+      tokenId: 'consumed',
+    })).resolves.toBe('expired');
+
+    await expect(store.find('consumed')).resolves.toBeUndefined();
+    await expect(store.find('unrelated')).resolves.toBeUndefined();
+  });
+
+  it('evicts expired records during an in-memory revocation operation', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+    const store = createInMemoryStore();
+    await store.save(createRecord('expired', new Date('2026-01-01T00:00:01.000Z')));
+
+    vi.setSystemTime(new Date('2026-01-01T00:00:01.000Z'));
+    await store.revoke('missing');
+
+    await expect(store.find('expired')).resolves.toBeUndefined();
   });
 
   it('preserves rotation:false and reuses the same refresh token string', async () => {

--- a/packages/passport/src/refresh/jwt-refresh-token-adapter.ts
+++ b/packages/passport/src/refresh/jwt-refresh-token-adapter.ts
@@ -4,6 +4,7 @@ import {
   DefaultJwtVerifier,
   JwtConfigurationError,
   RefreshTokenService as JwtRefreshTokenService,
+  type RefreshTokenRecord,
   type RefreshTokenStore,
 } from '@fluojs/jwt';
 
@@ -35,36 +36,35 @@ function resolveSecret(options: RefreshTokenModuleOptions): string {
 }
 
 function createInMemoryStore(): RefreshTokenStore {
-  const records = new Map<string, {
-    id: string;
-    subject: string;
-    family: string;
-    expiresAt: Date;
-    used: boolean;
-    createdAt: Date;
-  }>();
+  const records = new Map<string, RefreshTokenRecord>();
+
+  const pruneExpired = (now: number): void => {
+    for (const [id, record] of records.entries()) {
+      if (record.expiresAt.getTime() <= now) {
+        records.delete(id);
+      }
+    }
+  };
 
   return {
-    async save(token: {
-      id: string;
-      subject: string;
-      family: string;
-      expiresAt: Date;
-      used: boolean;
-      createdAt: Date;
-    }): Promise<void> {
+    async save(token: RefreshTokenRecord): Promise<void> {
       records.set(token.id, token);
+      pruneExpired(Date.now());
     },
 
     async find(tokenId: string) {
-      return records.get(tokenId);
+      const record = records.get(tokenId);
+      pruneExpired(Date.now());
+      return record;
     },
 
     async revoke(tokenId: string): Promise<void> {
+      pruneExpired(Date.now());
       records.delete(tokenId);
     },
 
     async revokeBySubject(subject: string): Promise<void> {
+      pruneExpired(Date.now());
       for (const [id, record] of records.entries()) {
         if (record.subject === subject) {
           records.delete(id);
@@ -73,6 +73,7 @@ function createInMemoryStore(): RefreshTokenStore {
     },
 
     async revokeByFamily(family: string): Promise<void> {
+      pruneExpired(Date.now());
       for (const [id, record] of records.entries()) {
         if (record.family === family) {
           records.delete(id);
@@ -82,6 +83,7 @@ function createInMemoryStore(): RefreshTokenStore {
 
     async consume(input: { tokenId: string; subject: string; family: string; now: Date }) {
       const record = records.get(input.tokenId);
+      pruneExpired(input.now.getTime());
 
       if (!record) {
         return 'invalid';


### PR DESCRIPTION
## Summary

Bound retention in the explicit development-only Passport in-memory refresh-token store by evicting expired records during normal store operations.

Linked context: Closes #2687

## Changes

- Prune expired in-memory refresh-token records during save, find, consume, and revocation operations.
- Preserve the existing first lookup and consume result for an expired target while removing its retained Map entry.
- Add regression coverage for save, lookup, consume, and revoke eviction paths.
- Add a patch changeset for `@fluojs/passport`.

## Testing

- `pnpm --filter @fluojs/passport test` — 8 test files passed, 105 tests passed.
- `pnpm --filter @fluojs/passport typecheck` — passed.
- `git diff --check origin/main..HEAD` — passed.
- Changed-file LSP diagnostics were requested, but the TypeScript LSP is not installed in this environment; package-scoped `tsc --noEmit` passed instead.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Patch rationale: the public API and documented `store: "memory"` development-only contract remain unchanged, but publishing the retained-memory bug fix requires a patch release under the Changesets-only workflow.

## Public export documentation

- [x] No public exports changed; source TSDoc requirements are not applicable.
- [x] Existing public API documentation remains unchanged.
- [x] README examples remain unchanged because the documented development/single-instance boundary is preserved.

## Behavioral contract

- [x] No documented behavioral contracts were removed.
- [x] No new public behavioral contract was introduced.
- [x] The intentional development-only and single-instance limitation remains explicit.
- [x] Runtime invariants are covered by affected-package regression tests.

## Platform consistency governance (SSOT)

- [x] No governance or localized documentation changed.
- [x] The internal Map eviction is runtime-neutral and does not alter platform adapter contracts.
- [x] Platform conformance harness updates are not applicable to this Passport-internal store fix.