### PR TITLE
Resolve #2804: Make Bun Socket.IO initialization single-flight and retry-safe

### DIFF
--- a/.changeset/retry-bun-socket-io-initialization.md
+++ b/.changeset/retry-bun-socket-io-initialization.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/socket.io': patch
+---
+
+Serialize Bun Socket.IO server initialization, publish the server only after realtime binding succeeds, and clean partial resources so failed initialization can be retried safely.

--- a/book/intermediate/ch14-socketio.ko.md
+++ b/book/intermediate/ch14-socketio.ko.md
@@ -55,7 +55,7 @@ import { SocketIoModule } from '@fluojs/socket.io';
 export class ChatModule {}
 ```
 
-기본적으로 fluo는 CORS를 deny-by-default, 즉 `origin: false` 상태로 유지합니다. Cross-origin 브라우저 클라이언트를 허용하려면 허용된 origin 목록을 명시적으로 작성해야 합니다. `engine` 설정은 Engine.IO에 직접 매핑되며, production 안정성을 위해 payload size를 제한할 수 있게 합니다. Bun에서는 adapter가 같은 `engine.maxHttpBufferSize` 값을 HTTP request body limit와 WebSocket payload limit 양쪽에 매핑합니다. Bun은 이 두 host contract를 별도로 노출하기 때문입니다. 이런 기본값은 실시간 연결이 브라우저에서 오래 유지되는 특성을 고려한 안전한 출발점입니다.
+기본적으로 fluo는 CORS를 deny-by-default, 즉 `origin: false` 상태로 유지합니다. Cross-origin 브라우저 클라이언트를 허용하려면 허용된 origin 목록을 명시적으로 작성해야 합니다. `engine` 설정은 Engine.IO에 직접 매핑되며, production 안정성을 위해 payload size를 제한할 수 있게 합니다. Bun에서는 adapter가 같은 `engine.maxHttpBufferSize` 값을 HTTP request body limit와 WebSocket payload limit 양쪽에 매핑합니다. Bun은 이 두 host contract를 별도로 노출하기 때문입니다. 별도로 `buffer.maxPendingMessagesPerSocket`과 `buffer.overflowPolicy`는 socket 연결 후 connection handler가 준비되기 전에 수신한 inbound event를 제한하며, outbound emit이나 Socket.IO reconnect buffering을 제어하지 않습니다. 이런 기본값은 실시간 연결이 브라우저에서 오래 유지되는 특성을 고려한 안전한 출발점입니다.
 
 ## 14.3 Room management with SocketIoRoomService
 
@@ -122,7 +122,7 @@ SocketIoModule.forRoot({
 })
 ```
 
-Guard는 `true`, `undefined`, 또는 아무 값을 반환하지 않을 때 허용합니다. `false` 또는 `{ message: '권한이 없는 명령어입니다.' }` 같은 rejection object를 반환할 때만 연결이나 메시지가 표준화된 Socket.IO error 객체와 함께 거부됩니다. 클라이언트는 실패 원인을 일관된 방식으로 처리할 수 있고, 서버는 권한 없는 실시간 동작을 handler 실행 전에 차단할 수 있습니다. 정책을 감사하기 쉽게 만들고 싶다면 애플리케이션 코드에서는 명시적인 `true`/`false`/rejection 반환을 선호하되, `void` guard를 rejection으로 취급하지 마세요.
+Guard는 `true`, `undefined`, 또는 아무 값을 반환하지 않을 때 허용합니다. `false` 또는 `{ message: '권한이 없는 명령어입니다.' }` 같은 rejection object를 반환할 때만 거부합니다. Connection rejection은 Socket.IO namespace connection error 경로를 따릅니다. Message rejection은 해당 event에 acknowledgement callback이 제공된 경우에만 `{ error, data }` 형태로 client에 전달되며, ACK callback이 없으면 fluo는 암묵적인 client error event를 emit하지 않습니다. `disconnect: true`인 rejection은 그대로 socket 연결을 종료합니다. 따라서 server는 별도의 message-error channel을 만들지 않고도 권한 없는 실시간 동작을 handler 실행 전에 차단합니다. 정책을 감사하기 쉽게 만들고 싶다면 애플리케이션 코드에서는 명시적인 `true`/`false`/rejection 반환을 선호하되, `void` guard를 rejection으로 취급하지 마세요.
 
 ## 14.5 Accessing the raw server
 

--- a/book/intermediate/ch14-socketio.md
+++ b/book/intermediate/ch14-socketio.md
@@ -55,7 +55,7 @@ import { SocketIoModule } from '@fluojs/socket.io';
 export class ChatModule {}
 ```
 
-By default, fluo keeps CORS deny by default, meaning `origin: false`. To allow cross origin browser clients, you must explicitly write the allowed origin list. The `engine` configuration maps directly to Engine.IO, letting you limit payload size for production stability. On Bun, the adapter maps the same `engine.maxHttpBufferSize` value into both the HTTP request body limit and the WebSocket payload limit because Bun exposes those host contracts separately. These defaults are a safer starting point because realtime browser connections often stay open for a long time.
+By default, fluo keeps CORS deny by default, meaning `origin: false`. To allow cross origin browser clients, you must explicitly write the allowed origin list. The `engine` configuration maps directly to Engine.IO, letting you limit payload size for production stability. On Bun, the adapter maps the same `engine.maxHttpBufferSize` value into both the HTTP request body limit and the WebSocket payload limit because Bun exposes those host contracts separately. Separately, `buffer.maxPendingMessagesPerSocket` and `buffer.overflowPolicy` bound inbound events received after a socket connects but before its connection handlers become ready; they do not control outbound emits or Socket.IO reconnect buffering. These defaults are a safer starting point because realtime browser connections often stay open for a long time.
 
 ## 14.3 Room management with SocketIoRoomService
 
@@ -122,7 +122,7 @@ SocketIoModule.forRoot({
 })
 ```
 
-Guards accept when they return `true`, `undefined`, or no value. They reject only when they return `false` or a rejection object such as `{ message: 'Unauthorized command.' }`; the connection or message is then rejected with a standardized Socket.IO error object. Clients can handle failures consistently, and the server can block unauthorized realtime work before a handler runs. Prefer explicit `true`/`false`/rejection returns in application code when that makes the policy easier to audit, but do not treat a `void` guard as rejection.
+Guards accept when they return `true`, `undefined`, or no value. They reject only when they return `false` or a rejection object such as `{ message: 'Unauthorized command.' }`. Connection rejection follows Socket.IO's namespace connection error path. Message rejection reaches the client only through an acknowledgement callback supplied with that event, using `{ error, data }`; without an ACK callback, fluo emits no implicit client error event. A rejection with `disconnect: true` still closes the socket. The server therefore blocks unauthorized realtime work before a handler runs without inventing a second message-error channel. Prefer explicit `true`/`false`/rejection returns in application code when that makes the policy easier to audit, but do not treat a `void` guard as rejection.
 
 ## 14.5 Accessing the raw server
 

--- a/packages/socket.io/README.ko.md
+++ b/packages/socket.io/README.ko.md
@@ -135,7 +135,7 @@ SocketIoModule.forRoot({
 });
 ```
 
-`cors`를 생략하면 `@fluojs/socket.io`는 `{ credentials: false, origin: false }`를 기본값으로 사용하므로 cross-origin 노출은 명시적 opt-in이 필요합니다. `engine.maxHttpBufferSize`를 생략하면 어댑터가 1 MiB Engine.IO payload 상한을 적용합니다. 기본값에는 `buffer.maxPendingMessagesPerSocket: 128`, `buffer.overflowPolicy: 'drop-oldest'`, `shutdown.timeoutMs: 5000`도 포함됩니다. 명시적인 `engine.maxHttpBufferSize`, `buffer.maxPendingMessagesPerSocket`, `shutdown.timeoutMs` 값은 양의 정수여야 하며, 잘못된 명시 값은 기본값으로 fallback하지 않고 모듈 등록 중 실패합니다.
+`cors`를 생략하면 `@fluojs/socket.io`는 `{ credentials: false, origin: false }`를 기본값으로 사용하므로 cross-origin 노출은 명시적 opt-in이 필요합니다. `engine.maxHttpBufferSize`를 생략하면 어댑터가 1 MiB Engine.IO payload 상한을 적용합니다. 기본값에는 `buffer.maxPendingMessagesPerSocket: 128`, `buffer.overflowPolicy: 'drop-oldest'`, `shutdown.timeoutMs: 5000`도 포함됩니다. `buffer` 옵션은 socket 연결 후 connection handler가 준비되기 전에 들어온 inbound event를 제한하며, outbound emit이나 Socket.IO reconnect buffering을 제어하지 않습니다. 명시적인 `engine.maxHttpBufferSize`, `buffer.maxPendingMessagesPerSocket`, `shutdown.timeoutMs` 값은 양의 정수여야 하며, 잘못된 명시 값은 기본값으로 fallback하지 않고 모듈 등록 중 실패합니다.
 
 정적 `@WebSocketGateway({ path })` namespace는 fluo gateway discovery가 소유하며 Socket.IO dynamic child namespace로 취급하지 않습니다. 어댑터는 이러한 정적 namespace에 대해 Socket.IO의 `cleanupEmptyChildNamespaces` 동작을 비활성화합니다. 애플리케이션 코드가 raw `SOCKETIO_SERVER` 접근으로 dynamic child namespace를 만들면 해당 소유권과 cleanup 정책은 애플리케이션 수준 Socket.IO 통합이 담당합니다.
 
@@ -143,7 +143,7 @@ SocketIoModule.forRoot({
 
 ### Guard 계약
 
-`auth.connection`은 namespace connect handler가 실행되기 전에 `SocketIoConnectionGuardContext`를 받습니다. `auth.message`는 message handler가 실행되기 전에 `SocketIoMessageGuardContext`를 받습니다. Guard는 `true`, `undefined`, 또는 아무 값도 반환하지 않으면 허용합니다. `false` 또는 `message`, optional `data`, optional `disconnect`를 가진 `SocketIoGuardRejection`을 반환하면 거부하며, message rejection은 `{ error, data }` 형태의 ACK payload를 사용합니다. Root export의 `SocketIoHandshakeRequest`는 런타임 중립으로 유지됩니다. Node-backed adapter는 구조적으로 typed HTTP handshake request를 제공하고 Bun은 Web-standard `Request`를 제공합니다.
+`auth.connection`은 namespace connect handler가 실행되기 전에 `SocketIoConnectionGuardContext`를 받습니다. `auth.message`는 message handler가 실행되기 전에 `SocketIoMessageGuardContext`를 받습니다. Guard는 `true`, `undefined`, 또는 아무 값도 반환하지 않으면 허용합니다. `false` 또는 `message`, optional `data`, optional `disconnect`를 가진 `SocketIoGuardRejection`을 반환하면 거부합니다. Connection rejection은 Socket.IO namespace connection error 경로를 사용합니다. Message rejection은 해당 event에 acknowledgement callback이 제공된 경우에만 `{ error, data }` 형태의 ACK payload로 전달되며, ACK callback이 없으면 fluo는 암묵적인 client error event를 emit하지 않습니다. 명시적인 `disconnect: true`는 그대로 socket 연결을 종료합니다. Root export의 `SocketIoHandshakeRequest`는 런타임 중립으로 유지됩니다. Node-backed adapter는 구조적으로 typed HTTP handshake request를 제공하고 Bun은 Web-standard `Request`를 제공합니다.
 
 ### Bun 전용 참고
 

--- a/packages/socket.io/README.md
+++ b/packages/socket.io/README.md
@@ -137,7 +137,7 @@ SocketIoModule.forRoot({
 });
 ```
 
-When `cors` is omitted, `@fluojs/socket.io` defaults to `{ credentials: false, origin: false }` so cross-origin exposure stays opt-in. When `engine.maxHttpBufferSize` is omitted, the adapter applies a bounded 1 MiB Engine.IO payload limit. Defaults also include `buffer.maxPendingMessagesPerSocket: 128`, `buffer.overflowPolicy: 'drop-oldest'`, and `shutdown.timeoutMs: 5000`. Explicit `engine.maxHttpBufferSize`, `buffer.maxPendingMessagesPerSocket`, and `shutdown.timeoutMs` values must be positive integers; invalid explicit values fail during module registration instead of falling back to defaults.
+When `cors` is omitted, `@fluojs/socket.io` defaults to `{ credentials: false, origin: false }` so cross-origin exposure stays opt-in. When `engine.maxHttpBufferSize` is omitted, the adapter applies a bounded 1 MiB Engine.IO payload limit. Defaults also include `buffer.maxPendingMessagesPerSocket: 128`, `buffer.overflowPolicy: 'drop-oldest'`, and `shutdown.timeoutMs: 5000`. The `buffer` options bound inbound events that arrive after a socket connects but before its connection handlers become ready; they do not control outbound emits or Socket.IO reconnect buffering. Explicit `engine.maxHttpBufferSize`, `buffer.maxPendingMessagesPerSocket`, and `shutdown.timeoutMs` values must be positive integers; invalid explicit values fail during module registration instead of falling back to defaults.
 
 Static `@WebSocketGateway({ path })` namespaces are owned by fluo's gateway discovery and are not treated as Socket.IO dynamic child namespaces. The adapter keeps Socket.IO's `cleanupEmptyChildNamespaces` behavior disabled for those static namespaces. If application code creates dynamic child namespaces through raw `SOCKETIO_SERVER` access, that ownership and cleanup policy stays with the application-level Socket.IO integration.
 
@@ -145,7 +145,7 @@ During application shutdown, Socket.IO owns cleanup for connected Socket.IO clie
 
 ### Guard contracts
 
-`auth.connection` receives `SocketIoConnectionGuardContext` before namespace connect handlers run. `auth.message` receives `SocketIoMessageGuardContext` before message handlers run. Guards accept by returning `true`, `undefined`, or no value. They reject by returning `false` or a `SocketIoGuardRejection` with `message`, optional `data`, and optional `disconnect`; message rejections use ACK payloads shaped as `{ error, data }`. `SocketIoHandshakeRequest` stays runtime-neutral at the root export: Node-backed adapters provide a structurally typed HTTP handshake request and Bun provides a Web-standard `Request`.
+`auth.connection` receives `SocketIoConnectionGuardContext` before namespace connect handlers run. `auth.message` receives `SocketIoMessageGuardContext` before message handlers run. Guards accept by returning `true`, `undefined`, or no value. They reject by returning `false` or a `SocketIoGuardRejection` with `message`, optional `data`, and optional `disconnect`. Connection rejection uses Socket.IO's namespace connection error path. Message rejection is reported only through an acknowledgement callback supplied with that event, using an ACK payload shaped as `{ error, data }`; without an ACK callback, fluo emits no implicit client error event. An explicit `disconnect: true` still disconnects the socket. `SocketIoHandshakeRequest` stays runtime-neutral at the root export: Node-backed adapters provide a structurally typed HTTP handshake request and Bun provides a Web-standard `Request`.
 
 ### Bun-specific notes
 

--- a/packages/socket.io/src/adapter.ts
+++ b/packages/socket.io/src/adapter.ts
@@ -1293,6 +1293,11 @@ export class SocketIoLifecycleService
   }
 
   private async runShutdownLifecycle(): Promise<void> {
+    const initialization = this.serverInitializationPromise;
+    if (initialization) {
+      await Promise.allSettled([initialization]);
+    }
+
     const io = this.io;
 
     if (!io) {

--- a/packages/socket.io/src/adapter.ts
+++ b/packages/socket.io/src/adapter.ts
@@ -382,6 +382,7 @@ export class SocketIoLifecycleService
   private namespaceContext: AsyncLocalStorage<string> | undefined;
   private namespaceContextPromise: Promise<AsyncLocalStorage<string>> | undefined;
   private readonly socketRegistry = new Map<string, Socket>();
+  private serverInitializationPromise: Promise<Server> | undefined;
   private shutdownPromise: Promise<void> | undefined;
   private shutdownStarted = false;
   private wired = false;
@@ -428,6 +429,10 @@ export class SocketIoLifecycleService
       return this.io;
     }
 
+    if (this.serverInitializationPromise) {
+      return this.serverInitializationPromise;
+    }
+
     const runtime = resolveSocketIoBootstrapRuntime(this.adapter);
 
     if (runtime.kind === 'server-backed') {
@@ -435,9 +440,42 @@ export class SocketIoLifecycleService
       return this.io;
     }
 
-    this.io = new Server(this.createServerOptions());
-    await this.installBunSocketIoBinding(runtime, this.io);
-    return this.io;
+    const io = new Server(this.createServerOptions());
+    const initialization = this.installBunSocketIoBinding(runtime, io)
+      .then(() => {
+        this.io = io;
+        return io;
+      })
+      .catch(async (error: unknown) => {
+        this.io = undefined;
+        this.bunEngine = undefined;
+
+        const cleanupResults = await Promise.allSettled([
+          Promise.resolve().then(() => runtime.bindingHost.configureRealtimeBinding(undefined)),
+          this.closeServerWithTimeout(io, this.resolveShutdownTimeoutMs()),
+        ]);
+        const cleanupErrors = cleanupResults.flatMap((result) =>
+          result.status === 'rejected' ? [result.reason] : [],
+        );
+
+        if (cleanupErrors.length > 0) {
+          throw new AggregateError(
+            [error, ...cleanupErrors],
+            'Socket.IO Bun initialization failed and partial resource cleanup did not complete.',
+          );
+        }
+
+        throw error;
+      });
+    this.serverInitializationPromise = initialization;
+
+    try {
+      return await initialization;
+    } finally {
+      if (this.serverInitializationPromise === initialization) {
+        this.serverInitializationPromise = undefined;
+      }
+    }
   }
 
   /**

--- a/packages/socket.io/src/bun-initialization.test.ts
+++ b/packages/socket.io/src/bun-initialization.test.ts
@@ -18,9 +18,11 @@ class TestBunAdapter implements HttpApplicationAdapter {
   private binding: unknown | undefined;
   private bindingAttemptCount = 0;
   private bindingClearCount = 0;
-  private failNextBinding = true;
 
-  constructor(private readonly retainFailedBinding = false) {}
+  constructor(
+    private readonly retainFailedBinding = false,
+    private failNextBinding = true,
+  ) {}
 
   get attempts(): number {
     return this.bindingAttemptCount;
@@ -28,6 +30,10 @@ class TestBunAdapter implements HttpApplicationAdapter {
 
   get clears(): number {
     return this.bindingClearCount;
+  }
+
+  get currentBinding(): unknown | undefined {
+    return this.binding;
   }
 
   close(): void {}
@@ -109,5 +115,37 @@ describe('SocketIoLifecycleService Bun initialization', () => {
     expect(server).toBeInstanceOf(Server);
     expect(adapter.attempts).toBe(2);
     expect(adapter.clears).toBe(1);
+  });
+
+  it('clears a Bun server initialized while application shutdown is in progress', async () => {
+    // Given
+    const adapter = new TestBunAdapter(false, false);
+    const service = createLifecycleService(adapter);
+    const installBinding = service['installBunSocketIoBinding'].bind(service);
+    let markInitializationStarted = (): void => undefined;
+    let releaseInitialization = (): void => undefined;
+    const initializationStarted = new Promise<void>((resolve) => {
+      markInitializationStarted = resolve;
+    });
+    const initializationGate = new Promise<void>((resolve) => {
+      releaseInitialization = resolve;
+    });
+    service['installBunSocketIoBinding'] = async (runtime, io) => {
+      markInitializationStarted();
+      await initializationGate;
+      await installBinding(runtime, io);
+    };
+    const initialization = service.getServerAsync();
+    await initializationStarted;
+
+    // When
+    const shutdown = service.onApplicationShutdown();
+    releaseInitialization();
+    await Promise.all([initialization, shutdown]);
+
+    // Then
+    expect(service['io']).toBeUndefined();
+    expect(service['bunEngine']).toBeUndefined();
+    expect(adapter.currentBinding).toBeUndefined();
   });
 });

--- a/packages/socket.io/src/bun-initialization.test.ts
+++ b/packages/socket.io/src/bun-initialization.test.ts
@@ -1,0 +1,113 @@
+import { Container } from '@fluojs/di';
+import {
+  createFetchStyleHttpAdapterRealtimeCapability,
+  type Dispatcher,
+  type HttpApplicationAdapter,
+} from '@fluojs/http';
+import type { ApplicationLogger } from '@fluojs/runtime';
+import { Server } from 'socket.io';
+import { describe, expect, it } from 'vitest';
+
+import { SocketIoLifecycleService } from './adapter.js';
+
+class TestBunBindingError extends Error {
+  readonly name = 'TestBunBindingError';
+}
+
+class TestBunAdapter implements HttpApplicationAdapter {
+  private binding: unknown | undefined;
+  private bindingAttemptCount = 0;
+  private bindingClearCount = 0;
+  private failNextBinding = true;
+
+  constructor(private readonly retainFailedBinding = false) {}
+
+  get attempts(): number {
+    return this.bindingAttemptCount;
+  }
+
+  get clears(): number {
+    return this.bindingClearCount;
+  }
+
+  close(): void {}
+
+  configureRealtimeBinding(binding: unknown | undefined): void {
+    if (binding === undefined) {
+      if (this.binding !== undefined) {
+        this.bindingClearCount += 1;
+      }
+      this.binding = undefined;
+      return;
+    }
+
+    this.bindingAttemptCount += 1;
+
+    if (this.failNextBinding) {
+      this.failNextBinding = false;
+      if (this.retainFailedBinding) {
+        this.binding = binding;
+      }
+      throw new TestBunBindingError('Bun binding failed.');
+    }
+
+    if (this.binding !== undefined) {
+      throw new TestBunBindingError('A stale Bun binding blocked retry.');
+    }
+
+    this.binding = binding;
+  }
+
+  getRealtimeCapability() {
+    return createFetchStyleHttpAdapterRealtimeCapability(
+      'Test adapter supports Bun-style Socket.IO binding.',
+      { support: 'supported' },
+    );
+  }
+
+  listen(_dispatcher: Dispatcher): void {}
+}
+
+const silentLogger: ApplicationLogger = {
+  debug() {},
+  error() {},
+  log() {},
+  warn() {},
+};
+
+function createLifecycleService(adapter: TestBunAdapter): SocketIoLifecycleService {
+  return new SocketIoLifecycleService(new Container(), [], silentLogger, adapter, {});
+}
+
+describe('SocketIoLifecycleService Bun initialization', () => {
+  it('shares a Bun binding failure with concurrent server callers', async () => {
+    // Given
+    const adapter = new TestBunAdapter();
+    const service = createLifecycleService(adapter);
+
+    // When
+    const results = await Promise.allSettled([
+      service.getServerAsync(),
+      service.getServerAsync(),
+    ]);
+
+    // Then
+    expect(results.map((result) => result.status)).toEqual(['rejected', 'rejected']);
+    expect(adapter.attempts).toBe(1);
+  });
+
+  it('cleans a partial Bun binding before retrying server initialization', async () => {
+    // Given
+    const adapter = new TestBunAdapter(true);
+    const service = createLifecycleService(adapter);
+    await expect(service.getServerAsync()).rejects.toThrow(TestBunBindingError);
+
+    // When
+    const server = await service.getServerAsync();
+
+    // Then
+    expect(server).toBeInstanceOf(Server);
+    expect(adapter.attempts).toBe(2);
+    expect(adapter.clears).toBe(1);
+  });
+});

--- a/packages/socket.io/src/types.ts
+++ b/packages/socket.io/src/types.ts
@@ -130,7 +130,8 @@ export interface SocketIoMessageGuardContext {
  * Guard function that can reject one inbound Socket.IO event before gateway message handlers execute.
  *
  * Returning `true`, `undefined`, or no value accepts the event. Returning `false` or a
- * {@link SocketIoGuardRejection} rejects it.
+ * {@link SocketIoGuardRejection} rejects it. A rejection is reported to the client only through
+ * the event's acknowledgement callback when one was supplied; no implicit error event is emitted.
  */
 export type SocketIoMessageGuard = (
   context: SocketIoMessageGuardContext,
@@ -158,13 +159,13 @@ export interface SocketIoModuleOptions {
   };
 
   /**
-   * In-memory outbound buffering controls applied before the server flushes messages to sockets.
+   * In-memory inbound buffering controls applied while connection handlers are becoming ready.
    */
   buffer?: {
-    /** Maximum number of queued outbound messages allowed per socket before overflow handling applies. */
+    /** Maximum inbound events queued per socket before its connection handlers become ready. */
     maxPendingMessagesPerSocket?: number;
 
-    /** Strategy used when one socket exceeds the configured pending message cap. */
+    /** Strategy used when one socket exceeds the configured pre-ready inbound event cap. */
     overflowPolicy?: 'close' | 'drop-newest' | 'drop-oldest';
   };
 


### PR DESCRIPTION
## Summary

Make Bun Socket.IO initialization atomic for concurrent callers and retryable after binding failures.

Closes #2804

## Changes

- share one in-flight Bun initialization promise and publish `io` only after realtime binding succeeds
- clear partial host binding and close the partial Socket.IO server before allowing retry, preserving cleanup failures in an `AggregateError`
- add regression coverage for concurrent failure propagation and retry after partial binding
- correct `buffer` documentation to describe inbound pre-ready events and clarify ACK-only message guard rejection reporting in EN/KO package and book docs
- add `.changeset/retry-bun-socket-io-initialization.md` with a patch bump for `@fluojs/socket.io`

## Testing

- `pnpm exec biome check packages/socket.io/src/adapter.ts packages/socket.io/src/bun-initialization.test.ts packages/socket.io/src/types.ts`
- `pnpm --filter @fluojs/socket.io... build`
- `pnpm --filter @fluojs/socket.io typecheck`
- `pnpm --filter @fluojs/socket.io test` — 69 tests passed
- `pnpm docs:sync-check` — 42 EN/KO page pairs and 10 navigation metadata pairs passed
- `pnpm verify:platform-consistency-governance`
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main`
- `FLUO_CLI_SANDBOX_ROOT=<fresh-temp-path> pnpm verify:release-readiness` — canonical release readiness passed without writing draft artifacts

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Patch rationale: this restores promised Bun initialization behavior without changing the public API.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No export was added or removed. Existing `SocketIoMessageGuard` and `SocketIoModuleOptions.buffer` TSDoc now matches runtime behavior; function tag requirements are not applicable.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

The Bun lifecycle now guarantees single-flight initialization, publish-after-bind, partial cleanup, and retry. Existing inbound buffering and ACK-only message rejection behavior is documented accurately.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests, such as `createPlatformConformanceHarness(...)` for platform component contracts or `createHttpAdapterPortabilityHarness(...)` for HTTP adapter portability contracts.

No governance SSOT document changed. Package README and Chapter 14 EN/KO mirrors are synchronized, and the package-local Bun initialization regression covers the changed runtime contract.