### PR TITLE
Resolve #2548: Restore executable DI Testing/Mocking examples

### DIFF
--- a/packages/di/README.ko.md
+++ b/packages/di/README.ko.md
@@ -129,22 +129,42 @@ class ServiceWithOptionalLogger {
 
 ## 테스트 및 모킹
 
-`useValue`를 사용하면 단위 테스트 중에 컨테이너의 provider를 모의 객체(mock)나 스텁(stub)으로 쉽게 교체할 수 있습니다.
+먼저 전체 의존성 그래프를 등록한 다음, `override(...)`와 `useValue`를 사용해 기존 provider를 mock이나 stub으로 교체하세요. `register(...)`는 새 provider를 추가하며 중복 토큰을 거부하고, `override(...)`는 지원되는 교체 API입니다.
 
 ```typescript
+import { Inject } from '@fluojs/core';
 import { Container } from '@fluojs/di';
+import { expect, it, vi } from 'vitest';
 
-const container = new Container();
-const mockDb = { query: vi.fn() };
+class Database {
+  async query(): Promise<readonly string[]> {
+    return ['real row'];
+  }
+}
 
-// 실제 Database 클래스를 모의 객체 값으로 교체
-container.register({ 
-  provide: Database, 
-  useValue: mockDb 
+@Inject(Database)
+class DataService {
+  constructor(private readonly database: Database) {}
+
+  async load(): Promise<readonly string[]> {
+    return this.database.query();
+  }
+}
+
+it('uses a mock database', async () => {
+  const mockDb = { query: vi.fn().mockResolvedValue(['mock row']) };
+  const container = new Container().register(Database, DataService);
+
+  container.override({
+    provide: Database,
+    useValue: mockDb,
+  });
+
+  const service = await container.resolve(DataService);
+
+  await expect(service.load()).resolves.toEqual(['mock row']);
+  expect(mockDb.query).toHaveBeenCalledOnce();
 });
-
-const service = await container.resolve(DataService);
-// service는 실제 Database 인스턴스 대신 mockDb를 사용합니다.
 ```
 
 ## 문제 해결

--- a/packages/di/README.md
+++ b/packages/di/README.md
@@ -129,22 +129,42 @@ class ServiceWithOptionalLogger {
 
 ## Testing and Mocking
 
-You can easily override providers in the container to use mocks or stubs during unit testing by using `useValue`.
+Register the complete dependency graph first, then use `override(...)` with `useValue` to replace an existing provider with a mock or stub. `register(...)` adds new providers and rejects duplicate tokens; `override(...)` is the supported replacement API.
 
 ```typescript
+import { Inject } from '@fluojs/core';
 import { Container } from '@fluojs/di';
+import { expect, it, vi } from 'vitest';
 
-const container = new Container();
-const mockDb = { query: vi.fn() };
+class Database {
+  async query(): Promise<readonly string[]> {
+    return ['real row'];
+  }
+}
 
-// Override the real Database class with a mock value
-container.register({ 
-  provide: Database, 
-  useValue: mockDb 
+@Inject(Database)
+class DataService {
+  constructor(private readonly database: Database) {}
+
+  async load(): Promise<readonly string[]> {
+    return this.database.query();
+  }
+}
+
+it('uses a mock database', async () => {
+  const mockDb = { query: vi.fn().mockResolvedValue(['mock row']) };
+  const container = new Container().register(Database, DataService);
+
+  container.override({
+    provide: Database,
+    useValue: mockDb,
+  });
+
+  const service = await container.resolve(DataService);
+
+  await expect(service.load()).resolves.toEqual(['mock row']);
+  expect(mockDb.query).toHaveBeenCalledOnce();
 });
-
-const service = await container.resolve(DataService);
-// service uses mockDb instead of the real Database instance
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary

- `@fluojs/di` EN/KO Testing/Mocking 예제를 실제 지원되는 provider 교체 계약과 일치시킵니다.
- 복사 가능한 Vitest 예제가 전체 의존성 그래프를 등록한 뒤 `container.override(...)`를 사용하도록 복원합니다.

Linked context: Closes #2548

## Changes

- `Database`와 `DataService`를 포함한 완전한 DI graph를 등록합니다.
- 중복 등록용 `register(...)` 대신 지원되는 `override({ provide: Database, useValue: mockDb })`를 사용합니다.
- mock 결과와 호출을 검증하는 실행 가능한 Vitest assertion을 추가합니다.
- `packages/di/README.md`와 `packages/di/README.ko.md`의 설명과 code block을 동기화합니다.

## Testing

- 기존 README 형태를 임시 Vitest test로 실행해 `ContainerResolutionError`를 재현하고, 수정된 동일 snippet이 통과함을 확인한 뒤 임시 파일을 제거했습니다.
- `pnpm --filter @fluojs/di test` — 121 tests passed.
- `pnpm --filter @fluojs/di... build && pnpm --filter @fluojs/di typecheck` — passed.
- `pnpm docs:sync-check` — passed.
- `pnpm verify:platform-consistency-governance` — passed.
- EN/KO Testing/Mocking code block identity check — passed.
- `pnpm verify` — build, typecheck, lint, and 304 test files passed; 4117 tests passed and 1 skipped.

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

Docs-only correction입니다. Published behavior, API surface, package contents, release metadata는 변경하지 않으므로 changeset을 추가하지 않았습니다.

## Public export documentation

해당 없음 — package source와 public export를 변경하지 않았습니다. README scenario example만 기존 공개 API와 일치하도록 수정했습니다.

- [x] No public exports changed.
- [x] README scenario examples remain aligned with source-level API documentation.

## Behavioral contract

- [x] 문서화된 behavioral contract를 제거하지 않았습니다.
- [x] 기존 `Container.override(...)` contract를 source와 `packages/di/src/container.test.ts`의 regression coverage에 맞췄습니다.
- [x] 새 runtime behavior나 intentional limitation을 추가하지 않았습니다.

## Platform consistency governance (SSOT)

- [x] 변경된 EN/KO package README의 설명과 code block을 동기화했습니다.
- [x] `pnpm verify:platform-consistency-governance`를 통과했습니다.
- [x] Platform contract docs나 conformance claim은 변경하지 않았으므로 companion platform harness 변경은 해당 없습니다.