### PR TITLE
Resolve #2756: Synchronize CLI quick-start output

### DIFF
--- a/book/beginner/ch02-cli-setup.ko.md
+++ b/book/beginner/ch02-cli-setup.ko.md
@@ -132,6 +132,8 @@ fluo new fluo-blog
 4. **Tooling and package manager**: 생성 프로젝트가 사용할 스크립트와 설치 흐름.
 5. **Install and git choices**: CLI가 의존성 설치와 git 초기화를 바로 수행할지 여부.
 
+이 책에서는 package manager로 pnpm을 선택합니다. 첫 실행으로 바로 이어가려면 즉시 dependency 설치를 승인하세요. 설치를 건너뛰었다면 생성 프로젝트로 이동한 뒤 `pnpm dev` 전에 `pnpm install`을 실행해야 하며, 해당 설치가 끝날 때까지 `pnpm-lock.yaml`은 존재하지 않습니다.
+
 ### Previewing the starter plan
 
 처음에는 CLI가 파일을 쓰기 전에 무엇을 하려는지 먼저 보는 편이 도움이 됩니다. 이때 `--print-plan`을 사용합니다.
@@ -153,7 +155,7 @@ Plan preview 모드는 실제 스캐폴딩과 같은 프로젝트 이름, shape,
 - 스타터 템플릿을 준비합니다.
 - `package.json`에 프로젝트 메타데이터를 기록합니다.
 - fluo 관례에 맞는 소스 트리를 만듭니다.
-- 앱 실행에 필요한 패키지를 설치합니다.
+- 즉시 설치를 선택하면 앱 실행에 필요한 패키지를 설치하고, 건너뛰면 해당 단계를 사용자가 나중에 수행하도록 남겨 둡니다.
 - 곧바로 읽고 실행할 수 있는 구조를 남깁니다.
 
 처음 fluo를 접하는 개발자에게 이 과정이 유용한 이유는 분명합니다. “프레임워크를 공부하고 싶다”는 의도를 “이제 실제로 열어 보고 실행할 수 있는 기준점이 있다”는 상태로 바꿔 주기 때문입니다.
@@ -179,7 +181,7 @@ Plan preview 모드는 실제 스캐폴딩과 같은 프로젝트 이름, shape,
 생성기 출력 메시지를 그냥 지나치지 마세요. 처음 실행하면 마지막에 짧은 터미널 요약이 보이고, 그 부분에는 바로 다음 행동을 정하는 데 필요한 정보가 들어 있습니다. 보통 다음 정보를 알려 줍니다.
 
 - 어떤 폴더가 생성되었는지,
-- 어떤 의존성이 설치되었는지,
+- 의존성을 설치했는지 건너뛰었는지,
 - 다음에 어떤 명령을 실행해야 하는지,
 - 실행 전 주의할 점이 있는지.
 
@@ -218,7 +220,7 @@ cd fluo-blog
 ```text
 fluo-blog/
 ├── package.json              # Scripts and dependencies
-├── pnpm-lock.yaml            # Locked dependency versions
+├── pnpm-lock.yaml            # pnpm install 완료 후 존재
 ├── tsconfig.json             # TypeScript configuration
 ├── vitest.config.ts          # Unit, slice, e2e test configuration
 ├── test/                     # Request-pipeline/e2e tests
@@ -238,6 +240,8 @@ fluo-blog/
     │   └── greeting.slice.test.ts      # Module/provider wiring test
     └── main.ts               # Bootstrap entrypoint
 ```
+
+이 책은 의도적으로 pnpm 경로를 따릅니다. 위 트리에 `pnpm-lock.yaml`이 포함되는 시점은 wizard가 dependency를 설치했거나 사용자가 직접 `pnpm install`을 실행한 뒤뿐입니다. 스캐폴딩 중 설치를 건너뛰면 해당 명령이 완료될 때까지 이 파일은 없습니다.
 
 이 단계에서 각 파일은 처음 프로젝트를 열었을 때 자연스럽게 생기는 질문에 답해 줍니다.
 
@@ -406,7 +410,7 @@ curl http://localhost:3000/greeting
 처음 실행에 성공하면 그 요청이 무엇을 증명하는지 과소평가하기 쉽습니다.
 
 - CLI가 유효한 프로젝트를 생성했습니다.
-- 의존성이 정상적으로 설치되었습니다.
+- 의존성이 wizard 또는 나중에 실행한 `pnpm install`을 통해 정상적으로 설치되었습니다.
 - TypeScript가 개발 모드에서 기대한 방식으로 컴파일 또는 변환되었습니다.
 - 런타임 어댑터가 정상적으로 시작되었습니다.
 - 기본 검증 라우트인 runtime `/health`와 starter-owned `/greeting`에 접근할 수 있습니다.

--- a/book/beginner/ch02-cli-setup.md
+++ b/book/beginner/ch02-cli-setup.md
@@ -132,6 +132,8 @@ Typical questions include the following.
 4. **Tooling and package manager**: The scripts and install flow the generated project will use.
 5. **Install and git choices**: Whether the CLI should install dependencies and initialize a repository immediately.
 
+Keep the package-manager choice on pnpm for this book. Accept immediate dependency installation to continue directly to the first run. If you skip it, enter the generated project and run `pnpm install` before `pnpm dev`; `pnpm-lock.yaml` remains absent until that install completes.
+
 ### Previewing the starter plan
 
 When you are new, it can be helpful to see what the CLI would do before it writes files. Use `--print-plan` for that.
@@ -153,7 +155,7 @@ The generator is not just a folder-copying tool.
 - It prepares the starter template.
 - It records project metadata in `package.json`.
 - It creates a source tree that follows fluo conventions.
-- It installs the packages required to run the app.
+- If you choose immediate installation, it installs the packages required to run the app; otherwise, it leaves that step for you.
 - It leaves behind a structure you can read and run right away.
 
 This process is useful for developers new to fluo because it turns the intent to study the framework into a concrete baseline that you can open and execute.
@@ -179,7 +181,7 @@ In this chapter, the interactive flow is more helpful because each configuration
 Do not skip over the generator output. On the first run, you will see a short terminal summary at the end, and it contains the information you need to decide what to do next. It usually tells you the following.
 
 - Which folder was created,
-- Which dependencies were installed,
+- Whether dependencies were installed or skipped,
 - Which command to run next,
 - Whether there is anything to watch before running the app.
 
@@ -218,7 +220,7 @@ The generated structure is intentionally small. It is designed so you can unders
 ```text
 fluo-blog/
 ├── package.json              # Scripts and dependencies
-├── pnpm-lock.yaml            # Locked dependency versions
+├── pnpm-lock.yaml            # Present after pnpm install completes
 ├── tsconfig.json             # TypeScript configuration
 ├── vitest.config.ts          # Unit, slice, and e2e test configuration
 ├── test/                     # Request-pipeline/e2e tests
@@ -238,6 +240,8 @@ fluo-blog/
     │   └── greeting.slice.test.ts      # Module/provider wiring test
     └── main.ts               # Bootstrap entrypoint
 ```
+
+This book intentionally follows the pnpm path. The tree includes `pnpm-lock.yaml` only after the wizard installs dependencies or you run `pnpm install` yourself. If you skip installation during scaffolding, the file is absent until that command completes.
 
 At this stage, each file answers questions that naturally come up when opening a project for the first time.
 
@@ -406,7 +410,7 @@ If you see `{"status":"ok"}` and a greeting payload such as `{"message":"Hello f
 When the first run succeeds, it is easy to underestimate what that request proves.
 
 - The CLI generated a valid project.
-- Dependencies were installed correctly.
+- Dependencies were installed correctly, either by the wizard or by your later `pnpm install`.
 - TypeScript compiled or transformed as expected in development mode.
 - The runtime adapter started correctly.
 - The default verification routes, runtime `/health` and starter-owned `/greeting`, are reachable.

--- a/docs/getting-started/quick-start.ko.md
+++ b/docs/getting-started/quick-start.ko.md
@@ -39,7 +39,7 @@ pnpm dlx @fluojs/cli new my-fluo-app
 기본 애플리케이션 스타터:
 
 ```bash
-fluo new my-fluo-app
+fluo new my-fluo-app --package-manager pnpm
 cd my-fluo-app
 ```
 
@@ -52,7 +52,7 @@ Next steps:
   pnpm dev  # runs fluo dev
 ```
 
-dependency 설치를 선택하지 않으면 CLI는 이 완료 출력 전에 `Skipping dependency installation.`을 출력합니다. dependency를 설치하면 같은 다음 단계 전에 `Installing dependencies with pnpm...`과 package manager 출력이 나타납니다.
+`Done.`과 `Next steps` 블록은 성공한 모든 스캐폴드에 공통입니다. Non-interactive 출력에서는 dependency를 설치할 때 이 블록 전에 `Installing dependencies with pnpm...`과 package manager 출력이 나타나고, `--no-install`을 사용하면 `Skipping dependency installation.`이 나타납니다. Interactive terminal에서는 wizard가 이러한 non-interactive stdout line 대신 status UI(`Dependencies installed` 또는 `Dependency installation skipped`)로 같은 상태를 알린 뒤 공통 완료 블록을 출력합니다. 이 literal 예제는 pnpm을 명시합니다. `--package-manager pnpm`을 생략하면 선택된 manager에 따라 다음 단계 명령과 lockfile이 달라집니다.
 
 대표적인 명시적 스타터:
 
@@ -82,7 +82,7 @@ my-fluo-app/
 ├── README.md
 ├── babel.config.cjs
 ├── package.json
-├── pnpm-lock.yaml # dependency를 설치할 때 작성
+├── pnpm-lock.yaml # pnpm dependency 설치 후 존재
 ├── tsconfig.json
 ├── tsconfig.build.json
 ├── vite.config.ts
@@ -105,7 +105,7 @@ my-fluo-app/
         └── greeting.slice.test.ts
 ```
 
-위 트리는 기본 Node.js + Fastify 애플리케이션 스타터 기준입니다. `pnpm-lock.yaml`은 dependency 설치 단계에서 생성되므로 `fluo new ... --no-install`은 이 파일을 만들지 않습니다. `vite.config.ts` artifact는 애플리케이션 파일 데코레이터 변환을 위해 `@fluojs/vite`의 `fluoDecoratorsPlugin()`을 import하고, `vitest.config.ts`는 생성된 테스트 파일이 testing-specific transform 경로를 유지하도록 `@fluojs/testing/vitest`를 import합니다. 다른 shipped starter recipe는 의도적으로 다릅니다. Deno는 Node/Vite/Babel/Vitest 설정 파일을 생성하지 않고 Deno-native `src/app.test.ts`를 유지하며, Cloudflare Workers는 `src/worker.ts`와 `wrangler.jsonc`를 사용하고, gRPC microservice는 `proto/math.proto`를 추가하며, microservice 또는 mixed starter는 HTTP 전용 greeting tree만이 아니라 `src/math/*` transport handler도 생성합니다.
+위 트리는 명시된 pnpm dependency 설치가 완료된 기본 Node.js + Fastify 애플리케이션 스타터 기준입니다. 이 설치가 `pnpm-lock.yaml`을 생성하며, `fluo new ... --no-install`을 사용하면 생성 프로젝트에서 `pnpm install`을 실행할 때까지 이 파일이 없습니다. 다른 package manager를 선택하면 설치 시 `pnpm-lock.yaml` 대신 해당 manager의 lockfile이 생성됩니다. `vite.config.ts` artifact는 애플리케이션 파일 데코레이터 변환을 위해 `@fluojs/vite`의 `fluoDecoratorsPlugin()`을 import하고, `vitest.config.ts`는 생성된 테스트 파일이 testing-specific transform 경로를 유지하도록 `@fluojs/testing/vitest`를 import합니다. 다른 shipped starter recipe는 의도적으로 다릅니다. Deno는 Node/Vite/Babel/Vitest 설정 파일을 생성하지 않고 Deno-native `src/app.test.ts`를 유지하며, Cloudflare Workers는 `src/worker.ts`와 `wrangler.jsonc`를 사용하고, gRPC microservice는 `proto/math.proto`를 추가하며, microservice 또는 mixed starter는 HTTP 전용 greeting tree만이 아니라 `src/math/*` transport handler도 생성합니다.
 
 기준 스타터 매트릭스: [fluo new 지원 매트릭스](../reference/fluo-new-support-matrix.ko.md).
 

--- a/docs/getting-started/quick-start.ko.md
+++ b/docs/getting-started/quick-start.ko.md
@@ -43,14 +43,16 @@ fluo new my-fluo-app
 cd my-fluo-app
 ```
 
-예상 출력 패턴:
+완료 출력 패턴:
 
 ```text
-Scaffolding project: my-fluo-app
-Template: application/http/node/fastify
-Installing dependencies: <package-manager-dependent>
-Project ready
+Done.
+Next steps:
+  cd ./my-fluo-app
+  pnpm dev  # runs fluo dev
 ```
+
+dependency 설치를 선택하지 않으면 CLI는 이 완료 출력 전에 `Skipping dependency installation.`을 출력합니다. dependency를 설치하면 같은 다음 단계 전에 `Installing dependencies with pnpm...`과 package manager 출력이 나타납니다.
 
 대표적인 명시적 스타터:
 
@@ -80,7 +82,7 @@ my-fluo-app/
 ├── README.md
 ├── babel.config.cjs
 ├── package.json
-├── pnpm-lock.yaml
+├── pnpm-lock.yaml # dependency를 설치할 때 작성
 ├── tsconfig.json
 ├── tsconfig.build.json
 ├── vite.config.ts
@@ -103,7 +105,7 @@ my-fluo-app/
         └── greeting.slice.test.ts
 ```
 
-위 트리는 기본 Node.js + Fastify 애플리케이션 스타터 기준입니다. `vite.config.ts` artifact는 애플리케이션 파일 데코레이터 변환을 위해 `@fluojs/vite`의 `fluoDecoratorsPlugin()`을 import하고, `vitest.config.ts`는 생성된 테스트 파일이 testing-specific transform 경로를 유지하도록 `@fluojs/testing/vitest`를 import합니다. 다른 shipped starter recipe는 의도적으로 다릅니다. Deno는 Node/Vite/Babel/Vitest 설정 파일을 생성하지 않고 Deno-native `src/app.test.ts`를 유지하며, Cloudflare Workers는 `src/worker.ts`와 `wrangler.jsonc`를 사용하고, gRPC microservice는 `proto/math.proto`를 추가하며, microservice 또는 mixed starter는 HTTP 전용 greeting tree만이 아니라 `src/math/*` transport handler도 생성합니다.
+위 트리는 기본 Node.js + Fastify 애플리케이션 스타터 기준입니다. `pnpm-lock.yaml`은 dependency 설치 단계에서 생성되므로 `fluo new ... --no-install`은 이 파일을 만들지 않습니다. `vite.config.ts` artifact는 애플리케이션 파일 데코레이터 변환을 위해 `@fluojs/vite`의 `fluoDecoratorsPlugin()`을 import하고, `vitest.config.ts`는 생성된 테스트 파일이 testing-specific transform 경로를 유지하도록 `@fluojs/testing/vitest`를 import합니다. 다른 shipped starter recipe는 의도적으로 다릅니다. Deno는 Node/Vite/Babel/Vitest 설정 파일을 생성하지 않고 Deno-native `src/app.test.ts`를 유지하며, Cloudflare Workers는 `src/worker.ts`와 `wrangler.jsonc`를 사용하고, gRPC microservice는 `proto/math.proto`를 추가하며, microservice 또는 mixed starter는 HTTP 전용 greeting tree만이 아니라 `src/math/*` transport handler도 생성합니다.
 
 기준 스타터 매트릭스: [fluo new 지원 매트릭스](../reference/fluo-new-support-matrix.ko.md).
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -43,14 +43,16 @@ fluo new my-fluo-app
 cd my-fluo-app
 ```
 
-Expected output pattern:
+Completion output pattern:
 
 ```text
-Scaffolding project: my-fluo-app
-Template: application/http/node/fastify
-Installing dependencies: <package-manager-dependent>
-Project ready
+Done.
+Next steps:
+  cd ./my-fluo-app
+  pnpm dev  # runs fluo dev
 ```
+
+When you choose not to install dependencies, the CLI prints `Skipping dependency installation.` before this completion output. When you install dependencies, it prints `Installing dependencies with pnpm...` and the package-manager output before the same next steps.
 
 Representative explicit starters:
 
@@ -80,7 +82,7 @@ my-fluo-app/
 ├── README.md
 ├── babel.config.cjs
 ├── package.json
-├── pnpm-lock.yaml
+├── pnpm-lock.yaml # written when dependencies are installed
 ├── tsconfig.json
 ├── tsconfig.build.json
 ├── vite.config.ts
@@ -103,7 +105,7 @@ my-fluo-app/
         └── greeting.slice.test.ts
 ```
 
-The tree above describes the default Node.js + Fastify application starter. The `vite.config.ts` artifact imports `fluoDecoratorsPlugin()` from `@fluojs/vite` for application-file decorator transforms, while `vitest.config.ts` imports `@fluojs/testing/vitest` so generated test files keep their testing-specific transform path. Other shipped starter recipes deliberately differ: Deno omits the Node/Vite/Babel/Vitest config files and keeps a Deno-native `src/app.test.ts`; Cloudflare Workers uses `src/worker.ts` plus `wrangler.jsonc`; gRPC microservices add `proto/math.proto`; and microservice or mixed starters emit `src/math/*` transport handlers instead of the HTTP-only greeting tree alone.
+The tree above describes the default Node.js + Fastify application starter. `pnpm-lock.yaml` is created by the dependency-install step, so `fluo new ... --no-install` omits it. The `vite.config.ts` artifact imports `fluoDecoratorsPlugin()` from `@fluojs/vite` for application-file decorator transforms, while `vitest.config.ts` imports `@fluojs/testing/vitest` so generated test files keep their testing-specific transform path. Other shipped starter recipes deliberately differ: Deno omits the Node/Vite/Babel/Vitest config files and keeps a Deno-native `src/app.test.ts`; Cloudflare Workers uses `src/worker.ts` plus `wrangler.jsonc`; gRPC microservices add `proto/math.proto`; and microservice or mixed starters emit `src/math/*` transport handlers instead of the HTTP-only greeting tree alone.
 
 Authoritative starter matrix: [fluo new support matrix](../reference/fluo-new-support-matrix.md).
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -39,7 +39,7 @@ pnpm dlx @fluojs/cli new my-fluo-app
 Default application starter:
 
 ```bash
-fluo new my-fluo-app
+fluo new my-fluo-app --package-manager pnpm
 cd my-fluo-app
 ```
 
@@ -52,7 +52,7 @@ Next steps:
   pnpm dev  # runs fluo dev
 ```
 
-When you choose not to install dependencies, the CLI prints `Skipping dependency installation.` before this completion output. When you install dependencies, it prints `Installing dependencies with pnpm...` and the package-manager output before the same next steps.
+The `Done.` and `Next steps` block is common to every successful scaffold. In non-interactive output, installing dependencies prints `Installing dependencies with pnpm...` and the package-manager output before this block, while `--no-install` prints `Skipping dependency installation.`. In an interactive terminal, the wizard reports the same state through its status UI (`Dependencies installed` or `Dependency installation skipped`) instead of those non-interactive stdout lines, then prints the common completion block. This literal example pins pnpm; if you omit `--package-manager pnpm`, the selected manager determines the next-step command and lockfile.
 
 Representative explicit starters:
 
@@ -82,7 +82,7 @@ my-fluo-app/
 ├── README.md
 ├── babel.config.cjs
 ├── package.json
-├── pnpm-lock.yaml # written when dependencies are installed
+├── pnpm-lock.yaml # present after pnpm dependency installation
 ├── tsconfig.json
 ├── tsconfig.build.json
 ├── vite.config.ts
@@ -105,7 +105,7 @@ my-fluo-app/
         └── greeting.slice.test.ts
 ```
 
-The tree above describes the default Node.js + Fastify application starter. `pnpm-lock.yaml` is created by the dependency-install step, so `fluo new ... --no-install` omits it. The `vite.config.ts` artifact imports `fluoDecoratorsPlugin()` from `@fluojs/vite` for application-file decorator transforms, while `vitest.config.ts` imports `@fluojs/testing/vitest` so generated test files keep their testing-specific transform path. Other shipped starter recipes deliberately differ: Deno omits the Node/Vite/Babel/Vitest config files and keeps a Deno-native `src/app.test.ts`; Cloudflare Workers uses `src/worker.ts` plus `wrangler.jsonc`; gRPC microservices add `proto/math.proto`; and microservice or mixed starters emit `src/math/*` transport handlers instead of the HTTP-only greeting tree alone.
+The tree above describes the default Node.js + Fastify application starter after the pinned pnpm dependency installation completes. That install creates `pnpm-lock.yaml`; `fluo new ... --no-install` omits it until you run `pnpm install` in the generated project. If another package manager is selected, its installation writes that manager's lockfile instead of `pnpm-lock.yaml`. The `vite.config.ts` artifact imports `fluoDecoratorsPlugin()` from `@fluojs/vite` for application-file decorator transforms, while `vitest.config.ts` imports `@fluojs/testing/vitest` so generated test files keep their testing-specific transform path. Other shipped starter recipes deliberately differ: Deno omits the Node/Vite/Babel/Vitest config files and keeps a Deno-native `src/app.test.ts`; Cloudflare Workers uses `src/worker.ts` plus `wrangler.jsonc`; gRPC microservices add `proto/math.proto`; and microservice or mixed starters emit `src/math/*` transport handlers instead of the HTTP-only greeting tree alone.
 
 Authoritative starter matrix: [fluo new support matrix](../reference/fluo-new-support-matrix.md).
 

--- a/packages/cli/README.ko.md
+++ b/packages/cli/README.ko.md
@@ -66,10 +66,21 @@ fluo -v
 몇 초 만에 완전한 스타터 애플리케이션을 스캐폴딩합니다.
 
 ```bash
-fluo new my-app
+fluo new my-app --package-manager pnpm
 cd my-app
 pnpm dev
 ```
+
+이 예제는 `pnpm`을 명시하므로 성공한 모든 스캐폴드는 같은 완료 블록으로 끝납니다.
+
+```text
+Done.
+Next steps:
+  cd ./my-app
+  pnpm dev  # runs fluo dev
+```
+
+Non-interactive 출력에서는 이 블록 전에 설치 시 `Installing dependencies with pnpm...`과 package manager 출력이 나타나고, `--no-install` 사용 시 `Skipping dependency installation.`이 나타납니다. Interactive terminal에서는 wizard가 이러한 non-interactive stdout line 대신 status UI(`Dependencies installed` 또는 `Dependency installation skipped`)로 같은 설치 상태를 알린 뒤 공통 완료 블록을 출력합니다. pnpm 설치가 완료되면 `pnpm-lock.yaml`이 생성되며, `--no-install`을 사용하면 생성 프로젝트에서 `pnpm install`을 실행할 때까지 이 파일이 없습니다. `--package-manager pnpm`을 생략하면 CLI가 현재 invocation 또는 workspace signal을 바탕으로 manager를 선택하고 신호가 없으면 pnpm을 사용하므로, 다음 단계 명령과 lockfile도 선택된 manager에 맞게 달라집니다. 다른 manager는 설치 시 `pnpm-lock.yaml` 대신 각자의 lockfile을 생성합니다.
 
 `fluo create`는 `fluo new`의 alias입니다. 버전 확인, 명령 도움말, 진단, first-party package shortcut, upgrade 안내가 필요하면 `fluo version`, `fluo help <command>`, `fluo doctor`/`fluo info`/`fluo analyze`, `fluo add`, `fluo upgrade`를 사용하세요.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -66,10 +66,21 @@ The update check is skipped in CI, non-TTY output, npm-script contexts, rerun-af
 Scaffold a complete starter application in seconds.
 
 ```bash
-fluo new my-app
+fluo new my-app --package-manager pnpm
 cd my-app
 pnpm dev
 ```
+
+This example pins `pnpm`, so every successful scaffold ends with the same completion block:
+
+```text
+Done.
+Next steps:
+  cd ./my-app
+  pnpm dev  # runs fluo dev
+```
+
+In non-interactive output, an install prints `Installing dependencies with pnpm...` and the package-manager output before that block, while `--no-install` prints `Skipping dependency installation.`. In an interactive terminal, the wizard reports the same install state through its status UI (`Dependencies installed` or `Dependency installation skipped`) instead of those non-interactive stdout lines, then prints the common completion block. A completed pnpm install writes `pnpm-lock.yaml`; `--no-install` leaves it absent until you run `pnpm install` in the generated project. If you omit `--package-manager pnpm`, the CLI selects a manager from the current invocation or workspace signals and falls back to pnpm, so both the next-step command and the lockfile become manager-specific; other managers write their own lockfile instead of `pnpm-lock.yaml` when installation runs.
 
 `fluo create` is an alias for `fluo new`. Use `fluo version`, `fluo help <command>`, `fluo doctor`/`fluo info`/`fluo analyze`, `fluo add`, and `fluo upgrade` for version checks, command help, diagnostics, first-party package shortcuts, and upgrade guidance.
 


### PR DESCRIPTION
## Summary

Synchronize CLI quick-start completion output and the default starter artifact tree with the current generated behavior.

Linked context: Closes #2756

## Changes

- Replaced stale scaffold-status text with the CLI completion output and installation-path explanation.
- Clarified that `pnpm-lock.yaml` is written during dependency installation rather than by the scaffold itself.
- Preserved the EN/KO quick-start pair and canonical starter-matrix links.

## Testing

- `pnpm docs:sync-check`
- `pnpm verify:platform-consistency-governance`
- `GIT_MASTER=1 git diff --check`

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

Documentation-only correction: no published package behavior, API surface, package contents, or release metadata changes.

## Public export documentation

Not applicable: no source exports or exported functions changed.

- [ ] Changed public exports include a source-level summary.
- [ ] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

Documentation now reflects the existing CLI scaffold and installation behavior; no runtime contract changed.

- [x] No documented behavioral contracts were removed without migration notes.
- [ ] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [ ] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

The EN/KO quick-start pair remains synchronized and the canonical governance verifier passes. No platform contract or package README conformance claim changed.

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by the applicable platform harness tests, such as `createPlatformConformanceHarness(...)` for platform component contracts or `createHttpAdapterPortabilityHarness(...)` for HTTP adapter portability contracts.