### PR TITLE
Resolve #2793: Hydrate nested DTOs for existing root instances

### DIFF
--- a/.changeset/hydrate-existing-validation-dtos.md
+++ b/.changeset/hydrate-existing-validation-dtos.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/validation': patch
+---
+
+Hydrate plain nested DTO fields and collection members when materializing existing DTO instances while preserving root and nested DTO identities.

--- a/packages/validation/src/internal/dto-materialization.ts
+++ b/packages/validation/src/internal/dto-materialization.ts
@@ -1,0 +1,126 @@
+import type { Constructor } from '@fluojs/core';
+
+import { DtoValidationError } from '../errors.js';
+import type { ValidationIssue } from '../types.js';
+import { getCachedDtoMetadata } from './dto-metadata-cache.js';
+import { assignSafeOwnEnumerableProperties, isPlainObject } from './object-utils.js';
+
+export interface NestedTraversalContext {
+  readonly active: WeakSet<object>;
+  readonly hydrateExistingInstances?: boolean;
+}
+
+export function enterTraversal(value: unknown, context?: NestedTraversalContext): boolean {
+  if (!context || typeof value !== 'object' || value === null) {
+    return true;
+  }
+
+  if (context.active.has(value)) {
+    return false;
+  }
+
+  context.active.add(value);
+  return true;
+}
+
+export function exitTraversal(value: unknown, context?: NestedTraversalContext): void {
+  if (!context || typeof value !== 'object' || value === null) {
+    return;
+  }
+
+  context.active.delete(value);
+}
+
+export function createNestedDtoInstance<T>(
+  target: Constructor<T>,
+  rawValue: unknown,
+  context?: NestedTraversalContext,
+): T {
+  if (rawValue instanceof target && context?.hydrateExistingInstances !== true) {
+    return rawValue as T;
+  }
+
+  if (!(rawValue instanceof target) && !isPlainObject(rawValue)) {
+    return rawValue as T;
+  }
+
+  const instance = (rawValue instanceof target ? rawValue : new target()) as Record<PropertyKey, unknown>;
+
+  if (!enterTraversal(rawValue, context)) {
+    return rawValue as T;
+  }
+
+  try {
+    const metadata = getCachedDtoMetadata(target);
+
+    if (isPlainObject(rawValue)) {
+      assignSafeOwnEnumerableProperties(instance, rawValue);
+
+      for (const propertyKey of metadata.mergedPropertyKeys) {
+        const sourceKey = metadata.bindingMap.get(propertyKey)?.key;
+        if (!sourceKey) continue;
+        instance[propertyKey] = rawValue[sourceKey];
+      }
+    }
+
+    for (const nestedEntry of metadata.nestedDtoTransforms) {
+      const currentValue = instance[nestedEntry.propertyKey];
+      if (currentValue === undefined || currentValue === null) {
+        continue;
+      }
+
+      instance[nestedEntry.propertyKey] = transformNestedCollectionValue(currentValue, nestedEntry.target, context);
+    }
+
+    return instance as T;
+  } finally {
+    exitTraversal(rawValue, context);
+  }
+}
+
+function transformNestedValue(value: unknown, target: Constructor, context?: NestedTraversalContext): unknown {
+  if (value === undefined || value === null) {
+    return value;
+  }
+
+  if (value instanceof target && context?.hydrateExistingInstances !== true) {
+    return value;
+  }
+
+  if (!(value instanceof target) && !isPlainObject(value)) {
+    return value;
+  }
+
+  return createNestedDtoInstance(target, value, context);
+}
+
+function transformNestedCollectionValue(value: unknown, target: Constructor, context?: NestedTraversalContext): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => transformNestedValue(item, target, context));
+  }
+
+  if (value instanceof Set) {
+    return new Set(Array.from(value.values(), (item) => transformNestedValue(item, target, context)));
+  }
+
+  if (value instanceof Map) {
+    return new Map(Array.from(value.entries(), ([key, item]) => [key, transformNestedValue(item, target, context)]));
+  }
+
+  return transformNestedValue(value, target, context);
+}
+
+function buildInvalidRootIssue(): ValidationIssue {
+  return {
+    code: 'INVALID_DTO',
+    message: 'DTO root value must be a plain object.',
+  };
+}
+
+export function assertValidRootValue(value: unknown, target: Constructor): void {
+  if (value instanceof target || isPlainObject(value)) {
+    return;
+  }
+
+  throw new DtoValidationError('Validation failed.', [buildInvalidRootIssue()]);
+}

--- a/packages/validation/src/internal/validation-issues.ts
+++ b/packages/validation/src/internal/validation-issues.ts
@@ -1,0 +1,63 @@
+import type { ValidationIssueMetadata, ValidationRuleResult } from '@fluojs/core/request-pipeline';
+
+import type { ValidationIssue } from '../types.js';
+
+function normalizeIssue(
+  issue: ValidationIssueMetadata,
+  field: string | undefined,
+  source: ValidationIssue['source'],
+): ValidationIssue {
+  return {
+    code: issue.code,
+    field: issue.field ?? field,
+    message: issue.message,
+    source: issue.source ?? source,
+  };
+}
+
+export function normalizeResult(
+  result: ValidationRuleResult,
+  field: string | undefined,
+  source: ValidationIssue['source'],
+  fallback: { readonly code: string; readonly message: string },
+): ValidationIssue[] {
+  if (result === undefined || result === true) {
+    return [];
+  }
+
+  if (result === false) {
+    return [{ code: fallback.code, field, message: fallback.message, source }];
+  }
+
+  if (Array.isArray(result)) {
+    return result.map((issue) => normalizeIssue(issue, field, source));
+  }
+
+  return [normalizeIssue(result as ValidationIssueMetadata, field, source)];
+}
+
+export function joinFieldPath(parent: string, child?: string): string {
+  if (!child) return parent;
+  return child.startsWith('[') ? `${parent}${child}` : `${parent}.${child}`;
+}
+
+export function prefixIssues(
+  issues: readonly ValidationIssue[],
+  fieldPrefix: string,
+  source: ValidationIssue['source'],
+): ValidationIssue[] {
+  return issues.map((issue) => ({ ...issue, field: joinFieldPath(fieldPrefix, issue.field), source: issue.source ?? source }));
+}
+
+export function buildIssue(
+  fallback: { readonly code: string; readonly message: string },
+  field: string,
+  source: ValidationIssue['source'],
+): ValidationIssue {
+  return {
+    code: fallback.code,
+    field,
+    message: fallback.message,
+    source,
+  };
+}

--- a/packages/validation/src/materialize-existing-instances.test.ts
+++ b/packages/validation/src/materialize-existing-instances.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+
+import { MinLength, ValidateNested } from './decorators.js';
+import { DefaultValidator } from './validation.js';
+
+class AddressDto {
+  @MinLength(1)
+  city = '';
+}
+
+class ExistingOrderDto {
+  @ValidateNested(() => AddressDto)
+  address: AddressDto | { city: string } = new AddressDto();
+}
+
+class CountryDto {
+  @MinLength(2)
+  code = '';
+}
+
+class ExistingAddressDto {
+  @ValidateNested(() => CountryDto)
+  country: CountryDto | { code: string } = new CountryDto();
+}
+
+class ExistingCustomerDto {
+  @ValidateNested(() => ExistingAddressDto)
+  address = new ExistingAddressDto();
+}
+
+class ExistingCollectionDto {
+  @ValidateNested(() => AddressDto)
+  addressArray: Array<AddressDto | { city: string }> = [];
+
+  @ValidateNested(() => AddressDto)
+  addressSet = new Set<AddressDto | { city: string }>();
+
+  @ValidateNested(() => AddressDto)
+  addressMap = new Map<string, AddressDto | { city: string }>();
+}
+
+describe('DefaultValidator existing-instance contract', () => {
+  it('hydrates a plain nested DTO while preserving the existing root identity', async () => {
+    // Given
+    const input = Object.assign(new ExistingOrderDto(), { address: { city: 'Seoul' } });
+    const validator = new DefaultValidator();
+
+    // When
+    const result = await validator.materialize<ExistingOrderDto>(input, ExistingOrderDto);
+
+    // Then
+    expect(result).toBe(input);
+    expect(result.address).toBeInstanceOf(AddressDto);
+    expect(result.address.city).toBe('Seoul');
+  });
+
+  it('hydrates descendants while preserving an existing nested DTO identity', async () => {
+    // Given
+    const existingAddress = Object.assign(new ExistingAddressDto(), { country: { code: 'KR' } });
+    const input = Object.assign(new ExistingCustomerDto(), { address: existingAddress });
+    const validator = new DefaultValidator();
+
+    // When
+    const result = await validator.materialize<ExistingCustomerDto>(input, ExistingCustomerDto);
+
+    // Then
+    expect(result.address).toBe(existingAddress);
+    expect(result.address.country).toBeInstanceOf(CountryDto);
+  });
+
+  it('does not replace plain descendants during validation-only checks', async () => {
+    // Given
+    const country = { code: 'KR' };
+    const existingAddress = Object.assign(new ExistingAddressDto(), { country });
+    const input = Object.assign(new ExistingCustomerDto(), { address: existingAddress });
+    const validator = new DefaultValidator();
+
+    // When
+    await validator.validate(input, ExistingCustomerDto);
+
+    // Then
+    expect(existingAddress.country).toBe(country);
+    expect(existingAddress.country).not.toBeInstanceOf(CountryDto);
+  });
+
+  it('hydrates plain array members on an existing root instance', async () => {
+    // Given
+    const input = Object.assign(new ExistingCollectionDto(), { addressArray: [{ city: 'Seoul' }] });
+    const validator = new DefaultValidator();
+
+    // When
+    const result = await validator.materialize<ExistingCollectionDto>(input, ExistingCollectionDto);
+
+    // Then
+    expect(result.addressArray[0]).toBeInstanceOf(AddressDto);
+  });
+
+  it('hydrates plain Set members on an existing root instance', async () => {
+    // Given
+    const input = Object.assign(new ExistingCollectionDto(), { addressSet: new Set([{ city: 'Seoul' }]) });
+    const validator = new DefaultValidator();
+
+    // When
+    const result = await validator.materialize<ExistingCollectionDto>(input, ExistingCollectionDto);
+
+    // Then
+    expect(Array.from(result.addressSet)[0]).toBeInstanceOf(AddressDto);
+  });
+
+  it('hydrates plain Map members on an existing root instance', async () => {
+    // Given
+    const input = Object.assign(new ExistingCollectionDto(), { addressMap: new Map([['home', { city: 'Seoul' }]]) });
+    const validator = new DefaultValidator();
+
+    // When
+    const result = await validator.materialize<ExistingCollectionDto>(input, ExistingCollectionDto);
+
+    // Then
+    expect(result.addressMap.get('home')).toBeInstanceOf(AddressDto);
+  });
+});

--- a/packages/validation/src/validation.ts
+++ b/packages/validation/src/validation.ts
@@ -2,11 +2,18 @@ import type {
   Constructor,
   MetadataPropertyKey,
 } from '@fluojs/core';
-import type { ClassValidationRule, DtoFieldBindingMetadata, DtoFieldValidationRule } from '@fluojs/core/request-pipeline';
+import type { ClassValidationRule, DtoFieldValidationRule } from '@fluojs/core/request-pipeline';
 
 import { DtoValidationError } from './errors.js';
+import {
+  assertValidRootValue,
+  createNestedDtoInstance,
+  enterTraversal,
+  exitTraversal,
+  type NestedTraversalContext,
+} from './internal/dto-materialization.js';
 import { getCachedDtoMetadata, resolveNestedDto } from './internal/dto-metadata-cache.js';
-import { assignSafeOwnEnumerableProperties, getIterableValues, isPlainObject } from './internal/object-utils.js';
+import { getIterableValues, isPlainObject } from './internal/object-utils.js';
 import { getRuleHandler, type NonCustomRule } from './internal/rule-handlers.js';
 import { buildIssue, joinFieldPath, normalizeResult, prefixIssues } from './internal/validation-issues.js';
 import type { ValidationIssue, Validator } from './types.js';
@@ -15,115 +22,9 @@ function toFieldName(propertyKey: MetadataPropertyKey): string {
   return typeof propertyKey === 'string' ? propertyKey : String(propertyKey);
 }
 
-interface NestedTraversalContext {
-  readonly active: WeakSet<object>;
-}
-
 interface ValidationContext {
   readonly fieldPrefix?: string;
   readonly inheritedSource?: ValidationIssue['source'];
-}
-
-function enterTraversal(value: unknown, context?: NestedTraversalContext): boolean {
-  if (!context || typeof value !== 'object' || value === null) {
-    return true;
-  }
-
-  if (context.active.has(value)) {
-    return false;
-  }
-
-  context.active.add(value);
-  return true;
-}
-
-function exitTraversal(value: unknown, context?: NestedTraversalContext): void {
-  if (!context || typeof value !== 'object' || value === null) {
-    return;
-  }
-
-  context.active.delete(value);
-}
-
-function createNestedDtoInstance<T>(target: Constructor<T>, rawValue: unknown, context?: NestedTraversalContext): T {
-  if (rawValue instanceof target) {
-    return rawValue as T;
-  }
-
-  if (!isPlainObject(rawValue)) {
-    return rawValue as T;
-  }
-
-  const instance = new target() as Record<PropertyKey, unknown>;
-
-  if (!enterTraversal(rawValue, context)) {
-    return rawValue as T;
-  }
-
-  try {
-    assignSafeOwnEnumerableProperties(instance, rawValue);
-
-    const metadata = getCachedDtoMetadata(target);
-    applyBindingValues(instance, rawValue, metadata.mergedPropertyKeys, metadata.bindingMap);
-
-    for (const nestedEntry of metadata.nestedDtoTransforms) {
-      const currentValue = instance[nestedEntry.propertyKey];
-      if (currentValue === undefined || currentValue === null) {
-        continue;
-      }
-
-      instance[nestedEntry.propertyKey] = transformNestedCollectionValue(currentValue, nestedEntry.target, context);
-    }
-
-    return instance as T;
-  } finally {
-    exitTraversal(rawValue, context);
-  }
-}
-
-function materializeNestedDtoValue<T>(target: Constructor<T>, rawValue: unknown, context?: NestedTraversalContext): unknown {
-  if (rawValue instanceof target) {
-    return rawValue;
-  }
-
-  if (!isPlainObject(rawValue)) {
-    return rawValue;
-  }
-
-  return createNestedDtoInstance(target, rawValue, context);
-}
-
-function applyBindingValues(
-  instance: Record<PropertyKey, unknown>,
-  rawValue: Record<PropertyKey, unknown>,
-  keys: Set<MetadataPropertyKey>,
-  bindingMap: Map<MetadataPropertyKey, DtoFieldBindingMetadata>,
-): void {
-  for (const propertyKey of keys) {
-    const sourceKey = bindingMap.get(propertyKey)?.key;
-    if (!sourceKey) continue;
-    instance[propertyKey] = rawValue[sourceKey];
-  }
-}
-
-function transformNestedValue(value: unknown, target: Constructor, context?: NestedTraversalContext): unknown {
-  return value === undefined || value === null ? value : materializeNestedDtoValue(target, value, context);
-}
-
-function transformNestedCollectionValue(value: unknown, target: Constructor, context?: NestedTraversalContext): unknown {
-  if (Array.isArray(value)) {
-    return value.map((item) => transformNestedValue(item, target, context));
-  }
-
-  if (value instanceof Set) {
-    return new Set(Array.from(value.values(), (item) => transformNestedValue(item, target, context)));
-  }
-
-  if (value instanceof Map) {
-    return new Map(Array.from(value.entries(), ([key, item]) => [key, transformNestedValue(item, target, context)]));
-  }
-
-  return transformNestedValue(value, target, context);
 }
 
 function describeValidator(rule: DtoFieldValidationRule, field: string): { code: string; message: string } {
@@ -133,21 +34,6 @@ function describeValidator(rule: DtoFieldValidationRule, field: string): { code:
     code: rule.code ?? (rule.kind === 'validatorjs' ? rule.validator.toUpperCase() : handler.defaultCode),
     message: rule.message ?? handler.describe(field, rule),
   };
-}
-
-function buildInvalidRootIssue(): ValidationIssue {
-  return {
-    code: 'INVALID_DTO',
-    message: 'DTO root value must be a plain object.',
-  };
-}
-
-function assertValidRootValue(value: unknown, target: Constructor): void {
-  if (value instanceof target || isPlainObject(value)) {
-    return;
-  }
-
-  throw new DtoValidationError('Validation failed.', [buildInvalidRootIssue()]);
 }
 
 function getRuleValues(value: unknown): unknown[] {
@@ -384,7 +270,10 @@ export class DefaultValidator implements Validator {
   async materialize<T>(value: unknown, target: Constructor<T>): Promise<T> {
     assertValidRootValue(value, target);
 
-    const instance = createNestedDtoInstance(target, value, { active: new WeakSet<object>() });
+    const instance = createNestedDtoInstance(target, value, {
+      active: new WeakSet<object>(),
+      hydrateExistingInstances: true,
+    });
     const issues = await collectValidationIssues(target, instance);
 
     if (issues.length > 0) {

--- a/packages/validation/src/validation.ts
+++ b/packages/validation/src/validation.ts
@@ -2,63 +2,17 @@ import type {
   Constructor,
   MetadataPropertyKey,
 } from '@fluojs/core';
-import type { ClassValidationRule, DtoFieldBindingMetadata, DtoFieldValidationRule, ValidationIssueMetadata, ValidationRuleResult } from '@fluojs/core/request-pipeline';
+import type { ClassValidationRule, DtoFieldBindingMetadata, DtoFieldValidationRule } from '@fluojs/core/request-pipeline';
 
 import { DtoValidationError } from './errors.js';
 import { getCachedDtoMetadata, resolveNestedDto } from './internal/dto-metadata-cache.js';
 import { assignSafeOwnEnumerableProperties, getIterableValues, isPlainObject } from './internal/object-utils.js';
 import { getRuleHandler, type NonCustomRule } from './internal/rule-handlers.js';
+import { buildIssue, joinFieldPath, normalizeResult, prefixIssues } from './internal/validation-issues.js';
 import type { ValidationIssue, Validator } from './types.js';
 
 function toFieldName(propertyKey: MetadataPropertyKey): string {
   return typeof propertyKey === 'string' ? propertyKey : String(propertyKey);
-}
-
-function normalizeIssue(
-  issue: ValidationIssueMetadata,
-  field: string | undefined,
-  source: ValidationIssue['source'],
-): ValidationIssue {
-  return {
-    code: issue.code,
-    field: issue.field ?? field,
-    message: issue.message,
-    source: issue.source ?? source,
-  };
-}
-
-function normalizeResult(
-  result: ValidationRuleResult,
-  field: string | undefined,
-  source: ValidationIssue['source'],
-  fallback: { code: string; message: string },
-): ValidationIssue[] {
-  if (result === undefined || result === true) {
-    return [];
-  }
-
-  if (result === false) {
-    return [{ code: fallback.code, field, message: fallback.message, source }];
-  }
-
-  if (Array.isArray(result)) {
-    return result.map((issue) => normalizeIssue(issue, field, source));
-  }
-
-  return [normalizeIssue(result as ValidationIssueMetadata, field, source)];
-}
-
-function joinFieldPath(parent: string, child?: string): string {
-  if (!child) return parent;
-  return child.startsWith('[') ? `${parent}${child}` : `${parent}.${child}`;
-}
-
-function prefixIssues(
-  issues: readonly ValidationIssue[],
-  fieldPrefix: string,
-  source: ValidationIssue['source'],
-): ValidationIssue[] {
-  return issues.map((issue) => ({ ...issue, field: joinFieldPath(fieldPrefix, issue.field), source: issue.source ?? source }));
 }
 
 interface NestedTraversalContext {
@@ -178,15 +132,6 @@ function describeValidator(rule: DtoFieldValidationRule, field: string): { code:
   return {
     code: rule.code ?? (rule.kind === 'validatorjs' ? rule.validator.toUpperCase() : handler.defaultCode),
     message: rule.message ?? handler.describe(field, rule),
-  };
-}
-
-function buildIssue(fallback: { code: string; message: string }, field: string, source: ValidationIssue['source']): ValidationIssue {
-  return {
-    code: fallback.code,
-    field,
-    message: fallback.message,
-    source,
   };
 }
 


### PR DESCRIPTION
## Summary

Restore recursive `DefaultValidator.materialize()` hydration when the root value is already an instance of the target DTO.

Linked context: Closes #2793

## Changes

- Preserve existing root and nested DTO identities while hydrating plain nested DTO fields.
- Hydrate plain array, `Set`, and `Map` members on existing DTO graphs.
- Keep `validate()` validation-only checks non-mutating for plain nested values.
- Extract DTO materialization and validation issue construction into focused internal modules.
- Add failing-first regressions and a patch Changesets entry for `@fluojs/validation`.

## Testing

- `pnpm exec biome check packages/validation/src/validation.ts packages/validation/src/internal/dto-materialization.ts packages/validation/src/internal/validation-issues.ts packages/validation/src/materialize-existing-instances.test.ts`
- `pnpm vitest run packages/validation/src/materialize-existing-instances.test.ts --project packages` — 6 passed
- `pnpm --filter @fluojs/validation test` — 79 passed
- `pnpm --filter @fluojs/validation typecheck`
- `pnpm --filter @fluojs/validation build`
- `pnpm verify:platform-consistency-governance`
- `pnpm verify:changeset-release-lane`
- `FLUO_CLI_SANDBOX_ROOT=<isolated-temp-path> pnpm verify:release-readiness` — passed, including 299 package test files / 3998 passed and all starter sandbox scenarios

The first release-readiness attempt collided with two concurrent worktrees using the shared default CLI sandbox. Re-running the same canonical gate with an isolated external sandbox passed without writing draft artifacts.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Patch intent: restore the documented `@fluojs/validation` hydration contract.

## Public export documentation

- [x] No public exports changed; source-level public export TSDoc is not applicable.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable. No exported function signatures changed.
- [x] Source `@example` blocks and README scenario examples still play complementary roles. Existing README behavior text already describes recursive hydration and identity preservation.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README. No new contract was introduced; this restores the existing documented contract.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

`materialize()` now fulfills the existing recursive hydration promise for existing root instances, while `validate()` continues to avoid replacing caller-owned nested values.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. No governance docs changed.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. Not applicable: no platform contract docs changed.
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests. Not applicable: this is package-local validation behavior, covered by package regression tests and the release-readiness gate.