### PR TITLE
Resolve #2738: Complete Bun websocket module setup documentation

### DIFF
--- a/packages/platform-bun/README.ko.md
+++ b/packages/platform-bun/README.ko.md
@@ -64,12 +64,20 @@ Bun.serve({
 ```
 
 ### 네이티브 WebSocket 업그레이드
-어댑터는 `@fluojs/websockets/bun` 바인딩을 통해 Bun의 네이티브 `server.upgrade()`를 지원합니다.
+어댑터는 `@fluojs/websockets/bun` 바인딩을 통해 Bun의 네이티브 `server.upgrade()`를 지원합니다. 런타임이 해당 바인딩을 설치하고 등록된 게이트웨이를 찾을 수 있도록 `app.listen()` 전에 application module에서 `BunWebSocketModule.forRoot(...)`를 import하세요.
 
 ```typescript
-// Bun 어댑터가 활성화된 경우 게이트웨이는 자동으로 Bun의 네이티브 업그레이드를 사용합니다.
+import { Module } from '@fluojs/core';
+import { BunWebSocketModule, WebSocketGateway } from '@fluojs/websockets/bun';
+
 @WebSocketGateway({ path: '/ws' })
-export class MyGateway {}
+class MyGateway {}
+
+@Module({
+  imports: [BunWebSocketModule.forRoot()],
+  providers: [MyGateway],
+})
+export class AppModule {}
 ```
 
 ### 네이티브 `routes` Object 가속

--- a/packages/platform-bun/README.md
+++ b/packages/platform-bun/README.md
@@ -64,12 +64,20 @@ Bun.serve({
 ```
 
 ### Native WebSocket Upgrade
-The adapter supports Bun's native `server.upgrade()` through the `@fluojs/websockets/bun` binding.
+The adapter supports Bun's native `server.upgrade()` through the `@fluojs/websockets/bun` binding. Import `BunWebSocketModule.forRoot(...)` into the application module before `app.listen()` so the runtime can install that binding and discover the registered gateways.
 
 ```typescript
-// gateways automatically use Bun's native upgrade when the Bun adapter is active
+import { Module } from '@fluojs/core';
+import { BunWebSocketModule, WebSocketGateway } from '@fluojs/websockets/bun';
+
 @WebSocketGateway({ path: '/ws' })
-export class MyGateway {}
+class MyGateway {}
+
+@Module({
+  imports: [BunWebSocketModule.forRoot()],
+  providers: [MyGateway],
+})
+export class AppModule {}
 ```
 
 ### Native `routes` Object Acceleration


### PR DESCRIPTION
## Summary

Complete the Bun native WebSocket setup guidance so readers register the runtime module that installs the documented upgrade binding.

Linked context: Closes #2738

## Changes

- Add `BunWebSocketModule.forRoot()` registration to the English Bun package README example.
- Mirror the same module and gateway provider setup in the Korean README.
- Keep the change documentation-only; existing Bun book examples already use the same executable module shape.

## Testing

- `pnpm docs:sync-check` — passed.
- `pnpm verify:platform-consistency-governance` — passed.
- `pnpm exec vitest run packages/websockets/src/bun/bun.test.ts` — 21 tests passed.
- `pnpm --filter @fluojs/platform-bun typecheck` — passed after workspace build.
- `pnpm --filter @fluojs/websockets typecheck` — passed after workspace build.
- `pnpm build` — passed.
- `pnpm verify` — build, typecheck, and lint passed; all 337 test files and 4380 tests passed, but the default parallel test process reported one Vitest worker RPC timeout.
- `pnpm exec vitest run --maxWorkers=1` — full suite passed: 337 files, 4380 passed, 1 skipped.

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

No changeset is included because this PR only corrects setup documentation; it does not change runtime behavior, public API, package contents, or release metadata.

## Public export documentation

- [x] No public exports changed.
- [x] Source `@example` blocks and README scenario examples remain complementary.

## Behavioral contract

- [x] No documented behavioral contracts were removed.
- [x] The affected package README now documents the required existing Bun module registration.
- [x] Existing Bun websocket regression coverage validates `BunWebSocketModule.forRoot()` provider wiring and application bootstrap behavior.

## Platform consistency governance (SSOT)

- [x] English and Korean package README guidance remains synchronized.
- [x] No platform contract or runtime implementation changed.
- [x] Existing Bun adapter and websocket tests remain the executable evidence for the documented setup.