### PR TITLE
Resolve #2740: Complete OpenAPI decorator option type inventory

### DIFF
--- a/packages/openapi/README.ko.md
+++ b/packages/openapi/README.ko.md
@@ -142,6 +142,7 @@ title/version/source 설정이 DI나 async setup에서 나오는 경우 `OpenApi
 - `ApiBody`, `ApiParam`, `ApiQuery`, `ApiHeader`, `ApiCookie`: 이름이 겹칠 때 추론된 요청 문서를 대체하는 명시적 요청 본문 및 파라미터 문서화 데코레이터.
 - `ApiBearerAuth`, `ApiSecurity`: 보안 요구사항 데코레이터.
 - `ApiExcludeEndpoint`: 특정 핸들러를 문서화에서 제외.
+- `ApiOperationOptions`, `ApiResponseOptions`, `ApiParameterOptions`, `ApiBodyOptions`: `@ApiOperation(...)`, `@ApiResponse(...)`, `@ApiParam(...)`, `@ApiQuery(...)`, `@ApiHeader(...)`, `@ApiCookie(...)`, `@ApiBody(...)`가 받는 데코레이터 옵션 타입.
 - `buildOpenApiDocument`: 프로그래밍 방식의 문서 빌더 (저수준).
 - `OpenApiHandlerRegistry`: 고급 통합에서 문서 생성 전에 handler descriptor를 스냅샷하는 mutable descriptor registry.
 - `getControllerTags`, `getMethodApiMetadata`: 고급 테스트와 통합 tooling을 위한 metadata reader.

--- a/packages/openapi/README.md
+++ b/packages/openapi/README.md
@@ -142,6 +142,7 @@ Use `OpenApiModule.forRootAsync(...)` when title/version/source configuration co
 - `ApiBody`, `ApiParam`, `ApiQuery`, `ApiHeader`, `ApiCookie`: Explicit request-body and parameter documentation decorators that override inferred request documentation when names overlap.
 - `ApiBearerAuth`, `ApiSecurity`: Security requirement decorators.
 - `ApiExcludeEndpoint`: Omit specific handlers from documentation.
+- `ApiOperationOptions`, `ApiResponseOptions`, `ApiParameterOptions`, `ApiBodyOptions`: Decorator option types accepted by `@ApiOperation(...)`, `@ApiResponse(...)`, `@ApiParam(...)`, `@ApiQuery(...)`, `@ApiHeader(...)`, `@ApiCookie(...)`, and `@ApiBody(...)`.
 - `buildOpenApiDocument`: Programmatic document builder (low-level).
 - `OpenApiHandlerRegistry`: Mutable descriptor registry used by advanced integrations to snapshot handler descriptors before document generation.
 - `getControllerTags`, `getMethodApiMetadata`: Metadata readers for advanced tests and integration tooling.


### PR DESCRIPTION
## Summary

Completes the public OpenAPI README inventory for existing decorator option types.

Linked context: https://github.com/fluojs/fluo/issues/2740

Closes #2740

## Changes

- Added `ApiOperationOptions`, `ApiResponseOptions`, `ApiParameterOptions`, and `ApiBodyOptions` to the English public API inventory.
- Added the matching Korean inventory entry with the same decorator-to-option mapping.
- Preserved the existing public export and runtime surface.

## Testing

- Passed `pnpm docs:sync-check` (42 EN/KO page pairs and 10 navigation metadata pairs).
- Passed `pnpm verify:public-export-tsdoc` in changed mode.
- `pnpm verify:docs` could not complete in the fresh worktree because dependencies are not installed and `fumadocs-mdx` is unavailable.
- `pnpm verify:public-export-tsdoc:baseline` reports pre-existing TSDoc gaps outside this documentation-only change.
- Markdown LSP diagnostics are unavailable because no `.md` language server is configured.

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

Docs-only inventory correction for existing public types. No package behavior, API export, package contents, or release metadata changed, so no changeset is required.

## Public export documentation

Not applicable: this PR does not change source exports. It documents four existing public decorator option types only; `pnpm verify:public-export-tsdoc` passed in changed mode.

## Behavioral contract

Not applicable: no runtime behavior, contract, intentional limitation, or regression-test expectation changed. The two package README locale entries remain aligned.

## Platform consistency governance (SSOT)

Not applicable: no platform contract or governance SSOT document changed. EN/KO package README parity was preserved and `pnpm docs:sync-check` passed.