### PR TITLE
Resolve #2681: Correct testing mockToken return-shape documentation

### DIFF
--- a/packages/testing/README.ko.md
+++ b/packages/testing/README.ko.md
@@ -132,7 +132,7 @@ const repo = createMock<UserRepository>({ findById: vi.fn() });
 const mailer = createDeepMock(MailService);
 ```
 
-`asMock(value)`는 기존 값을 mock-friendly 타입으로 좁히고, `mockToken(token, value)`는 token 기반 dependency를 위한 provider override tuple을 만듭니다. `createMock(..., { strict: true })`는 지정하지 않은 member 접근을 거부합니다. `DeepMocked<T>`는 root `@fluojs/testing` 패키지, `@fluojs/testing/types`, `@fluojs/testing/mock`에서 모두 노출됩니다. 세 경로는 Vitest peer declaration을 non-mock runtime helper로 끌어들이지 않으면서 같은 Vitest-compatible mock type boundary를 공유합니다. Vitest를 사용하지 않는 소비자는 `@fluojs/testing/app`, `@fluojs/testing/module`, 또는 harness subpath에서 non-mock helper만 import하세요.
+`asMock(value)`는 기존 값을 mock-friendly 타입으로 좁히고, `mockToken(token, value)`는 token 기반 override를 위해 `{ provide: token, useValue: value }` 형태의 `ValueProvider` descriptor를 만듭니다. `createMock(..., { strict: true })`는 지정하지 않은 member 접근을 거부합니다. `DeepMocked<T>`는 root `@fluojs/testing` 패키지, `@fluojs/testing/types`, `@fluojs/testing/mock`에서 모두 노출됩니다. 세 경로는 Vitest peer declaration을 non-mock runtime helper로 끌어들이지 않으면서 같은 Vitest-compatible mock type boundary를 공유합니다. Vitest를 사용하지 않는 소비자는 `@fluojs/testing/app`, `@fluojs/testing/module`, 또는 harness subpath에서 non-mock helper만 import하세요.
 
 배포된 런타임 import가 안정적으로 해석되도록, mock 헬퍼를 사용할 워크스페이스에는 `vitest`를 함께 설치해야 합니다.
 

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -130,7 +130,7 @@ const repo = createMock<UserRepository>({ findById: vi.fn() });
 const mailer = createDeepMock(MailService);
 ```
 
-`asMock(value)` narrows an existing value to a mock-friendly type, and `mockToken(token, value)` creates a provider override tuple for token-based dependencies. `createMock(..., { strict: true })` rejects access to unspecified members. `DeepMocked<T>` is exposed from the root `@fluojs/testing` package, `@fluojs/testing/types`, and `@fluojs/testing/mock`; all three paths intentionally share the same Vitest-compatible mock type boundary without importing Vitest peer declarations through non-mock runtime helpers. Consumers that do not use Vitest should import only non-mock helpers from `@fluojs/testing/app`, `@fluojs/testing/module`, or the harness subpaths.
+`asMock(value)` narrows an existing value to a mock-friendly type, and `mockToken(token, value)` creates a `ValueProvider` descriptor shaped as `{ provide: token, useValue: value }` for token-based overrides. `createMock(..., { strict: true })` rejects access to unspecified members. `DeepMocked<T>` is exposed from the root `@fluojs/testing` package, `@fluojs/testing/types`, and `@fluojs/testing/mock`; all three paths intentionally share the same Vitest-compatible mock type boundary without importing Vitest peer declarations through non-mock runtime helpers. Consumers that do not use Vitest should import only non-mock helpers from `@fluojs/testing/app`, `@fluojs/testing/module`, or the harness subpaths.
 
 Install `vitest` in the consuming workspace before using the mock helpers so the published runtime import resolves consistently.
 


### PR DESCRIPTION
## Summary

Correct the bilingual `@fluojs/testing` README contract for `mockToken(...)` so it matches the implementation return shape.

Linked context: Closes #2681

## Changes

- Replace the incorrect provider override tuple wording in `packages/testing/README.md`.
- Apply the equivalent correction in `packages/testing/README.ko.md`.
- Document the returned `ValueProvider` descriptor shape as `{ provide: token, useValue: value }`.

## Testing

- `git diff --check`
- `pnpm docs:sync-check`
- `pnpm verify:platform-consistency-governance`
- Compared the README wording with `packages/testing/src/mock.ts`, where `mockToken<T>(...)` returns `ValueProvider<T>` and `{ provide: token, useValue: partial as T }`.

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

No changeset is included because this is a docs-only correction that preserves the existing runtime implementation, public API, package contents, and release metadata.

## Public export documentation

- [x] No public exports changed; source TSDoc updates are not applicable.
- [x] The package README now accurately describes the existing public helper return shape.

## Behavioral contract

- [x] No documented behavioral contracts were removed.
- [x] The EN/KO package README pair now matches the existing `mockToken(...)` implementation contract.
- [x] Runtime implementation and tests were not changed because the issue is documentation-only.

## Platform consistency governance (SSOT)

- [x] English and Korean package README wording remains synchronized.
- [x] `pnpm docs:sync-check` passed.
- [x] `pnpm verify:platform-consistency-governance` passed.
- [x] No platform contract or runtime behavior changed; companion harness updates are not applicable.