### PR TITLE
Resolve #2733: Remove abort listener after synchronous callback throw

### DIFF
--- a/.changeset/race-with-abort-remove-listener-sync-throw.md
+++ b/.changeset/race-with-abort-remove-listener-sync-throw.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/runtime': patch
+---
+
+Remove the abort listener registered by `raceWithAbort(fn, signal)` even when `fn` throws synchronously before returning a promise. The synchronous throw is now converted into a settled rejection so the cleanup-dependent `finally` flow still runs and the listener is not leaked across repeated failed operations.

--- a/packages/runtime/README.ko.md
+++ b/packages/runtime/README.ko.md
@@ -164,6 +164,7 @@ class UsersModule {}
 - 플랫폼 component snapshot은 런타임 소유 계약 payload입니다. 각 component는 `readiness`, `health`, dependency id, telemetry tag, diagnostic issue, 그리고 `ownership.ownsResources` / `ownership.externallyManaged`를 통해 리소스 소유권을 보고합니다. Runtime은 shell snapshot에서 이 ownership flag를 보존하므로 adapter와 package integration이 fluo가 종료해야 하는 리소스와 host가 소유한 외부 관리 리소스를 구분할 수 있습니다.
 - 모듈 그래프 컴파일 결과 캐시는 `moduleGraphCache: true`를 통한 opt-in입니다. 캐시 항목은 root module identity, runtime provider, validation token, module replacement pair, core metadata version, compile algorithm version으로 식별되며, 성공한 컴파일만 저장하고 호출자 mutation이 이후 bootstrap을 오염시키지 않도록 격리된 그래프 복사본을 반환합니다.
 - `moduleReplacements`는 `bootstrapModule(...)` / `BootstrapModuleOptions`의 저수준 testing seam입니다. 원래 logical module identity를 보존하면서 replacement module metadata로 컴파일하고, replacement cycle은 일반 module graph validation 경로에서 거부하며, source module metadata를 mutate하지 않습니다.
+- `raceWithAbort(fn, signal)`은 `fn`이 settle된 후 항상 abort listener를 제거합니다. `fn`이 promise를 반환하기 전에 동기적으로 throw하는 경우도 포함합니다. 동기 throw는 settled rejection으로 변환되어 cleanup-dependent `finally` flow가 여전히 실행되고, 반복된 실패 작업에서 listener가 leak되지 않습니다.
 
 ## 공개 API 개요
 

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -164,6 +164,7 @@ class UsersModule {}
 - Platform component snapshots are runtime-owned contract payloads: each component reports `readiness`, `health`, dependency ids, telemetry tags, diagnostic issues, and resource ownership through `ownership.ownsResources` / `ownership.externallyManaged`. Runtime preserves those ownership flags in shell snapshots so adapters and package integrations can distinguish resources fluo must stop from externally managed resources the host owns.
 - Module graph compile-result caching is opt-in through `moduleGraphCache: true`; it keys entries by root module identity, runtime providers, validation tokens, module replacement pairs, core metadata versions, and the compile algorithm version, caches only successful compilations, and returns isolated graph copies so caller mutations cannot poison later bootstraps.
 - `moduleReplacements` is a low-level testing seam on `bootstrapModule(...)` / `BootstrapModuleOptions`. It compiles replacement module metadata while preserving the original logical module identity, rejects replacement cycles through the normal module graph validation path, and does not mutate source module metadata.
+- `raceWithAbort(fn, signal)` always removes its abort listener once `fn` settles, including when `fn` throws synchronously before returning a promise. The synchronous throw is converted into a settled rejection so the cleanup-dependent `finally` flow still runs and the listener is not leaked across repeated failed operations.
 
 ## Public API Overview
 

--- a/packages/runtime/src/abort.test.ts
+++ b/packages/runtime/src/abort.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createAbortError, raceWithAbort } from './abort.js';
+
+describe('raceWithAbort', () => {
+  it('resolves with the fn result when the signal never aborts', async () => {
+    const controller = new AbortController();
+    await expect(raceWithAbort(async () => 'ok', controller.signal)).resolves.toBe('ok');
+  });
+
+  it('rejects with an AbortError when the signal is already aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    await expect(raceWithAbort(async () => 'ok', controller.signal)).rejects.toSatisfy((error) => {
+      return error instanceof Error && error.name === 'AbortError';
+    });
+  });
+
+  it('rejects with an AbortError when the signal aborts while fn is pending', async () => {
+    const controller = new AbortController();
+    let resolveFn: (value: string) => void;
+    const pending = new Promise<string>((resolve) => {
+      resolveFn = resolve;
+    });
+    const promise = raceWithAbort(() => pending, controller.signal);
+    controller.abort();
+    await expect(promise).rejects.toSatisfy((error) => {
+      return error instanceof Error && error.name === 'AbortError';
+    });
+    resolveFn!('ok');
+  });
+
+  it('rethrows the original error when fn throws synchronously', async () => {
+    const controller = new AbortController();
+    const boom = new Error('sync throw');
+    await expect(
+      raceWithAbort(() => {
+        throw boom;
+      }, controller.signal),
+    ).rejects.toBe(boom);
+  });
+
+  it('removes the abort listener after fn throws synchronously', async () => {
+    const controller = new AbortController();
+    const removeSpy = vi.spyOn(controller.signal, 'removeEventListener');
+    const boom = new Error('sync throw');
+    await expect(
+      raceWithAbort(() => {
+        throw boom;
+      }, controller.signal),
+    ).rejects.toBe(boom);
+    expect(removeSpy).toHaveBeenCalledWith('abort', expect.any(Function));
+  });
+
+  it('does not fire the abort listener after fn throws synchronously', async () => {
+    const controller = new AbortController();
+    const onAbort = vi.fn();
+    controller.signal.addEventListener('abort', onAbort);
+    const boom = new Error('sync throw');
+    await expect(
+      raceWithAbort(() => {
+        throw boom;
+      }, controller.signal),
+    ).rejects.toBe(boom);
+    controller.abort();
+    // The raceWithAbort-owned listener is removed; only the test-owned
+    // listener remains and fires once.
+    expect(onAbort).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes the abort listener after fn resolves', async () => {
+    const controller = new AbortController();
+    const removeSpy = vi.spyOn(controller.signal, 'removeEventListener');
+    await raceWithAbort(async () => 'ok', controller.signal);
+    expect(removeSpy).toHaveBeenCalledWith('abort', expect.any(Function));
+  });
+});
+
+describe('createAbortError', () => {
+  it('normalizes an Error reason into an AbortError preserving the message', () => {
+    const error = createAbortError(new Error('boom'));
+    expect(error).toBeInstanceOf(Error);
+    expect(error.name).toBe('AbortError');
+    expect(error.message).toBe('boom');
+  });
+
+  it('uses a default message for non-Error reasons', () => {
+    const error = createAbortError('something else');
+    expect(error).toBeInstanceOf(Error);
+    expect(error.name).toBe('AbortError');
+    expect(error.message).toBe('Request aborted before response commit.');
+  });
+});

--- a/packages/runtime/src/abort.ts
+++ b/packages/runtime/src/abort.ts
@@ -3,10 +3,15 @@
  * Rejects immediately if the signal is already aborted, or rejects as soon
  * as the signal fires while `fn` is still pending.
  *
+ * The abort listener is always removed once `fn` settles, including when
+ * `fn` throws synchronously before returning a promise. The synchronous
+ * throw is converted into a settled rejection so the cleanup-dependent
+ * `finally` flow still runs.
+ *
  * @param fn Async operation to execute while observing the abort signal.
  * @param signal Abort signal that can cancel the in-flight operation.
  * @returns The resolved value from `fn` when no abort happens first.
- * @throws {Error} An `AbortError` when the signal is already aborted or aborts before `fn` settles.
+ * @throws {Error} An `AbortError` when the signal is already aborted or aborts before `fn` settles. Re-throws the original error when `fn` throws synchronously.
  */
 export async function raceWithAbort<T>(fn: () => Promise<T>, signal: AbortSignal): Promise<T> {
   if (signal.aborted) {
@@ -20,7 +25,18 @@ export async function raceWithAbort<T>(fn: () => Promise<T>, signal: AbortSignal
 
     signal.addEventListener('abort', onAbort, { once: true });
 
-    Promise.resolve(fn()).then(resolve, reject).finally(() => {
+    // Convert `fn()` invocation into a settled promise so a synchronous
+    // throw still flows through the `finally` cleanup that removes the
+    // abort listener. `Promise.resolve()` only wraps an already-produced
+    // value; it does not catch a throw emitted while `fn()` is invoked.
+    let fnResultPromise: Promise<T>;
+    try {
+      fnResultPromise = Promise.resolve(fn());
+    } catch (syncError) {
+      fnResultPromise = Promise.reject(syncError);
+    }
+
+    fnResultPromise.then(resolve, reject).finally(() => {
       signal.removeEventListener('abort', onAbort);
     });
   });


### PR DESCRIPTION
## Summary

Linked context: Closes #2733

`raceWithAbort(fn, signal)` registered its abort listener before invoking `fn()` and relied on `Promise.resolve(fn()).finally(...)` to remove it. When `fn()` threw synchronously, the throw escaped before `Promise.resolve` could wrap it, so the `finally` cleanup never ran and the abort listener leaked on the signal. Repeated failed operations could retain listeners and leaked references.

## Changes

- `packages/runtime/src/abort.ts`: Convert the `fn()` invocation into a settled promise via `try/catch` so a synchronous throw flows through the same `finally` cleanup that removes the abort listener. `Promise.resolve()` only wraps an already-produced value; it does not catch a throw emitted while `fn()` is invoked, so the explicit `try/catch` is required.
- `packages/runtime/src/abort.test.ts`: New regression test suite covering `raceWithAbort` and `createAbortError`, including sync-throw listener removal, post-throw abort behavior, and normal resolve/abort paths.
- `packages/runtime/README.md` / `README.ko.md`: Document the behavioral contract that the abort listener is always removed once `fn` settles, including synchronous throws.
- `.changeset/race-with-abort-remove-listener-sync-throw.md`: Patch changeset for `@fluojs/runtime` because abort helpers are public runtime integration behavior.

## Testing

- `pnpm vitest run packages/runtime/src/abort.test.ts` — 9 tests passed.
- `pnpm --filter @fluojs/runtime test` — 283 tests passed (24 files).
- `pnpm --filter @fluojs/runtime typecheck` — passed.
- `pnpm exec biome lint packages/runtime/src/abort.ts packages/runtime/src/abort.test.ts` — passed.
- `pnpm verify:public-export-tsdoc` — passed (changed mode).
- `pnpm verify:platform-consistency-governance` — passed.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Patch changeset for `@fluojs/runtime`: abort helpers are public runtime integration behavior and the listener-leak fix changes cleanup semantics for synchronous-throw callers.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

The `raceWithAbort` TSDoc was extended to document the synchronous-throw cleanup guarantee and the re-throw behavior.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [ ] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

New behavioral contract: `raceWithAbort(fn, signal)` always removes its abort listener once `fn` settles, including when `fn` throws synchronously before returning a promise. Documented in `packages/runtime/README.md` and `README.ko.md`, covered by `packages/runtime/src/abort.test.ts`.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by the applicable platform harness tests, such as `createPlatformConformanceHarness(...)` for platform component contracts or `createHttpAdapterPortabilityHarness(...)` for HTTP adapter portability contracts.

README EN/KO mirrors both received the new behavioral contract bullet. No platform contract docs changed. No platform harness conformance claims were added.