### PR TITLE
Resolve #2680: Harden Studio viewer and live-token regression tests

### DIFF
--- a/packages/studio/src/contracts.test.ts
+++ b/packages/studio/src/contracts.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { PlatformShellSnapshot } from '@fluojs/runtime';
+import type { Root } from 'react-dom/client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { bootstrapStudioApp } from './app/bootstrap.js';
 import { applyFilters, isStudioLiveEvent, parseStudioLiveEvent, parseStudioPayload, renderMermaid } from './contracts.js';
@@ -16,8 +17,11 @@ import { inspectComponentConnections, renderDiagnosticDocsUrl, renderDiagnostics
 const packageDir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const packageCommandTimeoutMs = 120_000;
 const packageCommandKillSignal: NodeJS.Signals = 'SIGTERM';
+let viewerRoot: Root | undefined;
 
 afterEach(() => {
+  viewerRoot?.unmount();
+  viewerRoot = undefined;
   delete (window as typeof window & { __FLUO_STUDIO__?: unknown }).__FLUO_STUDIO__;
   vi.unstubAllGlobals();
 });
@@ -125,11 +129,12 @@ const snapshotFixture: PlatformShellSnapshot = {
   },
 };
 
-async function loadStudioViewer(): Promise<void> {
+function loadStudioViewer(): Root {
   vi.resetModules();
   document.body.innerHTML = '<div id="app"></div>';
 
-  await import('./main.js');
+  viewerRoot = bootstrapStudioApp();
+  return viewerRoot;
 }
 
 function loadViewerFile(content: string, filename: string): void {
@@ -748,7 +753,7 @@ describe('parseStudioPayload', () => {
   });
 
   it('keeps viewer filter controls focused across search, readiness, and severity rerenders', async () => {
-    await loadStudioViewer();
+    loadStudioViewer();
     loadViewerFile(JSON.stringify(snapshotFixture), 'snapshot.json');
 
     await vi.waitFor(() => {
@@ -757,10 +762,13 @@ describe('parseStudioPayload', () => {
 
     const searchInput = document.querySelector<HTMLInputElement>('#search');
     expect(searchInput).not.toBeNull();
-    searchInput!.value = 'redis.default';
-    searchInput?.focus();
-    searchInput?.setSelectionRange(2, 7);
-    searchInput?.dispatchEvent(new Event('input', { bubbles: true }));
+    if (!searchInput) {
+      throw new Error('Expected the Studio search input to be rendered.');
+    }
+    searchInput.value = 'redis.default';
+    searchInput.focus();
+    searchInput.setSelectionRange(2, 7);
+    searchInput.dispatchEvent(new Event('input', { bubbles: true }));
 
     const restoredSearchInput = document.querySelector<HTMLInputElement>('#search');
     expect(document.activeElement).toBe(restoredSearchInput);
@@ -770,9 +778,12 @@ describe('parseStudioPayload', () => {
 
     const readinessInput = document.querySelector<HTMLInputElement>('#readiness-ready');
     expect(readinessInput).not.toBeNull();
-    readinessInput?.focus();
-    readinessInput!.checked = true;
-    readinessInput?.dispatchEvent(new Event('change', { bubbles: true }));
+    if (!readinessInput) {
+      throw new Error('Expected the Studio readiness filter to be rendered.');
+    }
+    readinessInput.focus();
+    readinessInput.checked = true;
+    readinessInput.dispatchEvent(new Event('change', { bubbles: true }));
 
     const restoredReadinessInput = document.querySelector<HTMLInputElement>('#readiness-ready');
     expect(document.activeElement).toBe(restoredReadinessInput);
@@ -780,9 +791,12 @@ describe('parseStudioPayload', () => {
 
     const severityInput = document.querySelector<HTMLInputElement>('#severity-warning');
     expect(severityInput).not.toBeNull();
-    severityInput?.focus();
-    severityInput!.checked = true;
-    severityInput?.dispatchEvent(new Event('change', { bubbles: true }));
+    if (!severityInput) {
+      throw new Error('Expected the Studio severity filter to be rendered.');
+    }
+    severityInput.focus();
+    severityInput.checked = true;
+    severityInput.dispatchEvent(new Event('change', { bubbles: true }));
 
     const restoredSeverityInput = document.querySelector<HTMLInputElement>('#severity-warning');
     expect(document.activeElement).toBe(restoredSeverityInput);
@@ -790,7 +804,7 @@ describe('parseStudioPayload', () => {
   });
 
   it('loads a dropped Studio JSON file into graph, summary, and diagnostics views', async () => {
-    await loadStudioViewer();
+    loadStudioViewer();
 
     const dropZone = document.querySelector<HTMLElement>('#drop-zone');
     expect(dropZone).not.toBeNull();
@@ -816,7 +830,7 @@ describe('parseStudioPayload', () => {
   });
 
   it('supports keyboard graph node selection without mouse interaction', async () => {
-    await loadStudioViewer();
+    loadStudioViewer();
     loadViewerFile(JSON.stringify(snapshotFixture), 'snapshot.json');
 
     await vi.waitFor(() => {
@@ -837,7 +851,7 @@ describe('parseStudioPayload', () => {
   });
 
   it('loads snapshot-plus-timing artifacts into static graph and timing views', async () => {
-    await loadStudioViewer();
+    loadStudioViewer();
     loadViewerFile(
       JSON.stringify({
         snapshot: snapshotFixture,
@@ -860,7 +874,7 @@ describe('parseStudioPayload', () => {
   });
 
   it('loads report artifacts into static graph, summary, diagnostics, and timing views', async () => {
-    await loadStudioViewer();
+    loadStudioViewer();
     loadViewerFile(
       JSON.stringify({
         generatedAt: snapshotFixture.generatedAt,
@@ -895,7 +909,7 @@ describe('parseStudioPayload', () => {
   });
 
   it('loads standalone timing diagnostics without requiring a static graph', async () => {
-    await loadStudioViewer();
+    loadStudioViewer();
     loadViewerFile(
       JSON.stringify({
         phases: [{ durationMs: 1.23, name: 'bootstrap_module' }],
@@ -993,7 +1007,22 @@ describe('applyFilters', () => {
 
     expect(filtered.components.map((component: { id: string }) => component.id)).toEqual(['redis.default', 'queue.default']);
     expect(filtered.diagnostics.map((issue: { code: string }) => issue.code)).toEqual(['QUEUE_DEPENDENCY_NOT_READY']);
-    expect(snapshotFixture.components).toHaveLength(2);
+  });
+
+  it('preserves deep input state and returns distinct snapshot collections', () => {
+    const source = structuredClone(snapshotFixture);
+    const original = structuredClone(source);
+
+    const filtered = applyFilters(source, {
+      query: 'redis.default',
+      readinessStatuses: [],
+      severities: [],
+    });
+
+    expect(source).toEqual(original);
+    expect(filtered).not.toBe(source);
+    expect(filtered.components).not.toBe(source.components);
+    expect(filtered.diagnostics).not.toBe(source.diagnostics);
   });
 
   it('applies query filters across diagnostic metadata and blockers', () => {

--- a/packages/studio/src/features/live-connection/model/useStudioLiveConnection.test.ts
+++ b/packages/studio/src/features/live-connection/model/useStudioLiveConnection.test.ts
@@ -112,6 +112,7 @@ function liveHeartbeatEvent(sequence: number): StudioLiveEvent {
 describe('useStudioLiveConnection', () => {
   afterEach(() => {
     delete (window as typeof window & { __FLUO_STUDIO__?: unknown }).__FLUO_STUDIO__;
+    window.history.replaceState({}, '', '/');
     vi.useRealTimers();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
@@ -164,6 +165,41 @@ describe('useStudioLiveConnection', () => {
 
     expect(FakeEventSource.instances).toHaveLength(0);
     expect(observedStates.some((state) => state.events.length > 0)).toBe(false);
+  });
+
+  it('consumes the viewer query token for state replay and live events', async () => {
+    const token = 'live token+/=?&';
+    const encodedToken = encodeURIComponent(token);
+    const search = new URLSearchParams({ token });
+    window.history.replaceState({}, '', `/?${search.toString()}`);
+    vi.stubGlobal('EventSource', FakeEventSource);
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ events: [], sequence: 0 }), { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    function Harness() {
+      const [state, dispatch] = useReducer(studioReducer, initialStudioState);
+      useStudioLiveConnection(dispatch);
+      return createElement('output', null, state.connection.status);
+    }
+
+    const container = document.createElement('div');
+    document.body.append(container);
+    const root: Root = createRoot(container);
+    root.render(createElement(Harness));
+
+    try {
+      await vi.waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledWith(
+          `/api/state?token=${encodedToken}`,
+          expect.objectContaining({ signal: expect.any(AbortSignal) }),
+        );
+        expect(FakeEventSource.instances).toHaveLength(1);
+      });
+
+      expect(FakeEventSource.instances[0]?.url).toBe(`/api/events?token=${encodedToken}`);
+    } finally {
+      root.unmount();
+    }
   });
 
   it('reports the full live connection lifecycle state set', async () => {

--- a/packages/studio/src/shared/lib/studio-config.test.ts
+++ b/packages/studio/src/shared/lib/studio-config.test.ts
@@ -1,0 +1,25 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { resolveStudioSidecarConfig } from './studio-config.js';
+
+describe('resolveStudioSidecarConfig', () => {
+  afterEach(() => {
+    window.history.replaceState({}, '', '/');
+    delete window.__FLUO_STUDIO__;
+  });
+
+  it('derives encoded state and event URLs from the viewer query token', () => {
+    const token = 'studio token+/=?&';
+    const search = new URLSearchParams({ token });
+    window.history.replaceState({}, '', `/?${search.toString()}`);
+
+    const config = resolveStudioSidecarConfig();
+    const encodedToken = encodeURIComponent(token);
+
+    expect(config).toEqual({
+      eventsUrl: `/api/events?token=${encodedToken}`,
+      stateUrl: `/api/state?token=${encodedToken}`,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Hardens existing `@fluojs/studio` viewer, filtering, and live-token contracts with deterministic regression coverage only.

Linked context: Closes #2680

## Changes

- Track the static viewer React root and unmount it in `afterEach`, so every viewer scenario releases its mounted tree even when an assertion fails.
- Verify `applyFilters()` preserves the complete nested input snapshot while returning distinct top-level and filtered collection references.
- Add direct `resolveStudioSidecarConfig()` coverage for URL query tokens containing reserved characters.
- Exercise the same query-token path through `useStudioLiveConnection()`, asserting token propagation to both state replay and EventSource URLs.
- Keep the change test-only; no runtime implementation, UI, styling, docs, or public exports changed.

## Testing

- `pnpm --filter @fluojs/studio... build`
- `pnpm --dir packages/studio test` — 6 files, 58 tests passed
- `pnpm --dir packages/studio typecheck`
- `pnpm lint`
- `pnpm exec biome check packages/studio/src/contracts.test.ts packages/studio/src/shared/lib/studio-config.test.ts packages/studio/src/features/live-connection/model/useStudioLiveConnection.test.ts`
- TypeScript no-excuse audit for all changed files
- `git diff --check`

TypeScript LSP diagnostics were unavailable because the local TypeScript language server is not installed; the package typecheck and changed-file Biome checks passed.

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

No `.changeset/*.md` is included because this PR changes tests only and does not alter published package behavior, API surface, package contents, or release metadata.

## Public export documentation

Not applicable: no public exports or source TSDoc changed. Existing README and public export documentation remain unchanged.

- [x] Public export summary requirements are not applicable because no exports changed.
- [x] `@param` / `@returns` requirements are not applicable because no exported functions changed.
- [x] Source and README examples are unchanged.

## Behavioral contract

- [x] No documented behavioral contracts were removed or changed.
- [x] No new behavioral contracts require README updates.
- [x] Existing intentional limitations remain unchanged.
- [x] Existing runtime invariants are strengthened by deterministic regression tests for viewer cleanup, immutable filtering, and query-token consumption.

Acceptance mapping:

- Viewer cleanup: `packages/studio/src/contracts.test.ts` tracks the mounted `Root` and unmounts it from `afterEach`.
- Filtering immutability: `packages/studio/src/contracts.test.ts` compares the full nested source snapshot and verifies distinct result collections.
- Viewer token config: `packages/studio/src/shared/lib/studio-config.test.ts` verifies reserved query tokens are decoded and safely re-encoded for both sidecar URLs.
- Live token consumption: `packages/studio/src/features/live-connection/model/useStudioLiveConnection.test.ts` verifies state replay and EventSource use the query-derived token.

## Platform consistency governance (SSOT)

- [x] No governance SSOT or English/Korean mirror documents changed.
- [x] No platform contract docs, discoverability indexes, tooling, or CI enforcement changed.
- [x] No package README alignment or platform conformance claims changed; platform harness coverage is not applicable to this test-only Studio viewer change.

## Risks

Low. The PR changes only test code. The remaining risk is that browser-specific behavior outside Happy DOM may differ, but the tests exercise the existing production URL parsing, React hook, fetch, and EventSource seams without timing sleeps or external network access.