### PR TITLE
Resolve #2811: Keep aborted fail-open transactions in shutdown drain

### DIFF
--- a/.changeset/drain-aborted-drizzle-fallbacks.md
+++ b/.changeset/drain-aborted-drizzle-fallbacks.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/drizzle': patch
+---
+
+Keep aborted fail-open request transaction callbacks in the shutdown drain until their direct execution settles, while continuing to reject the caller immediately on abort.

--- a/apps/docs/content/docs/guides/persistence.ko.mdx
+++ b/apps/docs/content/docs/guides/persistence.ko.mdx
@@ -123,10 +123,12 @@ export class AppModule {}
 Repository code는 `DrizzleDatabase.current()`를 사용하므로 active transaction handle을 자동으로 볼 수 있습니다.
 
 ```ts
+import { Inject } from '@fluojs/core';
 import { DrizzleDatabase } from '@fluojs/drizzle';
 import { eq } from 'drizzle-orm';
 import { users } from './schema';
 
+@Inject(DrizzleDatabase)
 export class UserRepository {
   constructor(private readonly db: DrizzleDatabase) {}
 

--- a/apps/docs/content/docs/guides/persistence.mdx
+++ b/apps/docs/content/docs/guides/persistence.mdx
@@ -123,10 +123,12 @@ export class AppModule {}
 Repository code uses `DrizzleDatabase.current()` so it automatically sees the active transaction handle.
 
 ```ts
+import { Inject } from '@fluojs/core';
 import { DrizzleDatabase } from '@fluojs/drizzle';
 import { eq } from 'drizzle-orm';
 import { users } from './schema';
 
+@Inject(DrizzleDatabase)
 export class UserRepository {
   constructor(private readonly db: DrizzleDatabase) {}
 

--- a/packages/drizzle/src/database.ts
+++ b/packages/drizzle/src/database.ts
@@ -402,17 +402,27 @@ export class DrizzleDatabase<
     this.assertRequestTransactionsAvailable();
 
     const abortContext = createRequestAbortContext(signal);
+
+    if (abortContext.signal.aborted) {
+      const abortError = createAbortError(abortContext.signal.reason);
+      abortContext.cleanup();
+      throw abortError;
+    }
+
     const active = this.trackActiveRequestTransaction(abortContext.controller);
+    const callback = new Promise<T>((resolve) => resolve(fn()));
+    const trackedCallback = callback.finally(() => {
+      this.untrackActiveRequestTransaction(active);
+    });
 
     try {
-      const result = await raceWithAbort(fn, abortContext.signal);
+      const result = await raceWithAbort(() => trackedCallback, abortContext.signal);
 
       this.throwIfRequestAborted(abortContext.signal);
 
       return result;
     } finally {
       abortContext.cleanup();
-      this.untrackActiveRequestTransaction(active);
     }
   }
 

--- a/packages/drizzle/src/database.ts
+++ b/packages/drizzle/src/database.ts
@@ -410,13 +410,15 @@ export class DrizzleDatabase<
     }
 
     const active = this.trackActiveRequestTransaction(abortContext.controller);
-    const callback = new Promise<T>((resolve) => resolve(fn()));
-    const trackedCallback = callback.finally(() => {
-      this.untrackActiveRequestTransaction(active);
-    });
 
     try {
-      const result = await raceWithAbort(() => trackedCallback, abortContext.signal);
+      const result = await raceWithAbort(() => {
+        const callback = new Promise<T>((resolve) => resolve(fn()));
+
+        return callback.finally(() => {
+          this.untrackActiveRequestTransaction(active);
+        });
+      }, abortContext.signal);
 
       this.throwIfRequestAborted(abortContext.signal);
 

--- a/packages/drizzle/src/module.test.ts
+++ b/packages/drizzle/src/module.test.ts
@@ -833,10 +833,11 @@ describe('@fluojs/drizzle', () => {
     }
   });
 
-  it('aborts unsupported requestTransaction fallback on shutdown before dispose', async () => {
+  it('keeps an aborted requestTransaction fallback in the shutdown drain until direct execution settles', async () => {
     const events: string[] = [];
     const database = {};
-    let requestRejected = false;
+    const controller = new AbortController();
+    const fallbackBarrier = createDeferred();
 
     const drizzleModule = DrizzleModule.forRoot<typeof database>({
       database,
@@ -856,20 +857,35 @@ describe('@fluojs/drizzle', () => {
     });
     const drizzle = await app.container.resolve(DrizzleDatabase<typeof database>);
 
+    // Given: fail-open direct execution that remains active after its caller is aborted.
     const openTransaction = drizzle.requestTransaction(async () => {
       events.push('request:start');
-      return new Promise<never>(() => undefined);
-    });
+      await fallbackBarrier.promise;
+      events.push('request:end');
+    }, controller.signal);
 
-    void openTransaction.catch(() => {
-      requestRejected = true;
-    });
+    let shutdownPromise: Promise<void> | undefined;
 
-    await app.close();
+    try {
+      // When: request cancellation rejects the caller before direct execution settles.
+      controller.abort(new Error('request aborted during fallback'));
 
-    await expect(openTransaction).rejects.toThrow('Application shutdown interrupted an open request transaction.');
-    expect(requestRejected).toBe(true);
-    expect(events).toEqual(['request:start', 'dispose']);
+      // Then: shutdown still drains the underlying callback before disposal.
+      await expect(openTransaction).rejects.toThrow('request aborted during fallback');
+      expect(drizzle.createPlatformStatusSnapshot().details.activeRequestTransactions).toBe(1);
+
+      shutdownPromise = app.close();
+      await Promise.resolve();
+      expect(events).toEqual(['request:start']);
+
+      fallbackBarrier.resolve();
+      await shutdownPromise;
+
+      expect(events).toEqual(['request:start', 'request:end', 'dispose']);
+    } finally {
+      fallbackBarrier.resolve();
+      await Promise.allSettled([openTransaction, shutdownPromise ?? app.close()]);
+    }
   });
 
   it('runs nested request and service transactions through a single transaction boundary', async () => {

--- a/packages/drizzle/src/module.test.ts
+++ b/packages/drizzle/src/module.test.ts
@@ -888,6 +888,54 @@ describe('@fluojs/drizzle', () => {
     }
   });
 
+  it('observes a late fallback rejection after synchronous self-abort while shutdown drains', async () => {
+    const events: string[] = [];
+    const unhandledRejections: unknown[] = [];
+    const database = {};
+    const controller = new AbortController();
+    const fallbackBarrier = createDeferred();
+    const callbackError = new Error('late fallback rejection');
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandledRejections.push(reason);
+    };
+    const drizzle = new DrizzleDatabase<typeof database>(database, () => {
+      events.push('dispose');
+    });
+    process.on('unhandledRejection', onUnhandledRejection);
+
+    // Given: the fail-open callback aborts its own request synchronously, then remains pending.
+    const openTransaction = drizzle.requestTransaction(async () => {
+      events.push('request:start');
+      controller.abort(new Error('request aborted synchronously during fallback'));
+      await fallbackBarrier.promise;
+    }, controller.signal);
+
+    let shutdownPromise: Promise<void> | undefined;
+
+    try {
+      // When: the caller observes cancellation and shutdown starts before the callback rejects.
+      await expect(openTransaction).rejects.toThrow('request aborted synchronously during fallback');
+      expect(drizzle.createPlatformStatusSnapshot().details.activeRequestTransactions).toBe(1);
+
+      shutdownPromise = drizzle.onApplicationShutdown();
+      await Promise.resolve();
+      expect(events).toEqual(['request:start']);
+
+      fallbackBarrier.reject(callbackError);
+      await shutdownPromise;
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      // Then: disposal waits for callback settlement and its rejection remains observed.
+      expect(events).toEqual(['request:start', 'dispose']);
+      expect(unhandledRejections).toEqual([]);
+    } finally {
+      fallbackBarrier.reject(callbackError);
+      await Promise.allSettled([openTransaction, shutdownPromise ?? drizzle.onApplicationShutdown()]);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      process.off('unhandledRejection', onUnhandledRejection);
+    }
+  });
+
   it('runs nested request and service transactions through a single transaction boundary', async () => {
     let transactionCalls = 0;
     const transactionDatabase = {


### PR DESCRIPTION
## Summary

Restore the documented Drizzle fail-open shutdown ordering when a request abort rejects its caller before the direct callback settles.

Linked context: https://github.com/fluojs/fluo/issues/2811

Closes #2811

## Changes

- Keep the underlying fail-open `requestTransaction(...)` callback tracked until direct execution settles while preserving immediate abort rejection for the caller.
- Add a regression that proves shutdown does not run `dispose(database)` before the aborted callback settles.
- Add explicit `@Inject(DrizzleDatabase)` decoration to the bilingual website persistence example.
- Add a patch Changeset for `@fluojs/drizzle`.

## Testing

- [x] `pnpm --filter @fluojs/drizzle test -- module.test.ts` (54 tests passed)
- [x] `pnpm --filter @fluojs/drizzle... build`
- [x] `pnpm --filter @fluojs/drizzle typecheck`
- [x] `pnpm exec biome check packages/drizzle/src/database.ts packages/drizzle/src/module.test.ts apps/docs/content/docs/guides/persistence.mdx apps/docs/content/docs/guides/persistence.ko.mdx`
- [x] `pnpm docs:sync-check`
- [x] `pnpm docs:typecheck`
- [x] `pnpm docs:build`
- [x] `pnpm verify:platform-consistency-governance`
- [x] `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main`
- [x] `pnpm verify:release-readiness`

## Release impact

- [x] This PR has consumer-visible release impact and includes `.changeset/drain-aborted-drizzle-fallbacks.md`.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] No public exports or signatures changed; source TSDoc updates are not applicable.
- [x] Existing package README, transaction architecture docs, and Drizzle book guidance were checked and already describe the intended drain contract.

## Behavioral contract

- [x] Fail-open request cancellation still rejects the caller immediately.
- [x] The underlying direct callback remains in shutdown tracking until settlement, so disposal cannot overtake it.
- [x] Runtime invariants are covered by the updated regression test.
- [x] No documented behavioral contract or intentional limitation was removed.

## Platform consistency governance (SSOT)

- [x] The website persistence example is synchronized across English and Korean.
- [x] No platform adapter contract changed.
- [x] Platform consistency governance and release-readiness checks passed.