### PR TITLE
Resolve #2575: Cover TCP timeout and error frames

### DIFF
--- a/packages/microservices/src/transports/tcp-transport.timeout-error.test.ts
+++ b/packages/microservices/src/transports/tcp-transport.timeout-error.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { TcpMicroserviceTransport } from './tcp-transport.js';
+
+describe('TcpMicroserviceTransport request failures', () => {
+  it('rejects a non-responding request after requestTimeoutMs instead of leaving it pending', async () => {
+    // Given
+    vi.useFakeTimers();
+    const requestTimeoutMs = 1_500;
+    const controller = new AbortController();
+    let markHandlerEntered: () => void = () => undefined;
+    const handlerEntered = new Promise<void>((resolve) => {
+      markHandlerEntered = resolve;
+    });
+    const handler = vi.fn(async () => {
+      markHandlerEntered();
+      return await new Promise<never>(() => undefined);
+    });
+    const transport = new TcpMicroserviceTransport({ port: 0, requestTimeoutMs });
+
+    try {
+      await transport.listen(handler);
+
+      // When
+      const sending = transport.send('inventory.reserve-preview', { sku: 'sku-1' }, controller.signal);
+      const rejected = vi.fn();
+      void sending.then(() => undefined, rejected);
+      await handlerEntered;
+
+      // Then
+      expect(handler).toHaveBeenCalledOnce();
+      await vi.advanceTimersByTimeAsync(requestTimeoutMs - 1);
+      expect(rejected).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(rejected).toHaveBeenCalledOnce();
+      await expect(sending).rejects.toThrow(`Microservice TCP request timed out after ${String(requestTimeoutMs)}ms.`);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      controller.abort();
+      try {
+        await transport.close();
+      } finally {
+        vi.useRealTimers();
+      }
+    }
+  });
+
+  it('receives a thrown remote handler error frame and rejects send with its documented message', async () => {
+    // Given
+    const remoteErrorMessage = 'Product not found';
+    const handler = vi.fn(async () => {
+      throw new Error(remoteErrorMessage);
+    });
+    const transport = new TcpMicroserviceTransport({ port: 0, requestTimeoutMs: 1_000 });
+
+    try {
+      await transport.listen(handler);
+
+      // When
+      const sending = transport.send('catalog.get', { productId: 'missing-product' });
+
+      // Then
+      await expect(sending).rejects.toMatchObject({
+        message: remoteErrorMessage,
+        name: 'Error',
+      });
+      await expect(sending).rejects.not.toHaveProperty('code');
+      expect(handler).toHaveBeenCalledWith({
+        kind: 'message',
+        pattern: 'catalog.get',
+        payload: { productId: 'missing-product' },
+        requestId: expect.any(String),
+      });
+    } finally {
+      await transport.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Add real-socket regression coverage for Microservices TCP timeout and remote error-frame contracts.

Linked context: Closes #2575

## Changes

- Verify a non-responding TCP handler rejects at configured `requestTimeoutMs`.
- Verify thrown remote handler errors are framed and reject `send()` with the documented message.
- Exercise the actual ephemeral listener/socket path with bounded cleanup.

## Testing

- Focused TCP tests: 10 passed
- Microservices package tests: 220 passed
- `pnpm --filter @fluojs/microservices typecheck`
- Microservices package build passed
- Timeout and error-frame production mutations both made the new regressions fail

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

Test-only coverage of existing TCP contracts; no runtime or public API change.

## Public export documentation

- [x] Not applicable: no public exports changed.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated.
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] Not applicable: no platform docs changed.
- [x] TCP timeout and remote error behavior are backed by real-socket regressions.