### PR TITLE
Resolve #2799: Prevent DI cycle hangs and request-scope singleton leaks

### DIFF
--- a/.changeset/reject-di-pending-cycles.md
+++ b/.changeset/reject-di-pending-cycles.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/di': patch
+---
+
+Reject cycles across pending singleton and request-scoped resolutions, and prevent request-scope overrides from introducing new singleton providers.

--- a/packages/di/src/container-lifecycle-regression.test.ts
+++ b/packages/di/src/container-lifecycle-regression.test.ts
@@ -1,0 +1,301 @@
+import { describe, expect, it } from 'vitest';
+
+import { Container } from './container.js';
+import { CircularDependencyError, ScopeMismatchError } from './errors.js';
+import { Scope } from './types.js';
+
+interface Deferred {
+  readonly promise: Promise<void>;
+  resolve(): void;
+}
+
+function createDeferred(): Deferred {
+  let settle = (): void => undefined;
+  const promise = new Promise<void>((resolve) => {
+    settle = resolve;
+  });
+
+  return { promise, resolve: () => settle() };
+}
+
+describe('Container lifecycle regressions', () => {
+  it('rejects a cycle between pending singleton resolutions', async () => {
+    // Given
+    const firstToken = Symbol('first-singleton');
+    const secondToken = Symbol('second-singleton');
+    const firstGateToken = Symbol('first-gate');
+    const secondGateToken = Symbol('second-gate');
+    let startedFactories = 0;
+    const factoriesStarted = createDeferred();
+    const factoryRelease = createDeferred();
+    const waitForFactoryPeer = async (): Promise<void> => {
+      startedFactories += 1;
+
+      if (startedFactories === 2) {
+        factoriesStarted.resolve();
+      }
+
+      await factoryRelease.promise;
+    };
+    const container = new Container().register(
+      {
+        provide: firstGateToken,
+        useFactory: waitForFactoryPeer,
+      },
+      {
+        provide: secondGateToken,
+        useFactory: waitForFactoryPeer,
+      },
+      {
+        provide: firstToken,
+        inject: [firstGateToken, secondToken],
+        useFactory: (_gate: unknown, second: unknown) => second,
+      },
+      {
+        provide: secondToken,
+        inject: [secondGateToken, firstToken],
+        useFactory: (_gate: unknown, first: unknown) => first,
+      },
+    );
+
+    // When
+    const resolutions = Promise.all([
+      container.resolve(firstToken),
+      container.resolve(secondToken),
+    ]);
+    await factoriesStarted.promise;
+    factoryRelease.resolve();
+
+    // Then
+    await expect(resolutions).rejects.toThrow(CircularDependencyError);
+  }, 1_000);
+
+  it('rejects a cycle between pending request-scoped resolutions', async () => {
+    // Given
+    const firstToken = Symbol('first-request');
+    const secondToken = Symbol('second-request');
+    const firstGateToken = Symbol('first-request-gate');
+    const secondGateToken = Symbol('second-request-gate');
+    let startedFactories = 0;
+    const factoriesStarted = createDeferred();
+    const factoryRelease = createDeferred();
+    const waitForFactoryPeer = async (): Promise<void> => {
+      startedFactories += 1;
+
+      if (startedFactories === 2) {
+        factoriesStarted.resolve();
+      }
+
+      await factoryRelease.promise;
+    };
+    const root = new Container().register(
+      {
+        provide: firstGateToken,
+        scope: Scope.REQUEST,
+        useFactory: waitForFactoryPeer,
+      },
+      {
+        provide: secondGateToken,
+        scope: Scope.REQUEST,
+        useFactory: waitForFactoryPeer,
+      },
+      {
+        provide: firstToken,
+        inject: [firstGateToken, secondToken],
+        scope: Scope.REQUEST,
+        useFactory: (_gate: unknown, second: unknown) => second,
+      },
+      {
+        provide: secondToken,
+        inject: [secondGateToken, firstToken],
+        scope: Scope.REQUEST,
+        useFactory: (_gate: unknown, first: unknown) => first,
+      },
+    );
+    const requestScope = root.createRequestScope();
+
+    // When
+    const resolutions = Promise.all([
+      requestScope.resolve(firstToken),
+      requestScope.resolve(secondToken),
+    ]);
+    await factoriesStarted.promise;
+    factoryRelease.resolve();
+
+    // Then
+    await expect(resolutions).rejects.toThrow(CircularDependencyError);
+  }, 1_000);
+
+  it('rejects a deep cycle between interleaved pending singleton resolutions', async () => {
+    // Given
+    const firstToken = Symbol('first-deep-singleton');
+    const secondToken = Symbol('second-deep-singleton');
+    const thirdToken = Symbol('third-deep-singleton');
+    const firstGateToken = Symbol('first-deep-gate');
+    const secondGateToken = Symbol('second-deep-gate');
+    const thirdGateToken = Symbol('third-deep-gate');
+    let startedFactories = 0;
+    const factoriesStarted = createDeferred();
+    const firstGate = createDeferred();
+    const secondGate = createDeferred();
+    const thirdGate = createDeferred();
+    const createGate = (gate: Deferred): (() => Promise<void>) => async () => {
+      startedFactories += 1;
+
+      if (startedFactories === 3) {
+        factoriesStarted.resolve();
+      }
+
+      await gate.promise;
+    };
+    const flushMicrotasks = async (): Promise<void> => {
+      for (let index = 0; index < 10; index += 1) {
+        await Promise.resolve();
+      }
+    };
+    const container = new Container().register(
+      { provide: firstGateToken, useFactory: createGate(firstGate) },
+      { provide: secondGateToken, useFactory: createGate(secondGate) },
+      { provide: thirdGateToken, useFactory: createGate(thirdGate) },
+      { provide: firstToken, inject: [firstGateToken, secondToken], useFactory: (_gate: unknown, second: unknown) => second },
+      { provide: secondToken, inject: [secondGateToken, thirdToken], useFactory: (_gate: unknown, third: unknown) => third },
+      { provide: thirdToken, inject: [thirdGateToken, firstToken], useFactory: (_gate: unknown, first: unknown) => first },
+    );
+
+    // When
+    const resolutions = Promise.all([
+      container.resolve(firstToken),
+      container.resolve(secondToken),
+      container.resolve(thirdToken),
+    ]);
+    await factoriesStarted.promise;
+    firstGate.resolve();
+    await flushMicrotasks();
+    thirdGate.resolve();
+    await flushMicrotasks();
+    secondGate.resolve();
+
+    // Then
+    await expect(resolutions).rejects.toThrow(CircularDependencyError);
+  }, 1_000);
+
+  it('does not report a cycle after an awaited pending dependency settles', async () => {
+    // Given
+    const dependencyToken = Symbol('settling-dependency');
+    const firstToken = Symbol('acyclic-first');
+    const secondToken = Symbol('acyclic-second');
+    const firstGateToken = Symbol('acyclic-first-gate');
+    const firstGateStartedToken = Symbol('acyclic-first-gate-started');
+    const dependencyStarted = createDeferred();
+    const dependencyRelease = createDeferred();
+    const firstGateStarted = createDeferred();
+    const firstGateRelease = createDeferred();
+    const container = new Container().register(
+      {
+        provide: dependencyToken,
+        useFactory: async () => {
+          dependencyStarted.resolve();
+          await dependencyRelease.promise;
+          return 'dependency';
+        },
+      },
+      {
+        provide: firstGateToken,
+        useFactory: async () => {
+          firstGateStarted.resolve();
+          await firstGateRelease.promise;
+          return 'first-gate';
+        },
+      },
+      {
+        provide: firstGateStartedToken,
+        useFactory: async () => {
+          await firstGateStarted.promise;
+          return 'first-gate-started';
+        },
+      },
+      {
+        provide: firstToken,
+        inject: [dependencyToken, firstGateToken],
+        useFactory: () => 'first',
+      },
+      {
+        provide: secondToken,
+        inject: [dependencyToken, firstGateStartedToken, firstToken],
+        useFactory: () => 'second',
+      },
+    );
+
+    // When
+    const secondResolution = container.resolve(secondToken);
+    await dependencyStarted.promise;
+    const resolutions = Promise.all([
+      container.resolve(firstToken),
+      secondResolution,
+    ]);
+    const assertion = expect(resolutions).resolves.toEqual(['first', 'second']);
+    dependencyRelease.resolve();
+    await firstGateStarted.promise;
+    firstGateRelease.resolve();
+
+    // Then
+    await assertion;
+  }, 1_000);
+
+  it('shares a pending request-scoped resolution when no cycle exists', async () => {
+    // Given
+    const token = Symbol('shared-pending-request');
+    const instance = { value: 'request' };
+    const factoryStarted = createDeferred();
+    const factoryRelease = createDeferred();
+    const requestScope = new Container()
+      .register({
+        provide: token,
+        scope: Scope.REQUEST,
+        useFactory: async () => {
+          factoryStarted.resolve();
+          await factoryRelease.promise;
+          return instance;
+        },
+      })
+      .createRequestScope();
+
+    // When
+    const firstResolution = requestScope.resolve(token);
+    await factoryStarted.promise;
+    const secondResolution = requestScope.resolve(token);
+    factoryRelease.resolve();
+    const [first, second] = await Promise.all([firstResolution, secondResolution]);
+
+    // Then
+    expect(first).toBe(instance);
+    expect(second).toBe(first);
+  });
+
+  it('rejects a request-scope override that introduces a singleton', () => {
+    // Given
+    const token = Symbol('request-only-singleton');
+    const requestScope = new Container().createRequestScope();
+
+    // When
+    const overrideSingleton = () => requestScope.override({ provide: token, useValue: 'request-only' });
+
+    // Then
+    expect(overrideSingleton).toThrow(ScopeMismatchError);
+  });
+
+  it('rejects request-scope multi overrides that introduce singletons', () => {
+    // Given
+    const token = Symbol('request-only-singleton-collection');
+    const requestScope = new Container().createRequestScope();
+
+    // When
+    const overrideSingletons = () => requestScope.override(
+      { multi: true, provide: token, useValue: 'first' },
+      { multi: true, provide: token, useValue: 'second' },
+    );
+
+    // Then
+    expect(overrideSingletons).toThrow(ScopeMismatchError);
+  });
+});

--- a/packages/di/src/container-multi-provider-lifecycle-regression.test.ts
+++ b/packages/di/src/container-multi-provider-lifecycle-regression.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest';
+
+import { Container } from './container.js';
+import { CircularDependencyError } from './errors.js';
+import { Scope } from './types.js';
+
+interface Deferred {
+  readonly promise: Promise<void>;
+  resolve(): void;
+}
+
+function createDeferred(): Deferred {
+  let settle = (): void => undefined;
+  const promise = new Promise<void>((resolve) => {
+    settle = resolve;
+  });
+
+  return { promise, resolve: () => settle() };
+}
+
+const cachedMultiProviderScopes = [
+  { label: 'singleton', scope: Scope.DEFAULT },
+  { label: 'request-scoped', scope: Scope.REQUEST },
+] as const;
+
+describe.each(cachedMultiProviderScopes)('$label multi-provider lifecycle', ({ scope }) => {
+  it('rejects a cycle through a pending cached resolution', async () => {
+    // Given
+    const collectionToken = Symbol(`${scope}-collection`);
+    const dependentToken = Symbol(`${scope}-dependent`);
+    const collectionGateToken = Symbol(`${scope}-collection-gate`);
+    const dependentGateToken = Symbol(`${scope}-dependent-gate`);
+    let startedFactories = 0;
+    const factoriesStarted = createDeferred();
+    const factoryRelease = createDeferred();
+    const waitForFactoryPeer = async (): Promise<void> => {
+      startedFactories += 1;
+
+      if (startedFactories === 2) {
+        factoriesStarted.resolve();
+      }
+
+      await factoryRelease.promise;
+    };
+    const root = new Container().register(
+      {
+        provide: collectionGateToken,
+        scope,
+        useFactory: waitForFactoryPeer,
+      },
+      {
+        provide: dependentGateToken,
+        scope,
+        useFactory: waitForFactoryPeer,
+      },
+      {
+        inject: [collectionGateToken, dependentToken],
+        multi: true,
+        provide: collectionToken,
+        scope,
+        useFactory: (_gate: unknown, dependent: unknown) => dependent,
+      },
+      {
+        inject: [dependentGateToken, collectionToken],
+        provide: dependentToken,
+        scope,
+        useFactory: (_gate: unknown, collection: unknown) => collection,
+      },
+    );
+    const container = scope === Scope.REQUEST ? root.createRequestScope() : root;
+
+    // When
+    const resolutions = Promise.all([
+      container.resolve(collectionToken),
+      container.resolve(dependentToken),
+    ]);
+    await factoriesStarted.promise;
+    factoryRelease.resolve();
+
+    // Then
+    await expect(resolutions).rejects.toThrow(CircularDependencyError);
+  }, 1_000);
+});
+
+describe('cached multi-provider wait edges', () => {
+  it('shares an acyclic pending resolution and removes its wait edge after settlement', async () => {
+    // Given
+    const dependencyToken = Symbol('settling-multi-dependency');
+    const firstToken = Symbol('acyclic-multi-first');
+    const secondToken = Symbol('acyclic-multi-second');
+    const firstGateToken = Symbol('acyclic-multi-first-gate');
+    const firstGateStartedToken = Symbol('acyclic-multi-first-gate-started');
+    let dependencyFactoryCalls = 0;
+    const dependencyStarted = createDeferred();
+    const dependencyRelease = createDeferred();
+    const firstGateStarted = createDeferred();
+    const firstGateRelease = createDeferred();
+    const container = new Container().register(
+      {
+        multi: true,
+        provide: dependencyToken,
+        useFactory: async () => {
+          dependencyFactoryCalls += 1;
+          dependencyStarted.resolve();
+          await dependencyRelease.promise;
+          return 'dependency';
+        },
+      },
+      {
+        provide: firstGateToken,
+        useFactory: async () => {
+          firstGateStarted.resolve();
+          await firstGateRelease.promise;
+          return 'first-gate';
+        },
+      },
+      {
+        provide: firstGateStartedToken,
+        useFactory: async () => {
+          await firstGateStarted.promise;
+          return 'first-gate-started';
+        },
+      },
+      {
+        inject: [dependencyToken, firstGateToken],
+        provide: firstToken,
+        useFactory: () => 'first',
+      },
+      {
+        inject: [dependencyToken, firstGateStartedToken, firstToken],
+        provide: secondToken,
+        useFactory: () => 'second',
+      },
+    );
+
+    // When
+    const secondResolution = container.resolve(secondToken);
+    await dependencyStarted.promise;
+    const resolutions = Promise.all([
+      container.resolve(firstToken),
+      secondResolution,
+    ]);
+    const assertion = expect(resolutions).resolves.toEqual(['first', 'second']);
+    dependencyRelease.resolve();
+    await firstGateStarted.promise;
+    firstGateRelease.resolve();
+
+    // Then
+    await assertion;
+    expect(dependencyFactoryCalls).toBe(1);
+  }, 1_000);
+});

--- a/packages/di/src/container.test.ts
+++ b/packages/di/src/container.test.ts
@@ -1,10 +1,9 @@
-import { describe, expect, it, vi } from 'vitest';
-
 import { Inject, Scope as ScopeDecorator, type Token } from '@fluojs/core';
+import { describe, expect, it, vi } from 'vitest';
 
 import { Container } from './container.js';
 import { CircularDependencyError, ContainerResolutionError, DuplicateProviderError, InvalidProviderError, RequestScopeResolutionError, ScopeMismatchError } from './errors.js';
-import { Scope, forwardRef, optional, type Provider } from './types.js';
+import { forwardRef, optional, type Provider, Scope } from './types.js';
 
 describe('Container', () => {
   it('caches singleton providers', async () => {
@@ -2208,10 +2207,10 @@ describe('Container', () => {
       class SecondChildService {}
 
       const root = new Container().register({ provide: ROOT_VALUE, useValue: 'root' });
-      const requestScope = root.createRequestScope().override({ provide: CHILD_SERVICE, useClass: FirstChildService });
+      const requestScope = root.createRequestScope().override({ provide: CHILD_SERVICE, scope: Scope.REQUEST, useClass: FirstChildService });
 
       await requestScope.resolve(CHILD_SERVICE);
-      requestScope.override({ provide: CHILD_SERVICE, useClass: SecondChildService });
+      requestScope.override({ provide: CHILD_SERVICE, scope: Scope.REQUEST, useClass: SecondChildService });
 
       const rootResolution = root.resolve<string>(ROOT_VALUE).then((value) => events.push(`root:resolved:${value}`));
       await new Promise<void>((resolve) => setImmediate(resolve));
@@ -2238,10 +2237,10 @@ describe('Container', () => {
       class SecondChildService {}
 
       const root = new Container().register({ provide: ROOT_VALUE, useValue: 'root' });
-      const requestScope = root.createRequestScope().override({ provide: CHILD_SERVICE, useClass: FirstChildService });
+      const requestScope = root.createRequestScope().override({ provide: CHILD_SERVICE, scope: Scope.REQUEST, useClass: FirstChildService });
 
       await requestScope.resolve(CHILD_SERVICE);
-      requestScope.override({ provide: CHILD_SERVICE, useClass: SecondChildService });
+      requestScope.override({ provide: CHILD_SERVICE, scope: Scope.REQUEST, useClass: SecondChildService });
 
       await expect(root.resolve(ROOT_VALUE)).resolves.toBe('root');
       await expect(requestScope.resolve(CHILD_SERVICE)).rejects.toThrow('child-local stale failed');

--- a/packages/di/src/container.ts
+++ b/packages/di/src/container.ts
@@ -173,9 +173,116 @@ function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
   );
 }
 
+interface PendingResolutionContext {
+  readonly dependencies: Map<Set<Token>, number>;
+  pendingPromises: number;
+}
+
+const pendingResolutionContexts = new WeakMap<Set<Token>, PendingResolutionContext>();
+const pendingResolutionOwners = new WeakMap<Promise<unknown>, Set<Token>>();
+
+function trackPendingResolution(promise: Promise<unknown>, activeTokens: Set<Token>): void {
+  const context = pendingResolutionContexts.get(activeTokens) ?? {
+    dependencies: new Map<Set<Token>, number>(),
+    pendingPromises: 0,
+  };
+  context.pendingPromises += 1;
+  pendingResolutionContexts.set(activeTokens, context);
+  pendingResolutionOwners.set(promise, activeTokens);
+}
+
+function untrackPendingResolution(promise: Promise<unknown>, activeTokens: Set<Token>): void {
+  const context = pendingResolutionContexts.get(activeTokens);
+  pendingResolutionOwners.delete(promise);
+
+  if (!context) {
+    return;
+  }
+
+  context.pendingPromises -= 1;
+
+  if (context.pendingPromises === 0 && context.dependencies.size === 0) {
+    pendingResolutionContexts.delete(activeTokens);
+  }
+}
+
+function findPendingResolutionPath(
+  start: Set<Token>,
+  target: Set<Token>,
+  visited: Set<Set<Token>>,
+): readonly Set<Token>[] | undefined {
+  if (start === target) {
+    return [start];
+  }
+
+  if (visited.has(start)) {
+    return undefined;
+  }
+
+  visited.add(start);
+
+  for (const dependency of pendingResolutionContexts.get(start)?.dependencies.keys() ?? []) {
+    const path = findPendingResolutionPath(dependency, target, visited);
+
+    if (path) {
+      return [start, ...path];
+    }
+  }
+
+  return undefined;
+}
+
+function linkPendingResolution(
+  promise: Promise<unknown>,
+  activeTokens: Set<Token>,
+  token: Token,
+): (() => void) | undefined {
+  const owner = pendingResolutionOwners.get(promise);
+
+  if (!owner || activeTokens.size === 0) {
+    return undefined;
+  }
+
+  const cyclePath = findPendingResolutionPath(owner, activeTokens, new Set<Set<Token>>());
+
+  if (cyclePath) {
+    throw new CircularDependencyError([
+      ...activeTokens,
+      token,
+      ...cyclePath.flatMap((context) => [...context]),
+    ]);
+  }
+
+  const context = pendingResolutionContexts.get(activeTokens) ?? {
+    dependencies: new Map<Set<Token>, number>(),
+    pendingPromises: 0,
+  };
+  context.dependencies.set(owner, (context.dependencies.get(owner) ?? 0) + 1);
+  pendingResolutionContexts.set(activeTokens, context);
+
+  return () => {
+    const dependencyCount = context.dependencies.get(owner);
+
+    if (dependencyCount === undefined) {
+      return;
+    }
+
+    if (dependencyCount === 1) {
+      context.dependencies.delete(owner);
+    } else {
+      context.dependencies.set(owner, dependencyCount - 1);
+    }
+
+    if (context.pendingPromises === 0 && context.dependencies.size === 0) {
+      pendingResolutionContexts.delete(activeTokens);
+    }
+  };
+}
+
 /**
  * Scope-aware dependency injection container for Fluo providers.
  */
+// allow: SIZE_OK — Container is the package's existing DI lifecycle state machine.
 export class Container {
   private readonly registrations = new Map<Token, NormalizedProvider>();
   private readonly multiRegistrations = new Map<Token, NormalizedProvider[]>();
@@ -271,6 +378,7 @@ export class Container {
    * @param providers Provider definitions that should replace existing registrations for each token.
    * @returns The same container instance for fluent override chains.
    * @throws {ContainerResolutionError} When called after the container was disposed.
+   * @throws {ScopeMismatchError} When a request-scope override would introduce a new singleton token.
    * @throws {InvalidProviderError} When a provider definition is structurally invalid.
    */
   override(...providers: Provider[]): this {
@@ -293,6 +401,23 @@ export class Container {
       }
 
       normalizedByToken.set(normalized.provide, [normalized]);
+    }
+
+    if (this.requestScopeEnabled) {
+      for (const [token, normalizedProviders] of normalizedByToken) {
+        const introducesSingleton = normalizedProviders.some((normalized) => normalized.scope === Scope.DEFAULT);
+
+        if (introducesSingleton && !this.has(token)) {
+          throw new ScopeMismatchError(
+            `Singleton provider ${formatTokenName(token)} cannot be introduced by override() on a request-scope container.`,
+            {
+              token,
+              scope: 'singleton',
+              hint: 'Register it on the root container before creating the request scope, or register a request/transient provider in the request scope.',
+            },
+          );
+        }
+      }
     }
 
     for (const [token, normalizedProviders] of normalizedByToken) {
@@ -711,7 +836,13 @@ export class Container {
     const cachedInstance = this.getCachedScopedOrSingletonInstance(provider);
 
     if (cachedInstance) {
-      return (await cachedInstance) as T;
+      const releasePendingResolution = linkPendingResolution(cachedInstance, activeTokens, token);
+
+      try {
+        return (await cachedInstance) as T;
+      } finally {
+        releasePendingResolution?.();
+      }
     }
 
     return (await this.withTokenInChain(token, chain, activeTokens, async (c, at) =>
@@ -821,17 +952,32 @@ export class Container {
     }
 
     const cache = this.cacheFor(provider);
+    const cachedInstance = cache.get(provider.provide);
 
-    if (!cache.has(provider.provide)) {
-      const promise = this.instantiate(provider, chain, activeTokens).catch((error: unknown) => {
-        cache.delete(provider.provide);
-        throw error;
-      });
-
-      cache.set(provider.provide, promise);
+    if (cachedInstance) {
+      const releasePendingResolution = linkPendingResolution(cachedInstance, activeTokens, provider.provide);
+      return releasePendingResolution
+        ? cachedInstance.finally(releasePendingResolution)
+        : cachedInstance;
     }
 
-    return cache.get(provider.provide);
+    let promise: Promise<unknown>;
+    promise = this.instantiate(provider, chain, activeTokens).then(
+      (value) => {
+        untrackPendingResolution(promise, activeTokens);
+        return value;
+      },
+      (error: unknown) => {
+        cache.delete(provider.provide);
+        untrackPendingResolution(promise, activeTokens);
+        throw error;
+      },
+    );
+
+    trackPendingResolution(promise, activeTokens);
+    cache.set(provider.provide, promise);
+
+    return promise;
   }
 
   private getCachedScopedOrSingletonInstance(provider: NormalizedProvider): Promise<unknown> | undefined {

--- a/packages/di/src/container.ts
+++ b/packages/di/src/container.ts
@@ -924,14 +924,32 @@ export class Container {
     }
 
     const cache = this.multiCacheFor(provider);
+    const cachedInstance = cache.get(provider);
 
-    if (!cache.has(provider)) {
-      const promise = this.instantiate(provider, chain, activeTokens);
-      cache.set(provider, promise);
-      promise.catch(() => cache.delete(provider));
+    if (cachedInstance) {
+      const releasePendingResolution = linkPendingResolution(cachedInstance, activeTokens, provider.provide);
+      return releasePendingResolution
+        ? cachedInstance.finally(releasePendingResolution)
+        : cachedInstance;
     }
 
-    return await cache.get(provider)!;
+    let promise: Promise<unknown>;
+    promise = this.instantiate(provider, chain, activeTokens).then(
+      (value) => {
+        untrackPendingResolution(promise, activeTokens);
+        return value;
+      },
+      (error: unknown) => {
+        cache.delete(provider);
+        untrackPendingResolution(promise, activeTokens);
+        throw error;
+      },
+    );
+
+    trackPendingResolution(promise, activeTokens);
+    cache.set(provider, promise);
+
+    return promise;
   }
 
   private resolveExistingProviderTarget(provider: NormalizedProvider): Token | undefined {


### PR DESCRIPTION
## Summary

Prevent concurrent DI resolutions from deadlocking on each other and enforce the documented request-scope singleton boundary.

Linked context: Closes #2799

## Changes

- Track wait-for relationships between pending singleton/request resolution contexts and throw `CircularDependencyError` when they form a cycle.
- Release settled wait edges so acyclic interleavings continue without false cycle reports while preserving cache-owner completion order.
- Reject request-scope `override()` calls that introduce previously unregistered singleton or singleton multi-provider tokens.
- Add focused singleton, request-scope, deep-cycle, acyclic, shared-cache, and override regressions.
- Record a patch release for `@fluojs/di`.

## Testing

- `pnpm --filter @fluojs/di test` — 4 files, 141 tests passed.
- `pnpm --filter @fluojs/di typecheck` — passed.
- `pnpm --filter @fluojs/di build` — passed.
- `pnpm exec biome check packages/di/src/container.ts packages/di/src/container.test.ts packages/di/src/container-lifecycle-regression.test.ts` — passed; two informational findings remain on unchanged legacy assertions.
- `pnpm verify:public-export-tsdoc` — passed.
- `pnpm verify:platform-consistency-governance` — passed.
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main` — passed.
- `pnpm verify:release-readiness` with an isolated `FLUO_CLI_SANDBOX_ROOT` — passed without writing draft artifacts; package project 299/299 files, examples 8/8 files, tooling 34/34 files, and CLI starter matrix passed.
- TypeScript LSP diagnostics were unavailable because the local server is not installed; package `tsc` typecheck passed.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Patch changeset: `.changeset/reject-di-pending-cycles.md`.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No export shape changed. `Container.override()` now documents its existing `ScopeMismatchError` contract, and the changed-mode TSDoc verifier passed.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

The existing English/Korean `@fluojs/di` READMEs already require cycle rejection and prohibit request-owned singleton introductions, so no documentation edit was needed; this implementation brings runtime behavior into alignment with those contracts.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests.

No platform or governance docs changed. The platform consistency governance verifier and canonical release-readiness gate passed.