### PR TITLE
Resolve #2810: Bound Passport.js strategy settlement and repair cookie-auth setup

### DIFF
--- a/.changeset/bound-passport-strategy-settlement.md
+++ b/.changeset/bound-passport-strategy-settlement.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/passport': patch
+---
+
+Reject invalid Passport.js action timeout configuration instead of leaving strategy settlement unbounded, preserve zero as a next-turn timeout, and correct cookie-auth JWT verifier wiring guidance.

--- a/apps/docs/content/docs/guides/auth.ko.mdx
+++ b/apps/docs/content/docs/guides/auth.ko.mdx
@@ -191,7 +191,11 @@ import {
 @Module({
   imports: [
     CookieAuthModule.forRoot(),
-    JwtModule.forRoot({ algorithms: ['HS256'], secret: 'your-secure-secret' }),
+    JwtModule.forRoot({
+      algorithms: ['HS256'],
+      global: true,
+      secret: 'your-secure-secret',
+    }),
     PassportModule.forRoot(
       { defaultStrategy: COOKIE_AUTH_STRATEGY_NAME },
       [{ name: COOKIE_AUTH_STRATEGY_NAME, token: CookieAuthStrategy }],
@@ -200,6 +204,8 @@ import {
 })
 export class AuthModule {}
 ```
+
+여기서 `CookieAuthModule`과 `JwtModule`은 sibling import입니다. Cookie module이 `CookieAuthStrategy`를 resolve할 때 `DefaultJwtVerifier`를 볼 수 있도록 JWT registration에 `global: true`를 유지하세요.
 
 Protected route에는 여전히 `@UseAuth(...)`가 필요합니다. Signed-in caller와 guest caller를 모두 허용하는 route라면 의도적으로 `@UseOptionalAuth(...)`를 사용합니다.
 
@@ -320,6 +326,7 @@ ThrottlerModule.forRoot({
 | Algorithms | 지원 algorithm을 하나 이상 설정하세요. 빈 algorithm list는 fail-fast됩니다. |
 | Access-token TTL | 양의 finite `accessTokenTtlSeconds`를 사용하세요. 잘못된 TTL은 token 발급 전에 실패합니다. |
 | JWKS | `jwksRequestTimeoutMs`로 remote JWKS fetch를 bounded하게 유지하세요. 기본값은 `5_000`입니다. |
+| Passport.js bridge | Callback settlement는 0 이상인 유한한 `actionTimeoutMs`(기본값 `30_000`)로 제한하세요. `0`은 다음 turn timeout으로 유지되고 invalid 값은 즉시 실패합니다. |
 | Principal shape | Normalized principal의 `subject`, `roles`, `scopes`, `claims`를 읽으세요. |
 | Refresh rotation | Atomic consume/revoke semantics를 사용하고, multi-instance production에서 memory store를 피하세요. |
 | Optional auth | Guest-compatible route에만 사용하세요. Scoped route에는 credential이 필요합니다. |

--- a/apps/docs/content/docs/guides/auth.mdx
+++ b/apps/docs/content/docs/guides/auth.mdx
@@ -191,7 +191,11 @@ import {
 @Module({
   imports: [
     CookieAuthModule.forRoot(),
-    JwtModule.forRoot({ algorithms: ['HS256'], secret: 'your-secure-secret' }),
+    JwtModule.forRoot({
+      algorithms: ['HS256'],
+      global: true,
+      secret: 'your-secure-secret',
+    }),
     PassportModule.forRoot(
       { defaultStrategy: COOKIE_AUTH_STRATEGY_NAME },
       [{ name: COOKIE_AUTH_STRATEGY_NAME, token: CookieAuthStrategy }],
@@ -200,6 +204,8 @@ import {
 })
 export class AuthModule {}
 ```
+
+`CookieAuthModule` and `JwtModule` are sibling imports here. Keep `global: true` on the JWT registration so `DefaultJwtVerifier` is visible when the cookie module resolves `CookieAuthStrategy`.
 
 Protected routes still need `@UseAuth(...)`. If a route supports both signed-in and guest callers, use `@UseOptionalAuth(...)` intentionally.
 
@@ -320,6 +326,7 @@ When an app sits behind a trusted reverse proxy, opt in to proxy header identity
 | Algorithms | Configure at least one supported algorithm. Empty algorithm lists fail fast. |
 | Access-token TTL | Use a positive finite `accessTokenTtlSeconds`; invalid TTL values fail before issuing a token. |
 | JWKS | Keep remote JWKS fetches bounded with `jwksRequestTimeoutMs` (default `5_000`). |
+| Passport.js bridge | Keep callback settlement bounded with a non-negative finite `actionTimeoutMs` (default `30_000`); `0` remains a next-turn timeout, while invalid values fail fast. |
 | Principal shape | Read `subject`, `roles`, `scopes`, and `claims` from the normalized principal. |
 | Refresh rotation | Use atomic consume/revoke semantics; avoid memory stores in multi-instance production. |
 | Optional auth | Use only for guest-compatible routes; scoped routes still need credentials. |

--- a/packages/passport/README.ko.md
+++ b/packages/passport/README.ko.md
@@ -122,6 +122,8 @@ export class AuthModule {}
 
 브릿지는 각 Passport.js 전략 실행을 정확히 한 번만 정착(settle)시킵니다. 전략은 바인딩된 Passport 액션(`success`, `fail`, `redirect`, `pass`, `error`) 중 하나를 호출해야 하며, promise rejection, 액션 없이 완료된 promise, 그리고 제한된 action timeout을 초과한 callback-style 실행은 요청을 미해결 상태로 두지 않고 인증 실패로 처리됩니다. `handled: true`를 포함한 모든 `AuthStrategyResult`는 전략이 response를 commit한 뒤에는 `principal`을 함께 포함하더라도 완전히 terminal입니다. 이때 `AuthGuard`는 principal validation, scope check, `requestContext.principal` 할당, protected handler 실행을 모두 건너뜁니다. 커스텀 `mapPrincipal` 함수는 비어 있지 않은 `subject`와 객체 형태의 `claims`를 포함한 유효한 fluo `Principal`을 반환해야 합니다.
 
+`actionTimeoutMs` 기본값은 `30_000`밀리초이며 0 이상인 유한한 숫자여야 합니다. `0`으로 설정하면 다음 timer turn에 timeout settlement를 예약합니다. 음수, `NaN`, 무한대 값은 settlement 제한을 비활성화하지 않고 bridge strategy 생성 시 `RangeError`를 발생시킵니다.
+
 ### 쿠키 인증 프리셋
 
 HTTP 쿠키에서 인증 정보를 읽는 애플리케이션이라면 `CookieAuthModule.forRoot(...)`를 사용합니다.
@@ -141,6 +143,7 @@ import {
     CookieAuthModule.forRoot(),
     JwtModule.forRoot({
       algorithms: ['HS256'],
+      global: true,
       secret: 'your-secure-secret',
     }),
     PassportModule.forRoot(
@@ -152,7 +155,7 @@ import {
 export class AuthModule {}
 ```
 
-애플리케이션 모듈에서 cookie-auth 지원이 필요하면 `CookieAuthModule.forRoot(...)`, `JwtModule.forRoot(...)`, `PassportModule.forRoot(...)`를 함께 import 하세요. Cookie preset은 `CookieAuthStrategy`와 cookie option을 제공하고, JWT 검증은 여전히 `@fluojs/jwt`에서 오며, passport registry는 여전히 `PassportModule.forRoot(...)`에서 옵니다.
+애플리케이션 모듈에서 cookie-auth 지원이 필요하면 `CookieAuthModule.forRoot(...)`, `JwtModule.forRoot(...)`, `PassportModule.forRoot(...)`를 함께 import 하세요. 이 graph에서 `CookieAuthModule`과 `JwtModule`은 sibling import이므로, cookie module이 `CookieAuthStrategy`를 resolve할 때 `DefaultJwtVerifier`를 볼 수 있도록 문서화된 JWT option `global: true`를 설정해야 합니다. Cookie preset은 `CookieAuthStrategy`와 cookie option을 제공하고, JWT 검증은 여전히 `@fluojs/jwt`에서 오며, passport registry는 여전히 `PassportModule.forRoot(...)`에서 옵니다.
 
 `CookieAuthModule.forRoot(...)`는 애플리케이션 등록을 위한 canonical module-first entrypoint입니다. `createCookieAuthPreset(...)`은 provider graph를 직접 조립하는 host를 위한 compatibility bundle로 공개되어 있으며, 동일한 cookie-auth provider와 대응하는 strategy registration을 반환합니다. 애플리케이션 문서, generated code, 일반 app module에서는 module facade를 우선 사용하세요.
 

--- a/packages/passport/README.md
+++ b/packages/passport/README.md
@@ -122,6 +122,8 @@ This bridge helper is the official exception to the module-facade rule for Passp
 
 The bridge settles each Passport.js strategy execution exactly once. A strategy must call one of the bound Passport actions (`success`, `fail`, `redirect`, `pass`, or `error`); promise rejections, promise completion without an action, and callback-style executions that exceed the bounded action timeout become authentication failures instead of leaving the request unresolved. Any `AuthStrategyResult` with `handled: true` is fully terminal after the strategy commits a response, even if it also includes a `principal`; `AuthGuard` skips principal validation, scope checks, `requestContext.principal` assignment, and the protected handler. Custom `mapPrincipal` functions must return a valid fluo `Principal` with a non-empty `subject` and object `claims`.
 
+`actionTimeoutMs` defaults to `30_000` milliseconds and must be a non-negative finite number. Set it to `0` to schedule timeout settlement on the next timer turn. Negative, `NaN`, and infinite values throw `RangeError` when the bridge strategy is constructed instead of disabling the settlement bound.
+
 ### Cookie Auth Preset
 
 Use `CookieAuthModule.forRoot(...)` when your app authenticates requests from HTTP cookies.
@@ -141,6 +143,7 @@ import {
     CookieAuthModule.forRoot(),
     JwtModule.forRoot({
       algorithms: ['HS256'],
+      global: true,
       secret: 'your-secure-secret',
     }),
     PassportModule.forRoot(
@@ -152,7 +155,7 @@ import {
 export class AuthModule {}
 ```
 
-Import `CookieAuthModule.forRoot(...)`, `JwtModule.forRoot(...)`, and `PassportModule.forRoot(...)` together when you want cookie-auth support in an application module. The cookie preset provides `CookieAuthStrategy` and cookie options; JWT verification still comes from `@fluojs/jwt`, and the passport registry still comes from `PassportModule.forRoot(...)`.
+Import `CookieAuthModule.forRoot(...)`, `JwtModule.forRoot(...)`, and `PassportModule.forRoot(...)` together when you want cookie-auth support in an application module. `CookieAuthModule` and `JwtModule` are sibling imports in this graph, so set the documented `global: true` JWT option to make `DefaultJwtVerifier` visible when the cookie module resolves `CookieAuthStrategy`. The cookie preset provides `CookieAuthStrategy` and cookie options; JWT verification still comes from `@fluojs/jwt`, and the passport registry still comes from `PassportModule.forRoot(...)`.
 
 `CookieAuthModule.forRoot(...)` is the canonical module-first entrypoint for application registration. `createCookieAuthPreset(...)` remains public as a compatibility bundle for manual provider composition; it returns the same cookie-auth providers plus the matching strategy registration for hosts that assemble provider graphs themselves. Prefer the module facade in application docs, generated code, and ordinary app modules.
 

--- a/packages/passport/src/adapters/passport-js.test.ts
+++ b/packages/passport/src/adapters/passport-js.test.ts
@@ -1,0 +1,144 @@
+import { Container } from '@fluojs/di';
+import type { FrameworkResponse, GuardContext } from '@fluojs/http';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { AuthenticationRequiredError } from '../errors.js';
+import { PassportJsAuthStrategy, type PassportJsStrategyLike } from './passport-js.js';
+
+class UnsettledStrategy implements PassportJsStrategyLike {
+  authenticate(): void {}
+}
+
+function createGuardContext(): GuardContext {
+  const response = {
+    committed: false,
+    headers: {},
+    redirect(status: number, location: string) {
+      this.setStatus(status);
+      this.setHeader('Location', location);
+      this.committed = true;
+    },
+    send() {
+      this.committed = true;
+    },
+    setHeader(name: string, value: string | string[]) {
+      this.headers[name] = value;
+    },
+    setStatus(code: number) {
+      this.statusCode = code;
+      this.statusSet = true;
+    },
+    statusCode: undefined,
+    statusSet: false,
+  } satisfies FrameworkResponse;
+
+  return {
+    handler: {
+      controllerToken: class TestController {},
+      metadata: {
+        controllerPath: '/auth',
+        effectivePath: '/auth/callback',
+        moduleMiddleware: [],
+        pathParams: [],
+      },
+      methodName: 'callback',
+      route: {
+        method: 'GET',
+        path: '/callback',
+      },
+    },
+    requestContext: {
+      container: new Container().createRequestScope(),
+      metadata: {},
+      request: {
+        body: undefined,
+        cookies: {},
+        headers: {},
+        method: 'GET',
+        params: {},
+        path: '/auth/callback',
+        query: {},
+        raw: {},
+        url: '/auth/callback',
+      },
+      response,
+    },
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('PassportJsAuthStrategy action timeout', () => {
+  it.each([
+    -1,
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    Number.NEGATIVE_INFINITY,
+  ])('rejects invalid actionTimeoutMs %s before authentication starts', (actionTimeoutMs) => {
+    // Given
+    const strategy = new UnsettledStrategy();
+
+    // When
+    const createBridgeStrategy = () => new PassportJsAuthStrategy(strategy, { actionTimeoutMs });
+
+    // Then
+    expect(createBridgeStrategy).toThrow(RangeError);
+  });
+
+  it('retains actionTimeoutMs 0 and clears the timer after timeout settlement', async () => {
+    // Given
+    vi.useFakeTimers();
+    const strategy = new PassportJsAuthStrategy(new UnsettledStrategy(), { actionTimeoutMs: 0 });
+
+    // When
+    const authentication = strategy.authenticate(createGuardContext());
+    const rejection = expect(authentication).rejects.toThrow(AuthenticationRequiredError);
+    await vi.runAllTimersAsync();
+
+    // Then
+    await rejection;
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('clears the pending action timeout after successful strategy settlement', async () => {
+    // Given
+    vi.useFakeTimers();
+    class SuccessfulStrategy implements PassportJsStrategyLike {
+      success?: (user: unknown) => void;
+
+      authenticate(): void {
+        this.success?.({ id: 'passport-user' });
+      }
+    }
+    const strategy = new PassportJsAuthStrategy(new SuccessfulStrategy(), { actionTimeoutMs: 1_000 });
+
+    // When
+    const principal = await strategy.authenticate(createGuardContext());
+
+    // Then
+    expect(principal).toMatchObject({ subject: 'passport-user' });
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('clears the pending action timeout after failed strategy settlement', async () => {
+    // Given
+    vi.useFakeTimers();
+    class FailedStrategy implements PassportJsStrategyLike {
+      fail?: (challenge?: unknown, status?: number) => void;
+
+      authenticate(): void {
+        this.fail?.('credentials rejected', 401);
+      }
+    }
+    const strategy = new PassportJsAuthStrategy(new FailedStrategy(), { actionTimeoutMs: 1_000 });
+
+    // When
+    const authentication = strategy.authenticate(createGuardContext());
+
+    // Then
+    await expect(authentication).rejects.toThrow(AuthenticationRequiredError);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/packages/passport/src/adapters/passport-js.ts
+++ b/packages/passport/src/adapters/passport-js.ts
@@ -1,6 +1,7 @@
+// allow: SIZE_OK — Keep the Passport.js action-binding state machine with its public bridge contracts for auditability.
 import type { Token } from '@fluojs/core';
-import type { GuardContext, Principal } from '@fluojs/http';
 import type { Provider } from '@fluojs/di';
+import type { GuardContext, Principal } from '@fluojs/http';
 
 import { AuthenticationFailedError, AuthenticationRequiredError } from '../errors.js';
 import { normalizePrincipalScopes } from '../scope.js';
@@ -65,7 +66,10 @@ export type PassportJsPrincipalMapper = (input: PassportJsPrincipalMapperInput) 
 export interface PassportJsAuthStrategyOptions {
   /** Optional options to pass to the Passport strategy's `authenticate` method. */
   authenticateOptions?: Readonly<Record<string, unknown>>;
-  /** Maximum time to wait for callback-style strategies to call a bound Passport action. */
+  /**
+   * Maximum time to wait for callback-style strategies to call a bound Passport action.
+   * Must be a non-negative finite number. A value of `0` schedules settlement on the next timer turn.
+   */
   actionTimeoutMs?: number;
   /** Optional custom mapper for converting user data to a principal. */
   mapPrincipal?: PassportJsPrincipalMapper;
@@ -184,14 +188,25 @@ function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
 /**
  * A bridge strategy that allows using Passport.js strategies within the fluo
  * authentication framework.
+ *
+ * @throws {RangeError} When `actionTimeoutMs` is negative or non-finite.
  */
 export class PassportJsAuthStrategy implements AuthStrategy {
+  private readonly actionTimeoutMs: number;
   private readonly requestState = new WeakMap<PassportJsExecutableStrategy, PassportJsRequestState>();
 
   constructor(
     private readonly strategyTemplate: PassportJsStrategyLike,
     private readonly options: PassportJsAuthStrategyOptions = {},
-  ) {}
+  ) {
+    const actionTimeoutMs = options.actionTimeoutMs ?? DEFAULT_ACTION_TIMEOUT_MS;
+
+    if (!Number.isFinite(actionTimeoutMs) || actionTimeoutMs < 0) {
+      throw new RangeError('Passport.js actionTimeoutMs must be a non-negative finite number.');
+    }
+
+    this.actionTimeoutMs = actionTimeoutMs;
+  }
 
   authenticate(context: GuardContext): Promise<Principal | AuthHandledResult> {
     const response = context.requestContext.response;
@@ -221,15 +236,11 @@ export class PassportJsAuthStrategy implements AuthStrategy {
 
       this.bindStrategyActions(strategy);
 
-      const actionTimeoutMs = this.options.actionTimeoutMs ?? DEFAULT_ACTION_TIMEOUT_MS;
-
-      if (Number.isFinite(actionTimeoutMs) && actionTimeoutMs >= 0) {
-        actionTimeout = setTimeout(() => {
-          this.settle(strategy, (state) => {
-            state.reject(new AuthenticationRequiredError('Passport strategy did not settle authentication.'));
-          });
-        }, actionTimeoutMs);
-      }
+      actionTimeout = setTimeout(() => {
+        this.settle(strategy, (state) => {
+          state.reject(new AuthenticationRequiredError('Passport strategy did not settle authentication.'));
+        });
+      }, this.actionTimeoutMs);
 
       try {
         const result = strategy.authenticate(request, this.options.authenticateOptions);
@@ -250,7 +261,7 @@ export class PassportJsAuthStrategy implements AuthStrategy {
             },
           );
         }
-      } catch (error: unknown) {
+      } catch (error: unknown) { // no-excuse-ok: catch — convert synchronous strategy throws to promise rejection.
         clearActionTimeout();
         this.settle(strategy, () => reject(error));
       }
@@ -298,7 +309,7 @@ export class PassportJsAuthStrategy implements AuthStrategy {
       this.settle(strategy, (state) => {
         try {
           state.resolve(state.mapPrincipal({ context: state.context, info, user }));
-        } catch (error: unknown) {
+        } catch (error: unknown) { // no-excuse-ok: catch — convert mapper throws to authentication promise rejection.
           state.reject(error);
         }
       });

--- a/packages/passport/src/cookie/cookie-auth-module.integration.test.ts
+++ b/packages/passport/src/cookie/cookie-auth-module.integration.test.ts
@@ -1,0 +1,40 @@
+import { Module } from '@fluojs/core';
+import { JwtModule } from '@fluojs/jwt';
+import { FluoFactory } from '@fluojs/runtime';
+import { describe, expect, it } from 'vitest';
+import { PassportModule } from '../module.js';
+import { COOKIE_AUTH_STRATEGY_NAME, CookieAuthStrategy } from './cookie-auth.js';
+import { CookieAuthModule } from './cookie-auth-module.js';
+
+describe('CookieAuthModule application wiring', () => {
+  it('resolves CookieAuthStrategy when a sibling JwtModule makes its verifier global', async () => {
+    // Given
+    @Module({
+      imports: [
+        CookieAuthModule.forRoot(),
+        JwtModule.forRoot({
+          algorithms: ['HS256'],
+          global: true,
+          secret: 'cookie-auth-integration-secret',
+        }),
+        PassportModule.forRoot(
+          { defaultStrategy: COOKIE_AUTH_STRATEGY_NAME },
+          [{ name: COOKIE_AUTH_STRATEGY_NAME, token: CookieAuthStrategy }],
+        ),
+      ],
+    })
+    class AuthModule {}
+
+    // When
+    const app = await FluoFactory.createApplicationContext(AuthModule);
+
+    try {
+      const strategy = await app.container.resolve(CookieAuthStrategy);
+
+      // Then
+      expect(strategy).toBeInstanceOf(CookieAuthStrategy);
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/packages/passport/src/cookie/cookie-auth-module.ts
+++ b/packages/passport/src/cookie/cookie-auth-module.ts
@@ -1,14 +1,13 @@
 import type { Provider } from '@fluojs/di';
 import { defineModule, type ModuleType } from '@fluojs/runtime';
-
+import type { AuthStrategyRegistration } from '../types.js';
 import {
   COOKIE_AUTH_OPTIONS,
   COOKIE_AUTH_STRATEGY_NAME,
-  CookieAuthStrategy,
   type CookieAuthOptions,
+  CookieAuthStrategy,
 } from './cookie-auth.js';
 import { CookieManager, type CookieManagerConfig } from './cookie-manager.js';
-import type { AuthStrategyRegistration } from '../types.js';
 
 type CookieAuthModuleType = ModuleType;
 
@@ -76,6 +75,7 @@ export class CookieAuthModule {
    * @example
    * ```ts
    * import { Module } from '@fluojs/core';
+   * import { JwtModule } from '@fluojs/jwt';
    * import {
    *   CookieAuthModule,
    *   CookieAuthStrategy,
@@ -86,6 +86,11 @@ export class CookieAuthModule {
    * @Module({
    *   imports: [
    *     CookieAuthModule.forRoot(),
+   *     JwtModule.forRoot({
+   *       algorithms: ['HS256'],
+   *       global: true,
+   *       secret: 'your-secure-secret',
+   *     }),
    *     PassportModule.forRoot(
    *       { defaultStrategy: COOKIE_AUTH_STRATEGY_NAME },
    *       [{ name: COOKIE_AUTH_STRATEGY_NAME, token: CookieAuthStrategy }],


### PR DESCRIPTION
## Summary

Bound Passport.js bridge settlement configuration and repaired the public cookie-auth module wiring guidance.

Linked context: https://github.com/fluojs/fluo/issues/2810

Closes #2810

## Changes

- Reject negative and non-finite `actionTimeoutMs` values with `RangeError` when `PassportJsAuthStrategy` is constructed while preserving `0` as a next-turn timeout.
- Add direct settlement regression coverage for invalid values, zero timeout behavior, and timeout cleanup after success and failure.
- Correct `CookieAuthModule` sibling wiring examples so `JwtModule.forRoot(...)` exposes `DefaultJwtVerifier` with `global: true`, with executable module-graph coverage.
- Synchronize package README and website auth guidance in English and Korean.
- Add `.changeset/bound-passport-strategy-settlement.md` with a patch bump for `@fluojs/passport`.

## Testing

- `pnpm exec biome check packages/passport/src/adapters/passport-js.ts packages/passport/src/adapters/passport-js.test.ts packages/passport/src/cookie/cookie-auth-module.ts packages/passport/src/cookie/cookie-auth-module.integration.test.ts`
- `bun run .../check-no-excuse-rules.ts` on all changed TypeScript files
- `pnpm --filter @fluojs/passport test` — 10 files, 113 tests passed
- `pnpm --filter @fluojs/passport... build`
- `pnpm --filter @fluojs/passport typecheck`
- `pnpm docs:sync-check`
- `pnpm docs:typecheck`
- `pnpm docs:build`
- `pnpm verify:public-export-tsdoc`
- `pnpm verify:platform-consistency-governance`
- `pnpm vitest run tooling/governance/verify-platform-consistency-governance.test.ts` — 114 tests passed
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main`
- `pnpm verify:release-readiness`

TypeScript LSP diagnostics were unavailable because the configured server is not installed; Biome, package typecheck, builds, and release readiness supplied changed-file and compiler verification.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Patch impact: invalid Passport.js timeout configuration now fails closed instead of silently removing the settlement bound.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No export names or signatures changed. The public `actionTimeoutMs` option and `PassportJsAuthStrategy` failure contract now document the accepted range and `RangeError` behavior, and the `CookieAuthModule` source example matches the package docs.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated and were not silently removed.
- [x] Runtime invariants are covered by regression tests.

The bridge retains exactly-once settlement, keeps timeout cleanup on every terminal action, and preserves `actionTimeoutMs: 0`.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests, such as `createPlatformConformanceHarness(...)` for platform component contracts or `createHttpAdapterPortabilityHarness(...)` for HTTP adapter portability contracts.

No platform adapter contract changed. EN/KO package and website auth surfaces are synchronized, and the cookie-auth wiring claim is backed by a real application-context integration test.