### PR TITLE
fix(release): add major changelog evidence for dependency-driven @fluojs/email and @fluojs/i18n 2.0.0 bumps

### DIFF
--- a/packages/email/CHANGELOG.md
+++ b/packages/email/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## 2.0.0
 
+### Major Changes
+
+- [#2649](https://github.com/fluojs/fluo/pull/2649) [`1261d96`](https://github.com/fluojs/fluo/commit/1261d96ecae66576fe26fae0a39f03458307e6a4) Thanks [@ayden94](https://github.com/ayden94)! - Bump major in lockstep with `@fluojs/runtime@2.0.0`, `@fluojs/di@2.0.0`, and `@fluojs/queue@2.0.0` because `@fluojs/email` depends on those packages' public contracts. The email package itself has no breaking API changes; consumers upgrading from `@fluojs/email@1.x` should follow the migration notes for `@fluojs/runtime` (multipart file payloads are now runtime-neutral `Uint8Array`), `@fluojs/di` (introspection state is read-only), and `@fluojs/queue` (scoped queue module discovery and dead-letter drain semantics).
+
 ### Patch Changes
 
 - [#2617](https://github.com/fluojs/fluo/pull/2617) [`5c9246c`](https://github.com/fluojs/fluo/commit/5c9246ca684137051d2ac43f92104e2a9cb9fce9) Thanks [@ayden94](https://github.com/ayden94)! - Make repeated and concurrent Email service shutdown calls share one cleanup operation so owned transports close at most once.

--- a/packages/i18n/CHANGELOG.md
+++ b/packages/i18n/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## 2.0.0
 
+### Major Changes
+
+- [#2439](https://github.com/fluojs/fluo/pull/2439) [`2854c36`](https://github.com/fluojs/fluo/commit/2854c366d99c191eae3416e375b9db577711aaff) Thanks [@ayden94](https://github.com/ayden94)! - Bump major in lockstep with `@fluojs/http@2.0.0` because `@fluojs/i18n` depends on the HTTP package's public `ResponseFormatter` contract. The i18n package itself has no breaking API changes; consumers upgrading from `@fluojs/i18n@1.x` should follow the migration notes for `@fluojs/http` (`ResponseFormatter.format(...)` now returns runtime-neutral `Uint8Array` instead of Node-specific `Buffer`).
+
 ### Patch Changes
 
 - [#2648](https://github.com/fluojs/fluo/pull/2648) [`337c0e2`](https://github.com/fluojs/fluo/commit/337c0e2eeeabce3c4e6fa1749c6919f62a88d925) Thanks [@ayden94](https://github.com/ayden94)! - Restore the governed `Unreleased` changelog placeholder for foundation packages and preserve it when Changesets generates future package versions.


### PR DESCRIPTION
## Problem

The Changesets release workflow (run [#29262746664](https://github.com/fluojs/fluo/actions/runs/29262746664)) failed at the `Verify changeset release lane` step because `@fluojs/email` and `@fluojs/i18n` were bumped to 2.0.0 (major) by Changesets due to dependency major bumps (`@fluojs/runtime`, `@fluojs/di`, `@fluojs/queue`, `@fluojs/http`), but their CHANGELOG `## 2.0.0` sections only contained `### Patch Changes` and were missing the required `### Major Changes` evidence.

The `verify-changeset-release-lane.mjs` guard requires every major version delta to have a matching `### Major Changes` section in the package CHANGELOG.

## Fix

Add `### Major Changes` sections to the `## 2.0.0` entries in:

- `packages/email/CHANGELOG.md` — lockstep major bump driven by `@fluojs/runtime@2.0.0`, `@fluojs/di@2.0.0`, and `@fluojs/queue@2.0.0`; no breaking API changes in the email package itself; consumer migration notes point to the dependency changelogs.
- `packages/i18n/CHANGELOG.md` — lockstep major bump driven by `@fluojs/http@2.0.0`; no breaking API changes in the i18n package itself; consumer migration notes point to the `ResponseFormatter.format(...)` return type change.

## Verification

```
pnpm verify:changeset-release-lane -- --lane=stable --base-ref=8b7084a6ee5c72a697d80d273ebe13976ff43869
→ Changeset release lane check passed for stable: 4 pending package bump intent(s), 42 package version delta(s).
```