### PR TITLE
Resolve #2755: Settle Studio sidecar on partial-body close

### DIFF
--- a/.changeset/studio-sidecar-partial-body-close.md
+++ b/.changeset/studio-sidecar-partial-body-close.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/cli': patch
+---
+
+Settle Studio sidecar ingestion when a local client closes the socket after sending only a partial request body. The sidecar now binds request `close`/`error` events to body-reader cancellation and sends a bounded error completion instead of hanging indefinitely on a malformed local client.

--- a/packages/cli/README.ko.md
+++ b/packages/cli/README.ko.md
@@ -209,7 +209,7 @@ fluo dev --studio --dry-run
 
 CLI는 local Studio sidecar를 시작하고, tokenized URL을 출력하며, restart lifecycle event를 sidecar로 계속 전달하고, 앱이 `@fluojs/runtime`을 import하기 전에 명시적인 Studio config를 Node 앱 child에 주입합니다. Studio live mode는 fluo가 소유한 Node restart runner를 요구합니다. 따라서 lifecycle event가 CLI restart boundary와 분리되지 않도록 `fluo dev --studio`는 `--raw-watch`, `--runner native`, `FLUO_DEV_RUNNER=native`를 거부합니다. Optional package인 `@fluojs/studio`가 설치되어 있으면 sidecar는 패키징된 `@fluojs/studio/viewer` React app을 제공합니다. Runtime package source는 `process.env`를 직접 읽지 않으며, CLI가 주입한 Studio config가 있을 때만 live graph/routes/request/timing/diagnostic event를 전송합니다.
 
-보안 기본값은 local-only입니다. Sidecar는 `127.0.0.1`에 bind되고, runtime ingestion 및 browser state/SSE API는 generated token을 요구하며, CORS는 기본적으로 활성화하지 않고, request body는 기본적으로 수집하지 않습니다.
+보안 기본값은 local-only입니다. Sidecar는 `127.0.0.1`에 bind되고, runtime ingestion 및 browser state/SSE API는 generated token을 요구하며, CORS는 기본적으로 활성화하지 않고, request body는 기본적으로 수집하지 않습니다. Local client가 partial request body만 보내고 socket을 닫으면 sidecar는 bounded error completion으로 ingestion 요청을 settle하므로, malformed local client가 sidecar 작업을 무기한 대기시킬 수 없습니다.
 
 MVP runtime support는 명시적으로 제한됩니다.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -209,7 +209,7 @@ fluo dev --studio --dry-run
 
 The CLI starts a local Studio sidecar, prints a tokenized URL, keeps restart lifecycle events flowing through the sidecar, and injects an explicit Studio config into the Node app child before the app imports `@fluojs/runtime`. Studio live mode requires the fluo-owned Node restart runner; `fluo dev --studio` rejects `--raw-watch`, `--runner native`, and `FLUO_DEV_RUNNER=native` so lifecycle events cannot be split from the CLI restart boundary. The sidecar serves the packaged `@fluojs/studio/viewer` React app when that optional package is installed. Runtime package source never reads `process.env` directly; it publishes live graph/routes/request/timing/diagnostic events only when CLI-injected Studio config is present.
 
-Security defaults are local-only: the sidecar binds `127.0.0.1`, runtime ingestion and browser state/SSE APIs require generated tokens, CORS is not enabled by default, and request bodies are not captured by default.
+Security defaults are local-only: the sidecar binds `127.0.0.1`, runtime ingestion and browser state/SSE APIs require generated tokens, CORS is not enabled by default, and request bodies are not captured by default. The sidecar settles ingestion requests with a bounded error completion when a local client closes the socket after sending only a partial request body, so a malformed local client cannot hang sidecar work indefinitely.
 
 Runtime support for the MVP is explicit:
 

--- a/packages/cli/src/studio/sidecar.test.ts
+++ b/packages/cli/src/studio/sidecar.test.ts
@@ -1,4 +1,5 @@
 import { createServer } from 'node:http';
+import { connect, type Socket } from 'node:net';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -250,5 +251,55 @@ describe('Studio sidecar', () => {
     expect(sidecar.epoch).not.toBe(initialEpoch);
     expect(sidecar.epoch).toBe(nextEpoch);
     expect(sidecar.env.FLUO_STUDIO_EPOCH).toBe(nextEpoch);
+  });
+
+  it('settles the ingestion request when a client closes the socket after a partial body', async () => {
+    const sidecar = await startTestSidecar();
+    const port = sidecar.port;
+    const token = sidecar.token;
+
+    const socket = connect(port, '127.0.0.1');
+    await new Promise<void>((resolve) => socket.on('connect', () => resolve()));
+
+    const partialBody = '{"payload":{"phase":"scheduled"},"source":';
+    socket.write(
+      `POST /api/runtime/events HTTP/1.1\r\n` +
+      `Host: 127.0.0.1:${port}\r\n` +
+      `Authorization: Bearer ${token}\r\n` +
+      `Content-Type: application/json\r\n` +
+      `Content-Length: 1000\r\n` +
+      `\r\n` +
+      partialBody,
+    );
+
+    await new Promise<void>((resolve) => socket.end(() => resolve()));
+
+    const state = await fetch(`${sidecar.url}/api/state?token=${encodeURIComponent(token)}`);
+    const stateJson = await state.json() as { events: Array<{ type: string }> };
+    expect(stateJson.events.some((event) => event.type === 'restart')).toBe(false);
+  });
+
+  it('settles the ingestion request when a client closes the socket before sending any body', async () => {
+    const sidecar = await startTestSidecar();
+    const port = sidecar.port;
+    const token = sidecar.token;
+
+    const socket = connect(port, '127.0.0.1');
+    await new Promise<void>((resolve) => socket.on('connect', () => resolve()));
+
+    socket.write(
+      `POST /api/runtime/events HTTP/1.1\r\n` +
+      `Host: 127.0.0.1:${port}\r\n` +
+      `Authorization: Bearer ${token}\r\n` +
+      `Content-Type: application/json\r\n` +
+      `Content-Length: 1000\r\n` +
+      `\r\n`,
+    );
+
+    await new Promise<void>((resolve) => socket.end(() => resolve()));
+
+    const state = await fetch(`${sidecar.url}/api/state?token=${encodeURIComponent(token)}`);
+    const stateJson = await state.json() as { events: Array<{ type: string }> };
+    expect(stateJson.events).toHaveLength(0);
   });
 });

--- a/packages/cli/src/studio/sidecar.ts
+++ b/packages/cli/src/studio/sidecar.ts
@@ -140,21 +140,57 @@ function createDefaultAppId(): string {
 
 function readBody(request: IncomingMessage): Promise<string> {
   return new Promise((resolve, reject) => {
+    let settled = false;
     let body = '';
     request.setEncoding('utf8');
-    request.on('data', (chunk: string) => {
+
+    const settle = (action: 'resolve' | 'reject', value: string | Error): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      request.off('data', onData);
+      request.off('end', onEnd);
+      request.off('error', onError);
+      request.off('close', onClose);
+      if (action === 'resolve') {
+        resolve(value as string);
+      } else {
+        reject(value as Error);
+      }
+    };
+
+    const onData = (chunk: string): void => {
       body += chunk;
       if (body.length > MAX_REQUEST_BYTES) {
-        reject(new Error('Studio event payload is too large.'));
+        settle('reject', new Error('Studio event payload is too large.'));
         request.destroy();
       }
-    });
-    request.on('end', () => resolve(body));
-    request.on('error', reject);
+    };
+    const onEnd = (): void => settle('resolve', body);
+    const onError = (error: NodeJS.ErrnoException): void => settle('reject', error);
+    // A client that closes the socket after sending only a partial request body
+    // may never emit `end` or `error`. Bind `close` to body-reader cancellation
+    // so the sidecar cannot hang on a malformed local client indefinitely.
+    const onClose = (): void => {
+      if (body.length === 0) {
+        settle('reject', new Error('Studio sidecar request closed before any body was received.'));
+        return;
+      }
+      settle('reject', new Error('Studio sidecar request closed before the full body was received.'));
+    };
+
+    request.on('data', onData);
+    request.on('end', onEnd);
+    request.on('error', onError);
+    request.on('close', onClose);
   });
 }
 
 function writeJson(response: ServerResponse, statusCode: number, payload: unknown): void {
+  if (response.writableEnded) {
+    return;
+  }
   response.writeHead(statusCode, {
     'cache-control': 'no-store',
     'content-type': 'application/json; charset=utf-8',


### PR DESCRIPTION
## Summary

Studio sidecar ingestion could hang indefinitely when a local client closed the socket after sending only a partial request body. The `readBody` reader only listened for `end` and `error` events, so a partial-body close (where neither event fires) left the ingestion Promise pending forever, allowing a malformed local client to consume sidecar work without bound.

Linked context: Closes #2755

## Changes

- `packages/cli/src/studio/sidecar.ts`: `readBody` now binds the request `close` event to body-reader cancellation. A `settled` guard ensures only the first of `end`/`error`/`close` wins, and all listeners are removed once settled. `close` rejects with a descriptive bounded error distinguishing zero-body vs partial-body close.
- `packages/cli/src/studio/sidecar.ts`: `writeJson` now guards against writing to an already-ended response, so the bounded error completion path does not throw when the client socket is already closed.
- `packages/cli/src/studio/sidecar.test.ts`: Added two regression tests — one for partial-body close (client sends partial JSON then closes) and one for zero-body close (client sends headers only then closes). Both assert the sidecar does not accept the event and remains usable.
- `packages/cli/README.md` / `packages/cli/README.ko.md`: Documented the partial-body close settlement invariant in the Studio sidecar security defaults section (EN/KO parity).
- `.changeset/studio-sidecar-partial-body-close.md`: Patch changeset for `@fluojs/cli` (CLI-launched sidecar lifecycle is documented tooling behavior).

## Testing

- `pnpm --filter @fluojs/cli test` — 393 tests passed (13 files), including the 2 new partial-body close regression tests.
- `pnpm --filter @fluojs/cli typecheck` — passed.
- `pnpm build` — full monorepo build passed.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.

The sidecar ingestion lifecycle is documented `@fluojs/cli` tooling behavior. A malformed local client could previously hang sidecar work indefinitely; this change settles ingestion with a bounded error completion. Patch bump is appropriate because no public API surface or documented ordering changes — only a latent hang is fixed.

## Public export documentation

- [x] Changed public exports include a source-level summary.

No public exports changed. The `readBody` function is module-internal; the `StudioSidecar` public interface is unchanged.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

The new invariant — "the sidecar settles ingestion requests with a bounded error completion when a local client closes the socket after sending only a partial request body" — is documented in `packages/cli/README.md` and `packages/cli/README.ko.md`, and covered by regression tests in `packages/cli/src/studio/sidecar.test.ts`.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.

The CLI README EN/KO pair was updated in lockstep. No platform contract docs or package-surface docs changed.