### PR TITLE
Resolve #2549: cover bootstrap cleanup error preservation

### DIFF
--- a/packages/runtime/src/bootstrap.test.ts
+++ b/packages/runtime/src/bootstrap.test.ts
@@ -1014,6 +1014,79 @@ describe('FluoFactory.createApplicationContext', () => {
     ]);
   });
 
+  it('preserves the original application bootstrap error when a runtime cleanup callback fails', async () => {
+    const bootstrapFailure = new Error('application bootstrap failed');
+    const cleanupFailure = new Error('application cleanup failed');
+    const logger = { debug: vi.fn(), error: vi.fn(), log: vi.fn(), warn: vi.fn() };
+
+    @Inject(RUNTIME_CLEANUP_REGISTRATION)
+    class CleanupRegistrant implements OnModuleInit {
+      constructor(private readonly registerCleanup: RuntimeCleanupRegistration) {}
+
+      onModuleInit() {
+        this.registerCleanup(() => {
+          throw cleanupFailure;
+        });
+      }
+    }
+
+    class FailingBootstrapHook {
+      onApplicationBootstrap() {
+        throw bootstrapFailure;
+      }
+    }
+
+    class AppModule {}
+    defineRuntimeModuleMetadata(AppModule, {
+      providers: [CleanupRegistrant, FailingBootstrapHook],
+    });
+
+    await expect(bootstrapApplication({ logger, rootModule: AppModule })).rejects.toBe(bootstrapFailure);
+    expect(logger.error).toHaveBeenCalledWith(
+      'Failed to clean up after application bootstrap failure.',
+      cleanupFailure,
+      'FluoFactory',
+    );
+  });
+
+  it('preserves the original application context bootstrap error when a runtime cleanup callback fails', async () => {
+    const bootstrapFailure = new Error('application context bootstrap failed');
+    const cleanupFailure = new Error('application context cleanup failed');
+    const errorLog = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    @Inject(RUNTIME_CLEANUP_REGISTRATION)
+    class CleanupRegistrant implements OnModuleInit {
+      constructor(private readonly registerCleanup: RuntimeCleanupRegistration) {}
+
+      onModuleInit() {
+        this.registerCleanup(() => {
+          throw cleanupFailure;
+        });
+      }
+    }
+
+    class FailingBootstrapHook {
+      onApplicationBootstrap() {
+        throw bootstrapFailure;
+      }
+    }
+
+    class AppModule {}
+    defineRuntimeModuleMetadata(AppModule, {
+      providers: [CleanupRegistrant, FailingBootstrapHook],
+    });
+
+    try {
+      await expect(FluoFactory.createApplicationContext(AppModule)).rejects.toBe(bootstrapFailure);
+      expect(errorLog).toHaveBeenCalledWith(
+        '[fluo] ERROR [FluoFactory] Failed to clean up after application context bootstrap failure.',
+      );
+      expect(errorLog).toHaveBeenCalledWith(cleanupFailure);
+    } finally {
+      errorLog.mockRestore();
+    }
+  });
+
   it('runs startup and shutdown lifecycle hooks around close()', async () => {
     const events: string[] = [];
 


### PR DESCRIPTION
## Summary

Application 및 application-context bootstrap 실패 후 runtime cleanup callback까지 실패하는 경우에도 원본 bootstrap error가 보존되고 cleanup failure가 별도로 기록되는 기존 계약을 회귀 테스트로 고정합니다.

Linked context: Closes #2549

## Changes

- `bootstrapApplication(...)` 경로에서 cleanup callback failure가 원본 bootstrap rejection을 대체하지 않는지 검증합니다.
- `FluoFactory.createApplicationContext(...)` 경로에서 같은 오류 우선순위와 별도 cleanup logging을 검증합니다.
- production code와 문서 계약은 변경하지 않습니다.

## Testing

- `pnpm --dir packages/runtime test -- bootstrap.test.ts` — 22 files, 266 tests passed
- `pnpm exec biome check packages/runtime/src/bootstrap.test.ts` — passed
- `pnpm verify` — 303 files passed, 4109 tests passed, 1 skipped

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

Test-only contract coverage이므로 `.changeset/*.md`는 추가하지 않았습니다.

## Public export documentation

해당 없음 — public export 또는 source TSDoc surface를 변경하지 않았습니다.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

기존 `packages/runtime/README.md` bootstrap failure 계약을 변경하지 않고 실행 가능한 regression coverage만 보강합니다.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

해당 없음 — platform contract 또는 governance SSOT 문서를 변경하지 않았습니다.

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests.