### PR TITLE
Resolve #2807: Align Studio timing contract and public TSDoc

### DIFF
--- a/packages/studio/README.ko.md
+++ b/packages/studio/README.ko.md
@@ -68,7 +68,7 @@ Live mode는 다음을 보여줍니다.
 - module/provider/controller/route graph node와 import/export/ownership/dependency edge
 - HTTP method/path/controller handler route descriptor
 - route/handler correlation, success/error, status code, duration을 포함한 최근 request flow
-- bootstrap/restart/request timing summary
+- live 및 static/report 데이터의 bootstrap timing summary
 - severity, target, message, 가능한 fix hint가 포함된 runtime/request diagnostics
 
 MVP request flow는 route/handler와 dependency-graph correlation을 의미합니다. full method-level service call-chain tracing은 아직 포함하지 않습니다.

--- a/packages/studio/README.md
+++ b/packages/studio/README.md
@@ -68,7 +68,7 @@ Live mode shows:
 - module/provider/controller/route graph nodes and import/export/ownership/dependency edges;
 - HTTP method/path/controller handler route descriptors;
 - recent request flow with route/handler correlation, success/error, status code, and duration;
-- bootstrap/restart/request timing summaries;
+- bootstrap timing summaries for live and static/report data;
 - runtime/request diagnostics with severity, target, message, and fix hints where available.
 
 MVP request flow intentionally means route/handler and dependency-graph correlation, not full method-level service call-chain tracing.

--- a/packages/studio/src/entities/studio/actions.ts
+++ b/packages/studio/src/entities/studio/actions.ts
@@ -1,6 +1,9 @@
 import type { ParsedPayload, StudioConnectionState, StudioLiveEvent } from '../../contracts.js';
 import type { StudioDashboardState } from './model.js';
 
+/**
+ * Describes state transitions handled by the Studio dashboard reducer.
+ */
 export type StudioAction =
   | { type: 'connection'; connection: StudioConnectionState }
   | { type: 'file-error'; message: string }

--- a/packages/studio/src/widgets/timing/ui/TimingPanel.tsx
+++ b/packages/studio/src/widgets/timing/ui/TimingPanel.tsx
@@ -50,7 +50,7 @@ export function TimingPanel({ state }: TimingPanelProps) {
     <section className="card timing-card">
       <div className="section-title-row">
         <div>
-          <p className="eyebrow">Bootstrap, restart, and request timing</p>
+          <p className="eyebrow">Bootstrap timing</p>
           <h2>Timing</h2>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Align Studio timing documentation with the current bootstrap-only TimingPanel and complete the missing `StudioAction` TSDoc.

Linked context: Closes #2807

## Changes

- Limit the TimingPanel label to bootstrap timing.
- Synchronize the English and Korean package README wording with live and static/report bootstrap timing.
- Keep per-request duration documented on the recent request-flow surface.
- Add the required source-level summary for the exported `StudioAction` type.

## Testing

- `pnpm --filter @fluojs/studio test` (58 tests passed)
- `pnpm --filter @fluojs/studio... build`
- `pnpm --filter @fluojs/studio typecheck`
- `pnpm lint`
- `pnpm verify:public-export-tsdoc`
- `pnpm docs:sync-check`
- `pnpm verify:platform-consistency-governance`
- `pnpm vitest run tooling/governance/verify-platform-consistency-governance.test.ts` (114 tests passed)
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main`
- `FLUO_CLI_SANDBOX_ROOT=<dedicated-temp-path> pnpm verify:release-readiness`

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

No changeset is required because this correction changes documentation, TSDoc, and an inaccurate viewer label without changing runtime behavior, public API shape, or package capabilities.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable. (`StudioAction` is a type export.)
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README. (No new behavior; the existing surface is now described accurately.)
- [x] Intentional limitations are explicitly stated rather than silently removed.
- [x] Runtime invariants are covered by regression tests. (Runtime behavior is unchanged; the existing Studio suite passes.)

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed documentation.
- [x] Platform contract companion updates are not applicable because no platform contract changed.
- [x] Package README alignment claims do not add a platform conformance claim.