### PR TITLE
Resolve #2736: Correct Fastify capability claims in advanced adapter book

### DIFF
--- a/book/advanced/ch13-custom-adapter.ko.md
+++ b/book/advanced/ch13-custom-adapter.ko.md
@@ -325,7 +325,7 @@ export class TinyNodeAdapter implements HttpApplicationAdapter {
 }
 ```
 
-이 스켈레톤은 이제 필수 request/response shape를 만족하지만 여전히 의도적으로 불완전합니다. Production code는 request body와 cookie parsing, size limit, 필요한 경우 정확한 raw byte 보존, header normalization, native listener 제거, streaming/backpressure, shutdown policy를 구현해야 합니다. 실제 상용 어댑터(예: FastifyAdapter)는 여기에 multipart 처리, compression, HTTP/2 같은 protocol optimization도 더합니다.
+이 스켈레톤은 이제 필수 request/response shape를 만족하지만 여전히 의도적으로 불완전합니다. Production code는 request body와 cookie parsing, size limit, 필요한 경우 정확한 raw byte 보존, header normalization, native listener 제거, streaming/backpressure, shutdown policy를 구현해야 합니다. 실제 상용 어댑터(예: FastifyAdapter)는 여기에 multipart 처리도 더합니다.
 
 ## 13.13 요약
 

--- a/book/advanced/ch13-custom-adapter.md
+++ b/book/advanced/ch13-custom-adapter.md
@@ -325,7 +325,7 @@ export class TinyNodeAdapter implements HttpApplicationAdapter {
 }
 ```
 
-This skeleton now satisfies the required request/response shape, but it is still intentionally incomplete: production code must parse request bodies and cookies, enforce size limits, preserve exact raw bytes when needed, normalize headers, remove native listeners, and implement streaming/backpressure and shutdown policy. A production adapter, such as `FastifyAdapter`, also adds multipart handling, compression, and protocol optimization logic such as HTTP/2.
+This skeleton now satisfies the required request/response shape, but it is still intentionally incomplete: production code must parse request bodies and cookies, enforce size limits, preserve exact raw bytes when needed, normalize headers, remove native listeners, and implement streaming/backpressure and shutdown policy. A production adapter, such as `FastifyAdapter`, also adds multipart handling.
 
 ## 13.13 Summary
 


### PR DESCRIPTION
## Summary

Correct the paired advanced custom-adapter book pages so they no longer claim unsupported Fastify compression or HTTP/2 capabilities.

Linked context: Closes #2736

## Changes

- Removed the unsupported compression and HTTP/2 claims from `book/advanced/ch13-custom-adapter.md`.
- Applied the equivalent correction to `book/advanced/ch13-custom-adapter.ko.md` to preserve EN/KO parity.
- Kept the verified multipart capability statement unchanged.

## Testing

- `pnpm docs:sync-check` — passed.
- `pnpm verify:docs` — passed, including docs typecheck and production build.
- `pnpm verify:platform-consistency-governance` — passed.
- `pnpm vitest run tooling/governance/verify-platform-consistency-governance.test.ts` — passed, 102 tests.
- `pnpm verify` — build, typecheck, and lint completed; the full test stage reported one unrelated 30-second timeout in `packages/cli/src/new/scaffold.test.ts` after 4,379 tests passed. The timed-out test passed on an immediate isolated rerun with `pnpm vitest run packages/cli/src/new/scaffold.test.ts -t "invalidates stale local package cache tarballs from the old rewrite pipeline"`.

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

No changeset is included because this is a docs-only correction to book content. It does not change public `@fluojs/*` package behavior, API surface, package contents, exports, or release metadata.

## Public export documentation

- [x] Not applicable: no package source or public exports changed.
- [x] Existing source TSDoc and README scenario examples are unchanged.

## Behavioral contract

- [x] No documented behavioral contract was removed; unsupported capability claims were corrected to match the existing Fastify package contract.
- [x] No new behavioral contract was introduced.
- [x] The verified multipart capability remains explicitly documented.
- [x] Runtime regression tests are not required because runtime behavior did not change.

## Platform consistency governance (SSOT)

- [x] The changed English/Korean book pages remain synchronized.
- [x] No platform contract SSOT, package README, tooling, CI, or runtime conformance claim changed.
- [x] The correction was checked against `packages/platform-fastify/README.md`, `packages/platform-fastify/README.ko.md`, and the adapter source/options.