### PR TITLE
Resolve #2682: Harden testing package export and cleanup regressions

### DIFF
--- a/packages/testing/src/babel-decorators-plugin.test.ts
+++ b/packages/testing/src/babel-decorators-plugin.test.ts
@@ -89,6 +89,14 @@ describe('fluoBabelDecoratorsPlugin', () => {
     },
   );
 
+  it('prefers the nearest Babel root config over an ancestor config', () => {
+    const { filePath, root } = createWorkspaceWithConfig('babel.config.cjs');
+    const nestedConfigFile = join(root, 'src', 'babel.config.json');
+    writeFileSync(nestedConfigFile, '{}');
+
+    expect(resolveNearestBabelConfigFile(filePath)).toBe(nestedConfigFile);
+  });
+
   it('fails clearly when no Babel root config can be found', async () => {
     mockedTransformAsync.mockClear();
     const root = mkdtempSync(join(tmpdir(), 'fluo-testing-babel-missing-'));

--- a/packages/testing/src/portability/http-adapter-portability.test.ts
+++ b/packages/testing/src/portability/http-adapter-portability.test.ts
@@ -1,13 +1,12 @@
-import { describe, expect, it, vi } from 'vitest';
-
+import { bootstrapExpressApplication, runExpressApplication } from '@fluojs/platform-express';
 import {
   bootstrapFastifyApplication,
-  FastifyHttpApplicationAdapter,
+  type FastifyHttpApplicationAdapter,
   runFastifyApplication,
 } from '@fluojs/platform-fastify';
-import { bootstrapExpressApplication, runExpressApplication } from '@fluojs/platform-express';
 import { bootstrapNodejsApplication, runNodejsApplication } from '@fluojs/platform-nodejs';
 import { bootstrapNodeApplication, runNodeApplication } from '@fluojs/runtime/node';
+import { describe, expect, it, vi } from 'vitest';
 
 import { createHttpAdapterPortabilityHarness } from './http-adapter-portability.js';
 
@@ -273,15 +272,19 @@ describe('http adapter portability cleanup reporting', () => {
     });
 
     try {
-      await harness.assertRemovesShutdownSignalListenersAfterClose();
-      throw new Error('Expected cleanup failure to be reported.');
-    } catch (error) {
-      expect(error).toBeInstanceOf(AggregateError);
-      if (!(error instanceof AggregateError)) {
-        throw error;
+      try {
+        await harness.assertRemovesShutdownSignalListenersAfterClose();
+        throw new Error('Expected cleanup failure to be reported.');
+      } catch (error) {
+        expect(error).toBeInstanceOf(AggregateError);
+        if (!(error instanceof AggregateError)) {
+          throw error;
+        }
+        expect(error.message).toContain('app.close() failed during portability harness cleanup');
+        expect(error.errors).toEqual([closeError]);
       }
-      expect(error.message).toContain('app.close() failed during portability harness cleanup');
-      expect(error.errors).toEqual([closeError]);
+    } finally {
+      process.removeListener(signal, listener);
     }
   });
 

--- a/packages/testing/src/surface.test.ts
+++ b/packages/testing/src/surface.test.ts
@@ -1,7 +1,9 @@
-import { spawn } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { type ChildProcessWithoutNullStreams, execFile, spawn } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
 
 import type { Mock } from 'vitest';
 import { describe, expect, it } from 'vitest';
@@ -50,7 +52,11 @@ const packageRoot = new URL('..', import.meta.url);
 const packageRootPath = fileURLToPath(packageRoot);
 const repoRootPath = fileURLToPath(new URL('../../..', import.meta.url));
 const packageJsonPath = new URL('../package.json', import.meta.url);
+const execFileAsync = promisify(execFile);
 const CHILD_PROCESS_TIMEOUT_MS = 240_000;
+const PROCESS_TERMINATION_CONFIRM_TIMEOUT_MS = 5_000;
+const PROCESS_EXIT_POLL_MS = 20;
+const PROCESS_EXIT_TEST_TIMEOUT_MS = 500;
 const emittedHarnessSubpaths = [
   '.',
   './app',
@@ -66,58 +72,147 @@ const emittedHarnessSubpaths = [
   './vitest/tooling',
 ] as const;
 
-function runNodeProcess(args: readonly string[], cwd: string): Promise<void> {
-  return new Promise((resolvePromise, reject) => {
-    const child = spawn(process.execPath, [...args], {
-      cwd,
-      env: process.env,
-      stdio: 'pipe',
-    });
-    let stderr = '';
-    let stdout = '';
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ESRCH') {
+      return false;
+    }
 
-    const onStdout = (chunk: Buffer | string): void => {
-      stdout += String(chunk);
-    };
-    const onStderr = (chunk: Buffer | string): void => {
-      stderr += String(chunk);
-    };
-    const cleanup = (): void => {
-      clearTimeout(timeout);
-      child.stdout.off('data', onStdout);
-      child.stderr.off('data', onStderr);
-      child.off('error', onError);
-      child.off('exit', onExit);
-    };
-    const rejectAndStop = (error: Error): void => {
+    throw error;
+  }
+}
+
+async function waitForProcessExit(pid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    if (!isProcessAlive(pid)) {
+      return true;
+    }
+
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, PROCESS_EXIT_POLL_MS));
+  }
+
+  return !isProcessAlive(pid);
+}
+
+async function terminateOwnedProcessTree(child: ChildProcessWithoutNullStreams): Promise<void> {
+  const pid = child.pid;
+
+  if (pid === undefined || child.exitCode !== null || child.signalCode !== null) {
+    return;
+  }
+
+  if (process.platform === 'win32') {
+    try {
+      await execFileAsync('taskkill.exe', ['/pid', String(pid), '/t', '/f'], { windowsHide: true });
+    } catch (error) {
       if (child.exitCode === null && child.signalCode === null) {
-        child.kill('SIGKILL');
+        throw new Error(`Unable to terminate child process tree ${pid} with taskkill.exe.`, { cause: error });
       }
-      cleanup();
-      reject(error);
-    };
-    const onError = (error: Error): void => {
-      rejectAndStop(error);
-    };
-    const onExit = (code: number | null, signal: NodeJS.Signals | null): void => {
-      cleanup();
+    }
+    return;
+  }
 
-      if (code !== 0 || signal !== null) {
-        reject(new Error([stdout, stderr, signal ? `signal: ${signal}` : ''].filter(Boolean).join('\n')));
-        return;
-      }
+  try {
+    process.kill(-pid, 'SIGKILL');
+  } catch (error) {
+    if (!(error instanceof Error && 'code' in error && error.code === 'ESRCH')) {
+      throw new Error(`Unable to terminate child process group ${pid}.`, { cause: error });
+    }
+  }
+}
 
-      resolvePromise();
-    };
-    const timeout = setTimeout(() => {
-      rejectAndStop(new Error(`Child process timed out after ${CHILD_PROCESS_TIMEOUT_MS}ms: ${args.join(' ')}`));
-    }, CHILD_PROCESS_TIMEOUT_MS);
-
-    child.stdout.on('data', onStdout);
-    child.stderr.on('data', onStderr);
-    child.once('error', onError);
-    child.once('exit', onExit);
+async function runNodeProcess(
+  args: readonly string[],
+  cwd: string,
+  timeoutMs: number = CHILD_PROCESS_TIMEOUT_MS,
+): Promise<void> {
+  const child = spawn(process.execPath, [...args], {
+    cwd,
+    detached: process.platform !== 'win32',
+    env: process.env,
+    stdio: 'pipe',
   });
+  let spawnError: Error | undefined;
+  let stderr = '';
+  let stdout = '';
+
+  const onStdout = (chunk: Buffer | string): void => {
+    stdout += String(chunk);
+  };
+  const onStderr = (chunk: Buffer | string): void => {
+    stderr += String(chunk);
+  };
+  const onError = (error: Error): void => {
+    spawnError = error;
+  };
+  let onClose: (code: number | null, signal: NodeJS.Signals | null) => void = () => {};
+  const closePromise = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolvePromise) => {
+    onClose = (code, signal): void => {
+      resolvePromise({ code, signal });
+    };
+    child.once('close', onClose);
+  });
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<'timeout'>((resolvePromise) => {
+    timeout = setTimeout(() => resolvePromise('timeout'), timeoutMs);
+  });
+
+  child.stdout.on('data', onStdout);
+  child.stderr.on('data', onStderr);
+  child.once('error', onError);
+
+  try {
+    const outcome = await Promise.race([closePromise, timeoutPromise]);
+
+    if (outcome === 'timeout') {
+      const timeoutError = new Error(`Child process timed out after ${timeoutMs}ms: ${args.join(' ')}`);
+      let confirmationTimeout: ReturnType<typeof setTimeout> | undefined;
+
+      try {
+        await terminateOwnedProcessTree(child);
+        await Promise.race([
+          closePromise,
+          new Promise<never>((_resolvePromise, reject) => {
+            confirmationTimeout = setTimeout(() => {
+              reject(new Error(`Child process ${String(child.pid)} did not close after process-tree termination.`));
+            }, PROCESS_TERMINATION_CONFIRM_TIMEOUT_MS);
+          }),
+        ]);
+      } catch (error) {
+        throw new AggregateError(
+          [timeoutError, error],
+          'Child process timed out and owned process-tree termination could not be confirmed.',
+        );
+      } finally {
+        if (confirmationTimeout !== undefined) {
+          clearTimeout(confirmationTimeout);
+        }
+      }
+
+      throw timeoutError;
+    }
+
+    if (spawnError) {
+      throw spawnError;
+    }
+
+    if (outcome.code !== 0 || outcome.signal !== null) {
+      throw new Error([stdout, stderr, outcome.signal ? `signal: ${outcome.signal}` : ''].filter(Boolean).join('\n'));
+    }
+  } finally {
+    if (timeout !== undefined) {
+      clearTimeout(timeout);
+    }
+    child.stdout.off('data', onStdout);
+    child.stderr.off('data', onStderr);
+    child.off('error', onError);
+    child.off('close', onClose);
+  }
 }
 
 async function runBuild(): Promise<void> {
@@ -223,6 +318,36 @@ describe('@fluojs/testing surface', () => {
     expect(koreanReadme).not.toContain('**Mock 서브패스**');
     expect(koreanReadme).not.toContain('**HTTP 헬퍼**');
   });
+
+  it('terminates descendant processes before reporting a child timeout', async () => {
+    const fixtureRoot = mkdtempSync(join(tmpdir(), 'fluo-testing-process-tree-'));
+    const descendantPidFile = join(fixtureRoot, 'descendant.pid');
+    const descendantScript = 'setInterval(() => {}, 1_000);';
+    const parentScript = `
+      const { spawn } = await import('node:child_process');
+      const { writeFileSync } = await import('node:fs');
+      const descendant = spawn(process.execPath, ['--eval', ${JSON.stringify(descendantScript)}], {
+        stdio: ['ignore', 'inherit', 'inherit'],
+      });
+      writeFileSync(${JSON.stringify(descendantPidFile)}, String(descendant.pid));
+      setInterval(() => {}, 1_000);
+    `;
+    let descendantPid: number | undefined;
+
+    try {
+      await expect(
+        runNodeProcess(['--input-type=module', '--eval', parentScript], packageRootPath, 1_000),
+      ).rejects.toThrow('Child process timed out after 1000ms');
+
+      descendantPid = Number(readFileSync(descendantPidFile, 'utf8'));
+      expect(await waitForProcessExit(descendantPid, PROCESS_EXIT_TEST_TIMEOUT_MS)).toBe(true);
+    } finally {
+      if (descendantPid !== undefined && isProcessAlive(descendantPid)) {
+        process.kill(descendantPid, 'SIGKILL');
+      }
+      rmSync(fixtureRoot, { force: true, recursive: true });
+    }
+  }, 5_000);
 
   it('build emits the published harness subpath files without blocking the Vitest worker event loop', async () => {
     await runBuild();

--- a/packages/testing/src/surface.test.ts
+++ b/packages/testing/src/surface.test.ts
@@ -22,6 +22,14 @@ import * as vitestEntry from './vitest.js';
 
 type Assert<T extends true> = T;
 type IsAssignable<From, To> = [From] extends [To] ? true : false;
+type TaskkillCommand = (
+  file: string,
+  args: readonly string[],
+  options: { readonly timeout?: number; readonly windowsHide: boolean },
+) => Promise<void>;
+type DestroyableStdio = {
+  destroy(): unknown;
+};
 
 interface LegacyDeepMockedConsumerService {
   findById(id: string): Promise<{ id: string }>;
@@ -72,6 +80,10 @@ const emittedHarnessSubpaths = [
   './vitest/tooling',
 ] as const;
 
+const executeTaskkillCommand: TaskkillCommand = async (file, args, options) => {
+  await execFileAsync(file, [...args], options);
+};
+
 function isProcessAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
@@ -99,6 +111,36 @@ async function waitForProcessExit(pid: number, timeoutMs: number): Promise<boole
   return !isProcessAlive(pid);
 }
 
+function destroyOwnedStdio(streams: readonly DestroyableStdio[], preservePrimaryError: boolean): void {
+  const cleanupErrors: unknown[] = [];
+
+  for (const stream of streams) {
+    try {
+      stream.destroy();
+    } catch (error) {
+      cleanupErrors.push(error);
+    }
+  }
+
+  if (!preservePrimaryError && cleanupErrors.length > 0) {
+    throw new AggregateError(cleanupErrors, 'Failed to destroy one or more child process stdio handles.');
+  }
+}
+
+async function runWindowsTaskkill(pid: number, execute: TaskkillCommand = executeTaskkillCommand): Promise<void> {
+  try {
+    await execute('taskkill.exe', ['/pid', String(pid), '/t', '/f'], {
+      timeout: PROCESS_TERMINATION_CONFIRM_TIMEOUT_MS,
+      windowsHide: true,
+    });
+  } catch (error) {
+    throw new Error(
+      `Unable to terminate Windows child process tree ${pid} within ${PROCESS_TERMINATION_CONFIRM_TIMEOUT_MS}ms using taskkill.exe /T /F.`,
+      { cause: error },
+    );
+  }
+}
+
 async function terminateOwnedProcessTree(child: ChildProcessWithoutNullStreams): Promise<void> {
   const pid = child.pid;
 
@@ -108,10 +150,10 @@ async function terminateOwnedProcessTree(child: ChildProcessWithoutNullStreams):
 
   if (process.platform === 'win32') {
     try {
-      await execFileAsync('taskkill.exe', ['/pid', String(pid), '/t', '/f'], { windowsHide: true });
+      await runWindowsTaskkill(pid);
     } catch (error) {
       if (child.exitCode === null && child.signalCode === null) {
-        throw new Error(`Unable to terminate child process tree ${pid} with taskkill.exe.`, { cause: error });
+        throw error;
       }
     }
     return;
@@ -165,6 +207,7 @@ async function runNodeProcess(
   child.stdout.on('data', onStdout);
   child.stderr.on('data', onStderr);
   child.once('error', onError);
+  let hasPrimaryError = false;
 
   try {
     const outcome = await Promise.race([closePromise, timeoutPromise]);
@@ -204,6 +247,9 @@ async function runNodeProcess(
     if (outcome.code !== 0 || outcome.signal !== null) {
       throw new Error([stdout, stderr, outcome.signal ? `signal: ${outcome.signal}` : ''].filter(Boolean).join('\n'));
     }
+  } catch (error) {
+    hasPrimaryError = true;
+    throw error;
   } finally {
     if (timeout !== undefined) {
       clearTimeout(timeout);
@@ -212,6 +258,7 @@ async function runNodeProcess(
     child.stderr.off('data', onStderr);
     child.off('error', onError);
     child.off('close', onClose);
+    destroyOwnedStdio([child.stdin, child.stdout, child.stderr], hasPrimaryError);
   }
 }
 
@@ -319,6 +366,51 @@ describe('@fluojs/testing surface', () => {
     expect(koreanReadme).not.toContain('**HTTP 헬퍼**');
   });
 
+  it('bounds and reports taskkill failures without invoking Windows', async () => {
+    const taskkillFailure = new Error('taskkill stalled');
+    let observedTimeout: number | undefined;
+
+    await expect(
+      runWindowsTaskkill(42, async (_file, _args, options) => {
+        observedTimeout = options.timeout;
+        throw taskkillFailure;
+      }),
+    ).rejects.toMatchObject({
+      cause: taskkillFailure,
+      message: `Unable to terminate Windows child process tree 42 within ${PROCESS_TERMINATION_CONFIRM_TIMEOUT_MS}ms using taskkill.exe /T /F.`,
+    });
+    expect(observedTimeout).toBe(PROCESS_TERMINATION_CONFIRM_TIMEOUT_MS);
+  });
+
+  it('destroys every owned stdio handle without replacing a primary child failure', () => {
+    const destroyed: string[] = [];
+
+    expect(() =>
+      destroyOwnedStdio(
+        [
+          {
+            destroy() {
+              destroyed.push('stdin');
+              throw new Error('stdin cleanup failed');
+            },
+          },
+          {
+            destroy() {
+              destroyed.push('stdout');
+            },
+          },
+          {
+            destroy() {
+              destroyed.push('stderr');
+            },
+          },
+        ],
+        true,
+      ),
+    ).not.toThrow();
+    expect(destroyed).toEqual(['stdin', 'stdout', 'stderr']);
+  });
+
   it('terminates descendant processes before reporting a child timeout', async () => {
     const fixtureRoot = mkdtempSync(join(tmpdir(), 'fluo-testing-process-tree-'));
     const descendantPidFile = join(fixtureRoot, 'descendant.pid');
@@ -342,6 +434,12 @@ describe('@fluojs/testing surface', () => {
       descendantPid = Number(readFileSync(descendantPidFile, 'utf8'));
       expect(await waitForProcessExit(descendantPid, PROCESS_EXIT_TEST_TIMEOUT_MS)).toBe(true);
     } finally {
+      if (descendantPid === undefined && existsSync(descendantPidFile)) {
+        const discoveredPid = Number(readFileSync(descendantPidFile, 'utf8'));
+        if (Number.isSafeInteger(discoveredPid) && discoveredPid > 0) {
+          descendantPid = discoveredPid;
+        }
+      }
       if (descendantPid !== undefined && isProcessAlive(descendantPid)) {
         process.kill(descendantPid, 'SIGKILL');
       }

--- a/packages/testing/src/surface.test.ts
+++ b/packages/testing/src/surface.test.ts
@@ -1,5 +1,4 @@
 import { spawn } from 'node:child_process';
-import { once } from 'node:events';
 import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -9,11 +8,12 @@ import { describe, expect, it } from 'vitest';
 import * as fetchStyleWebsocket from './conformance/fetch-style-websocket-conformance.js';
 import * as conformance from './conformance/platform-conformance.js';
 import * as http from './http.js';
+import type { DeepMocked as RootDeepMocked } from './index.js';
 import * as testing from './index.js';
+import type { DeepMocked as MockDeepMocked } from './mock.js';
 import * as mock from './mock.js';
 import * as portability from './portability/http-adapter-portability.js';
 import * as webPortability from './portability/web-runtime-adapter-portability.js';
-import type { DeepMocked as RootDeepMocked } from './index.js';
 import type { DeepMocked } from './types.js';
 import * as vitestTooling from './vitest/tooling.js';
 import * as vitestEntry from './vitest.js';
@@ -42,11 +42,15 @@ type _DeepMockedMockContextPreservesCallTuples = Assert<
 type _RootDeepMockedPreservesVitestMockCompatibility = Assert<
   IsAssignable<RootDeepMocked<LegacyDeepMockedConsumerService>['findById'], Mock<(id: string) => Promise<{ id: string }>>>
 >;
+type _MockDeepMockedPreservesVitestMockCompatibility = Assert<
+  IsAssignable<MockDeepMocked<LegacyDeepMockedConsumerService>['findById'], Mock<(id: string) => Promise<{ id: string }>>>
+>;
 
 const packageRoot = new URL('..', import.meta.url);
 const packageRootPath = fileURLToPath(packageRoot);
 const repoRootPath = fileURLToPath(new URL('../../..', import.meta.url));
 const packageJsonPath = new URL('../package.json', import.meta.url);
+const CHILD_PROCESS_TIMEOUT_MS = 240_000;
 const emittedHarnessSubpaths = [
   '.',
   './app',
@@ -62,41 +66,64 @@ const emittedHarnessSubpaths = [
   './vitest/tooling',
 ] as const;
 
-async function runBuild(): Promise<void> {
-  const scriptPath = fileURLToPath(new URL('../../../tooling/scripts/run-workspace-build-closure.mjs', import.meta.url));
-
-  await new Promise<void>((resolvePromise, reject) => {
-    const child = spawn(process.execPath, [scriptPath, '@fluojs/testing'], {
-      cwd: repoRootPath,
+function runNodeProcess(args: readonly string[], cwd: string): Promise<void> {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(process.execPath, [...args], {
+      cwd,
       env: process.env,
       stdio: 'pipe',
     });
-    const childEvents = child as unknown as NodeJS.EventEmitter;
-
     let stderr = '';
     let stdout = '';
 
-    child.stdout.on('data', (chunk) => {
+    const onStdout = (chunk: Buffer | string): void => {
       stdout += String(chunk);
-    });
-
-    child.stderr.on('data', (chunk) => {
+    };
+    const onStderr = (chunk: Buffer | string): void => {
       stderr += String(chunk);
-    });
-
-    void once(childEvents, 'error').then(([error]) => {
+    };
+    const cleanup = (): void => {
+      clearTimeout(timeout);
+      child.stdout.off('data', onStdout);
+      child.stderr.off('data', onStderr);
+      child.off('error', onError);
+      child.off('exit', onExit);
+    };
+    const rejectAndStop = (error: Error): void => {
+      if (child.exitCode === null && child.signalCode === null) {
+        child.kill('SIGKILL');
+      }
+      cleanup();
       reject(error);
-    });
+    };
+    const onError = (error: Error): void => {
+      rejectAndStop(error);
+    };
+    const onExit = (code: number | null, signal: NodeJS.Signals | null): void => {
+      cleanup();
 
-    void once(childEvents, 'exit').then(([code, signal]) => {
-      if (code !== 0 || signal) {
+      if (code !== 0 || signal !== null) {
         reject(new Error([stdout, stderr, signal ? `signal: ${signal}` : ''].filter(Boolean).join('\n')));
         return;
       }
 
       resolvePromise();
-    });
+    };
+    const timeout = setTimeout(() => {
+      rejectAndStop(new Error(`Child process timed out after ${CHILD_PROCESS_TIMEOUT_MS}ms: ${args.join(' ')}`));
+    }, CHILD_PROCESS_TIMEOUT_MS);
+
+    child.stdout.on('data', onStdout);
+    child.stderr.on('data', onStderr);
+    child.once('error', onError);
+    child.once('exit', onExit);
   });
+}
+
+async function runBuild(): Promise<void> {
+  const scriptPath = fileURLToPath(new URL('../../../tooling/scripts/run-workspace-build-closure.mjs', import.meta.url));
+
+  await runNodeProcess([scriptPath, '@fluojs/testing'], repoRootPath);
 }
 
 describe('@fluojs/testing surface', () => {
@@ -233,38 +260,7 @@ describe('@fluojs/testing surface', () => {
       await Promise.all(subpaths.map((subpath) => import(subpath === '.' ? '@fluojs/testing' : '@fluojs/testing/' + subpath.slice(2))));
     `;
 
-    await new Promise<void>((resolvePromise, reject) => {
-      const child = spawn(process.execPath, ['--input-type=module', '--eval', importScript], {
-        cwd: packageRootPath,
-        env: process.env,
-        stdio: 'pipe',
-      });
-      const childEvents = child as unknown as NodeJS.EventEmitter;
-
-      let stderr = '';
-      let stdout = '';
-
-      child.stdout.on('data', (chunk) => {
-        stdout += String(chunk);
-      });
-
-      child.stderr.on('data', (chunk) => {
-        stderr += String(chunk);
-      });
-
-      void once(childEvents, 'error').then(([error]) => {
-        reject(error);
-      });
-
-      void once(childEvents, 'exit').then(([code, signal]) => {
-        if (code !== 0) {
-          reject(new Error([stdout, stderr, signal ? `signal: ${signal}` : ''].filter(Boolean).join('\n')));
-          return;
-        }
-
-        resolvePromise();
-      });
-    });
+    await runNodeProcess(['--input-type=module', '--eval', importScript], packageRootPath);
 
     const mockSubpath = '@fluojs/testing/mock' as string;
     await expect(import(mockSubpath)).resolves.toBeTypeOf('object');


### PR DESCRIPTION
## Summary

`@fluojs/testing`의 기존 공개 export 및 cleanup 계약을 test-only regression coverage로 강화합니다.

Linked context: https://github.com/fluojs/fluo/issues/2682

Closes #2682

## Changes

- nested Babel config가 ancestor config보다 우선되는 nearest-root resolution을 고정했습니다.
- `@fluojs/testing/mock`의 `DeepMocked<T>`를 consumer-style type assertion으로 검증했습니다.
- surface build/export-map child process에 bounded timeout, forced termination, listener cleanup을 공통 적용했습니다.
- cleanup failure test가 process-wide signal listener를 test-owned `finally`에서 항상 제거하면서 기존 `AggregateError` 의미를 계속 검증하도록 했습니다.

## Testing

- `pnpm --filter @fluojs/testing test` — 11 files, 190 tests passed
- `pnpm --filter @fluojs/testing typecheck` — passed
- `pnpm exec biome check packages/testing/src/babel-decorators-plugin.test.ts packages/testing/src/surface.test.ts packages/testing/src/portability/http-adapter-portability.test.ts` — passed
- `pnpm lint` — passed; repository baseline infos/warnings only
- `pnpm verify:platform-consistency-governance` — passed
- `pnpm verify` — 298 files passed, 4088 tests passed, 1 skipped
- TypeScript LSP diagnostics were unavailable because the configured LSP server is not installed; package and repository typecheck gates passed instead.

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

No changeset: all changes are test-only and do not alter published package contents, runtime behavior, API surface, or release metadata.

## Public export documentation

- [x] No public export implementation changed; the existing `DeepMocked<T>` mock-subpath contract only gained compile-time consumer coverage.
- [x] No source TSDoc or README update is required.

## Behavioral contract

- [x] No documented behavioral contracts were removed or changed.
- [x] Existing Babel config precedence, public mock type export, cleanup failure aggregation, and listener cleanup contracts are covered by deterministic regressions.
- [x] Runtime behavior remains unchanged.

## Platform consistency governance (SSOT)

- [x] No governance docs or EN/KO mirrors changed.
- [x] `pnpm verify:platform-consistency-governance` passed.
- [x] HTTP adapter portability cleanup coverage remains on `createHttpAdapterPortabilityHarness(...)`.
