### PR TITLE
Resolve #2792: Emit valid OpenAPI 3.1 exclusive bounds

### DIFF
--- a/.changeset/emit-valid-openapi-exclusive-bounds.md
+++ b/.changeset/emit-valid-openapi-exclusive-bounds.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/openapi': patch
+---
+
+Emit OpenAPI 3.1 numeric exclusive bounds from compatible boolean metadata instead of forwarding invalid boolean keywords.

--- a/docs/architecture/openapi.ko.md
+++ b/docs/architecture/openapi.ko.md
@@ -27,6 +27,7 @@
 | 응답 메타데이터 | `@ApiResponse(...)`는 명시적 status/description/schema/type 메타데이터를 저장합니다. DTO `type` 값은 component schema reference로 변환됩니다. Handler 반환값과 TypeScript 반환 타입은 검사하지 않습니다. `@ApiResponse(...)`가 없으면 builder는 추론된 response schema가 아니라 method-derived 또는 `@HttpCode(...)` success status와 `OK` description만 생성합니다. | `packages/openapi/src/decorators.ts`, `packages/openapi/src/schema-builder.ts` |
 | 파라미터 및 body 메타데이터 | `@ApiParam(...)`, `@ApiQuery(...)`, `@ApiHeader(...)`, `@ApiCookie(...)`, `@ApiBody(...)`가 명시적 parameter와 request-body 메타데이터를 제공합니다. | `packages/openapi/src/decorators.ts`, `packages/openapi/src/schema-builder.ts` |
 | DTO 스키마 생성 | DTO 스키마는 `getDtoBindingSchema(...)`와 `getDtoValidationSchema(...)`를 통한 바인딩/검증 메타데이터에서 파생되며, `components.schemas`로 출력됩니다. | `packages/openapi/src/schema-builder.ts` |
+| 배타적 스키마 경계 | `OpenApiSchemaObject`는 숫자 및 기존 boolean 배타적 경계 입력을 유지합니다. `minimum`/`maximum`과 짝을 이룬 `true` metadata는 OpenAPI 3.1 숫자 배타적 keyword로 생성되고, `false`는 포괄 경계를 유지한 채 생략되며, 정규화할 수 없는 배타적 값은 문서 생성을 실패시킵니다. | `packages/openapi/src/schema-bounds.ts`, `packages/openapi/src/schema-builder.ts` |
 | 보안 메타데이터 | `@ApiBearerAuth()`와 `@ApiSecurity()`는 operation 수준 보안 요구사항을 추가합니다. `securitySchemes` 옵션은 `components.securitySchemes`를 채웁니다. | `packages/openapi/src/decorators.ts`, `packages/openapi/src/openapi-module.ts`, `packages/openapi/src/schema-builder.ts` |
 
 ## 출력 표면
@@ -37,7 +38,7 @@
 | Swagger UI | `ui: true`일 때 `GET uiPath`는 runtime global prefix 아래에서도 해당 module instance의 `documentPath`를 가리키는 HTML을 렌더링합니다. `uiPath`의 기본값은 `/docs`입니다. 기본 asset은 고정된 `swagger-ui-dist` 버전 `5.32.2`를 사용하며, self-hosted 또는 CSP-controlled deployment에서는 `swaggerUiAssets.cssUrl`과 `swaggerUiAssets.jsBundleUrl`로 URL을 교체할 수 있습니다. | `packages/openapi/src/openapi-module.ts`, `packages/openapi/src/swagger-ui.ts` |
 | 기본 오류 응답 | `defaultErrorResponsesPolicy`의 기본값은 `'inject'`입니다. `'omit'`으로 설정하면 builder가 프레임워크 기본 오류 응답을 추가하지 않을 수 있습니다. | `packages/openapi/src/schema-builder.ts`, `packages/openapi/src/openapi-module.ts`, `packages/openapi/src/openapi-module.test.ts` |
 | 추가 모델 | `extraModels`를 사용하면 핸들러에서 직접 발견되지 않는 DTO 생성자도 포함할 수 있습니다. | `packages/openapi/src/openapi-module.ts`, `packages/openapi/src/schema-builder.ts` |
-| 최종 변환 | `documentTransform(document)`는 생성된 문서를 노출 전에 다시 쓸 수 있습니다. | `packages/openapi/src/openapi-module.ts` |
+| 최종 변환 | `documentTransform(document)`는 생성된 문서를 노출 전에 다시 쓸 수 있습니다. OpenAPI 3.1 배타적 경계 정규화는 변환된 결과에 실행됩니다. | `packages/openapi/src/openapi-module.ts`, `packages/openapi/src/schema-bounds.ts` |
 
 ## 생성 경계
 

--- a/docs/architecture/openapi.md
+++ b/docs/architecture/openapi.md
@@ -27,6 +27,7 @@ This document defines the current OpenAPI document-generation contract implement
 | Response metadata | `@ApiResponse(...)` stores explicit status/description/schema/type metadata. DTO `type` values become component schema references. Handler return values and TypeScript return types are not inspected. Without `@ApiResponse(...)`, the builder emits only a method-derived or `@HttpCode(...)` success status with description `OK`, not an inferred response schema. | `packages/openapi/src/decorators.ts`, `packages/openapi/src/schema-builder.ts` |
 | Parameter and body metadata | `@ApiParam(...)`, `@ApiQuery(...)`, `@ApiHeader(...)`, `@ApiCookie(...)`, and `@ApiBody(...)` supply explicit parameter and request-body metadata. | `packages/openapi/src/decorators.ts`, `packages/openapi/src/schema-builder.ts` |
 | DTO schema generation | DTO schemas are derived from binding and validation metadata through `getDtoBindingSchema(...)` and `getDtoValidationSchema(...)`, then emitted into `components.schemas`. | `packages/openapi/src/schema-builder.ts` |
+| Exclusive schema bounds | `OpenApiSchemaObject` retains numeric and legacy boolean exclusive-bound inputs. Paired `true` plus `minimum`/`maximum` metadata is emitted as the OpenAPI 3.1 numeric exclusive keyword, `false` is omitted while retaining the inclusive bound, and unnormalizable exclusive values fail document generation. | `packages/openapi/src/schema-bounds.ts`, `packages/openapi/src/schema-builder.ts` |
 | Security metadata | `@ApiBearerAuth()` and `@ApiSecurity()` contribute operation-level security requirements. `securitySchemes` options populate `components.securitySchemes`. | `packages/openapi/src/decorators.ts`, `packages/openapi/src/openapi-module.ts`, `packages/openapi/src/schema-builder.ts` |
 
 ## Output Surface
@@ -37,7 +38,7 @@ This document defines the current OpenAPI document-generation contract implement
 | Swagger UI | With `ui: true`, `GET uiPath` renders HTML that points to that module instance's `documentPath`, including under a runtime global prefix. `uiPath` defaults to `/docs`. The default assets use the pinned `swagger-ui-dist` version `5.32.2`; `swaggerUiAssets.cssUrl` and `swaggerUiAssets.jsBundleUrl` can replace those URLs for self-hosted or CSP-controlled deployments. | `packages/openapi/src/openapi-module.ts`, `packages/openapi/src/swagger-ui.ts` |
 | Default error responses | `defaultErrorResponsesPolicy` defaults to `'inject'`. The builder can also omit framework-added defaults when set to `'omit'`. | `packages/openapi/src/schema-builder.ts`, `packages/openapi/src/openapi-module.ts`, `packages/openapi/src/openapi-module.test.ts` |
 | Extra models | `extraModels` lets the module include DTO constructors that are not otherwise discovered from handlers. | `packages/openapi/src/openapi-module.ts`, `packages/openapi/src/schema-builder.ts` |
-| Final transform | `documentTransform(document)` can rewrite the generated document before it is exposed. | `packages/openapi/src/openapi-module.ts` |
+| Final transform | `documentTransform(document)` can rewrite the generated document before it is exposed. OpenAPI 3.1 exclusive-bound normalization runs on the transformed result. | `packages/openapi/src/openapi-module.ts`, `packages/openapi/src/schema-bounds.ts` |
 
 ## Generation Boundaries
 

--- a/packages/openapi/README.ko.md
+++ b/packages/openapi/README.ko.md
@@ -89,6 +89,9 @@ Builder는 handler 반환값이나 TypeScript 반환 타입을 검사해 respons
 ### 통합 DTO 스키마
 `@fluojs/validation`과 함께 DTO binding 및 validation metadata에서 request schema를 파생합니다. Response DTO는 `@ApiResponse(..., { type: ResponseDto })` 또는 `extraModels`처럼 명시적으로 참조할 때만 OpenAPI component가 됩니다.
 
+### OpenAPI 3.1 배타적 경계
+`OpenApiSchemaObject`는 OpenAPI 3.1의 숫자 `exclusiveMinimum` 및 `exclusiveMaximum` 값을 받으면서 기존 boolean metadata와의 호환성도 유지합니다. `minimum` 또는 `maximum`과 함께 사용한 `true` 플래그는 생성 문서에서 대응하는 숫자 배타적 경계로 변환되고, `false` 플래그는 생략되는 대신 포괄 경계는 유지됩니다. 유한한 숫자 배타적 경계는 변경 없이 통과합니다. 유한한 대응 경계가 없는 `true` 플래그나 유한하지 않은 숫자 배타적 경계는 잘못된 OpenAPI 3.1 schema를 생성하는 대신 문서 생성을 실패시킵니다. 같은 정규화는 문서가 노출되기 전에 `documentTransform` 이후에도 실행됩니다.
+
 ### 버전 관리 지원
 `@fluojs/http`의 URI 기반 버전 관리를 자동으로 처리합니다. OpenAPI 경로에 해결된 버전 경로가 올바르게 반영됩니다.
 

--- a/packages/openapi/README.md
+++ b/packages/openapi/README.md
@@ -89,6 +89,9 @@ The builder does not inspect handler return values or TypeScript return types to
 ### Integrated DTO Schemas
 Works with `@fluojs/validation` to derive request schemas from DTO binding and validation metadata. Response DTOs become OpenAPI components only when they are referenced explicitly, such as with `@ApiResponse(..., { type: ResponseDto })` or `extraModels`.
 
+### OpenAPI 3.1 Exclusive Bounds
+`OpenApiSchemaObject` accepts OpenAPI 3.1 numeric `exclusiveMinimum` and `exclusiveMaximum` values while retaining compatibility with legacy boolean metadata. A `true` flag paired with `minimum` or `maximum` becomes the corresponding numeric exclusive bound in the emitted document, and a `false` flag is omitted while its inclusive bound remains. Finite numeric exclusive bounds pass through unchanged. A `true` flag without a finite paired bound, or a non-finite numeric exclusive bound, fails document generation instead of emitting an invalid OpenAPI 3.1 schema. The same normalization runs after `documentTransform` before the document is exposed.
+
 ### Versioning Support
 Handles URI-based versioning from `@fluojs/http` automatically. Your OpenAPI paths will correctly reflect the resolved versioned routes.
 

--- a/packages/openapi/src/schema-bounds.test.ts
+++ b/packages/openapi/src/schema-bounds.test.ts
@@ -1,0 +1,189 @@
+import { Controller, createHandlerMapping, Post } from '@fluojs/http';
+import { describe, expect, it } from 'vitest';
+
+import { ApiBody, ApiQuery, ApiResponse } from './decorators.js';
+import { buildOpenApiDocument } from './schema-builder.js';
+
+describe('OpenAPI 3.1 exclusive bounds', () => {
+  it('emits numeric exclusive bounds when typed metadata uses legacy booleans', () => {
+    // Given
+    @Controller('/bounds')
+    class BoundsController {
+      @ApiQuery('cursor', {
+        schema: {
+          exclusiveMinimum: true,
+          minimum: 0,
+          type: 'integer',
+        },
+      })
+      @ApiBody({
+        schema: {
+          properties: {
+            ratio: {
+              exclusiveMaximum: true,
+              maximum: 1,
+              type: 'number',
+            },
+          },
+          type: 'object',
+        },
+      })
+      @ApiResponse(200, {
+        schema: {
+          properties: {
+            inclusiveFloor: {
+              exclusiveMinimum: false,
+              minimum: 0,
+              type: 'number',
+            },
+            score: {
+              exclusiveMinimum: -1,
+              type: 'number',
+            },
+          },
+          type: 'object',
+        },
+      })
+      @Post('/')
+      create() {
+        return { score: 0 };
+      }
+    }
+
+    const descriptors = createHandlerMapping([{ controllerToken: BoundsController }]).descriptors;
+
+    // When
+    const document = buildOpenApiDocument({
+      defaultErrorResponsesPolicy: 'omit',
+      descriptors,
+      title: 'Bounds API',
+      version: '1.0.0',
+    });
+    const operation = document.paths['/bounds']?.post;
+
+    // Then
+    expect({
+      parameter: operation?.parameters?.[0]?.schema,
+      request: operation?.requestBody?.content['application/json']?.schema,
+      response: operation?.responses['200']?.content?.['application/json']?.schema,
+    }).toEqual({
+      parameter: {
+        exclusiveMinimum: 0,
+        type: 'integer',
+      },
+      request: {
+        properties: {
+          ratio: {
+            exclusiveMaximum: 1,
+            type: 'number',
+          },
+        },
+        type: 'object',
+      },
+      response: {
+        properties: {
+          inclusiveFloor: {
+            minimum: 0,
+            type: 'number',
+          },
+          score: {
+            exclusiveMinimum: -1,
+            type: 'number',
+          },
+        },
+        type: 'object',
+      },
+    });
+  });
+
+  it('normalizes exclusive bounds added by the final document transform', () => {
+    // Given
+    const options = {
+      defaultErrorResponsesPolicy: 'omit' as const,
+      descriptors: [],
+      documentTransform: (document: ReturnType<typeof buildOpenApiDocument>) => ({
+        ...document,
+        components: {
+          schemas: {
+            TransformedScore: {
+              exclusiveMaximum: true,
+              maximum: 100,
+              type: 'number' as const,
+            },
+          },
+        },
+      }),
+      title: 'Transformed Bounds API',
+      version: '1.0.0',
+    };
+
+    // When
+    const document = buildOpenApiDocument(options);
+
+    // Then
+    expect(document.components?.schemas?.TransformedScore).toEqual({
+      exclusiveMaximum: 100,
+      type: 'number',
+    });
+  });
+
+  it('rejects a true legacy exclusive bound when its numeric bound is missing', () => {
+    // Given
+    @Controller('/invalid-bounds')
+    class InvalidBoundsController {
+      @ApiResponse(200, {
+        schema: {
+          exclusiveMinimum: true,
+          type: 'number',
+        },
+      })
+      @Post('/')
+      create() {
+        return 1;
+      }
+    }
+
+    const descriptors = createHandlerMapping([{ controllerToken: InvalidBoundsController }]).descriptors;
+
+    // When
+    const buildDocument = () => buildOpenApiDocument({
+      defaultErrorResponsesPolicy: 'omit',
+      descriptors,
+      title: 'Invalid Bounds API',
+      version: '1.0.0',
+    });
+
+    // Then
+    expect(buildDocument).toThrowError(TypeError);
+  });
+
+  it('rejects a non-finite numeric exclusive bound', () => {
+    // Given
+    @Controller('/non-finite-bounds')
+    class NonFiniteBoundsController {
+      @ApiResponse(200, {
+        schema: {
+          exclusiveMaximum: Number.POSITIVE_INFINITY,
+          type: 'number',
+        },
+      })
+      @Post('/')
+      create() {
+        return 1;
+      }
+    }
+
+    const descriptors = createHandlerMapping([{ controllerToken: NonFiniteBoundsController }]).descriptors;
+
+    // When
+    const buildDocument = () => buildOpenApiDocument({
+      defaultErrorResponsesPolicy: 'omit',
+      descriptors,
+      title: 'Non-finite Bounds API',
+      version: '1.0.0',
+    });
+
+    // Then
+    expect(buildDocument).toThrowError(TypeError);
+  });
+});

--- a/packages/openapi/src/schema-bounds.test.ts
+++ b/packages/openapi/src/schema-bounds.test.ts
@@ -2,7 +2,7 @@ import { Controller, createHandlerMapping, Post } from '@fluojs/http';
 import { describe, expect, it } from 'vitest';
 
 import { ApiBody, ApiQuery, ApiResponse } from './decorators.js';
-import { buildOpenApiDocument } from './schema-builder.js';
+import { buildOpenApiDocument, type OpenApiSchemaObject } from './schema-builder.js';
 
 describe('OpenAPI 3.1 exclusive bounds', () => {
   it('emits numeric exclusive bounds when typed metadata uses legacy booleans', () => {
@@ -125,6 +125,73 @@ describe('OpenAPI 3.1 exclusive bounds', () => {
       exclusiveMaximum: 100,
       type: 'number',
     });
+  });
+
+  it('preserves a transformed schema self-cycle while normalizing its bounds', () => {
+    // Given
+    const properties: Record<string, OpenApiSchemaObject> = {};
+    const recursiveSchema: OpenApiSchemaObject = {
+      exclusiveMinimum: true,
+      minimum: 0,
+      properties,
+      type: 'object',
+    };
+    properties.self = recursiveSchema;
+
+    // When
+    const document = buildOpenApiDocument({
+      defaultErrorResponsesPolicy: 'omit',
+      descriptors: [],
+      documentTransform: (generatedDocument) => ({
+        ...generatedDocument,
+        components: {
+          schemas: { RecursiveSchema: recursiveSchema },
+        },
+      }),
+      title: 'Recursive Bounds API',
+      version: '1.0.0',
+    });
+    const normalizedSchema = document.components?.schemas?.RecursiveSchema;
+
+    // Then
+    expect(normalizedSchema).toMatchObject({ exclusiveMinimum: 0, type: 'object' });
+    expect(normalizedSchema?.minimum).toBeUndefined();
+    expect(normalizedSchema?.properties?.self).toBe(normalizedSchema);
+  });
+
+  it('preserves shared schema identity in a transformed DAG while normalizing its bounds', () => {
+    // Given
+    const sharedBound: OpenApiSchemaObject = {
+      exclusiveMaximum: true,
+      maximum: 10,
+      type: 'number',
+    };
+    const transformedSchema: OpenApiSchemaObject = {
+      properties: {
+        first: sharedBound,
+        second: sharedBound,
+      },
+      type: 'object',
+    };
+
+    // When
+    const document = buildOpenApiDocument({
+      defaultErrorResponsesPolicy: 'omit',
+      descriptors: [],
+      documentTransform: (generatedDocument) => ({
+        ...generatedDocument,
+        components: {
+          schemas: { TransformedDag: transformedSchema },
+        },
+      }),
+      title: 'Shared Bounds API',
+      version: '1.0.0',
+    });
+    const normalizedProperties = document.components?.schemas?.TransformedDag?.properties;
+
+    // Then
+    expect(normalizedProperties?.first).toEqual({ exclusiveMaximum: 10, type: 'number' });
+    expect(normalizedProperties?.first).toBe(normalizedProperties?.second);
   });
 
   it('rejects a true legacy exclusive bound when its numeric bound is missing', () => {

--- a/packages/openapi/src/schema-bounds.ts
+++ b/packages/openapi/src/schema-bounds.ts
@@ -1,0 +1,193 @@
+import type {
+  OpenApiDocument,
+  OpenApiMediaTypeObject,
+  OpenApiOperationObject,
+  OpenApiPathItemObject,
+  OpenApiResponseObject,
+  OpenApiSchemaObject,
+} from './schema-builder.js';
+
+function normalizeSchemaRecord(
+  schemas: Record<string, OpenApiSchemaObject>,
+  path: string,
+): Record<string, OpenApiSchemaObject> {
+  const normalized: Record<string, OpenApiSchemaObject> = {};
+
+  for (const [name, schema] of Object.entries(schemas)) {
+    normalized[name] = normalizeOpenApiSchemaBounds(schema, `${path}.${name}`);
+  }
+
+  return normalized;
+}
+
+function normalizeSchemaList(
+  schemas: readonly OpenApiSchemaObject[],
+  path: string,
+): OpenApiSchemaObject[] {
+  return schemas.map((schema, index) => normalizeOpenApiSchemaBounds(schema, `${path}[${String(index)}]`));
+}
+
+function normalizeOpenApiSchemaBounds(schema: OpenApiSchemaObject, path: string): OpenApiSchemaObject {
+  const normalized: OpenApiSchemaObject = { ...schema };
+
+  if (typeof schema.exclusiveMinimum === 'number' && !Number.isFinite(schema.exclusiveMinimum)) {
+    throw new TypeError(`OpenAPI schema ${path}.exclusiveMinimum must be a finite number.`);
+  }
+
+  if (typeof schema.exclusiveMinimum === 'boolean') {
+    delete normalized.exclusiveMinimum;
+
+    if (schema.exclusiveMinimum) {
+      if (schema.minimum === undefined || !Number.isFinite(schema.minimum)) {
+        throw new TypeError(`OpenAPI schema ${path}.exclusiveMinimum requires a finite minimum.`);
+      }
+
+      normalized.exclusiveMinimum = schema.minimum;
+      delete normalized.minimum;
+    }
+  }
+
+  if (typeof schema.exclusiveMaximum === 'number' && !Number.isFinite(schema.exclusiveMaximum)) {
+    throw new TypeError(`OpenAPI schema ${path}.exclusiveMaximum must be a finite number.`);
+  }
+
+  if (typeof schema.exclusiveMaximum === 'boolean') {
+    delete normalized.exclusiveMaximum;
+
+    if (schema.exclusiveMaximum) {
+      if (schema.maximum === undefined || !Number.isFinite(schema.maximum)) {
+        throw new TypeError(`OpenAPI schema ${path}.exclusiveMaximum requires a finite maximum.`);
+      }
+
+      normalized.exclusiveMaximum = schema.maximum;
+      delete normalized.maximum;
+    }
+  }
+
+  if (schema.allOf) {
+    normalized.allOf = normalizeSchemaList(schema.allOf, `${path}.allOf`);
+  }
+
+  if (schema.oneOf) {
+    normalized.oneOf = normalizeSchemaList(schema.oneOf, `${path}.oneOf`);
+  }
+
+  if (schema.anyOf) {
+    normalized.anyOf = normalizeSchemaList(schema.anyOf, `${path}.anyOf`);
+  }
+
+  if (schema.not) {
+    normalized.not = normalizeOpenApiSchemaBounds(schema.not, `${path}.not`);
+  }
+
+  if (schema.properties) {
+    normalized.properties = normalizeSchemaRecord(schema.properties, `${path}.properties`);
+  }
+
+  if (schema.items) {
+    normalized.items = normalizeOpenApiSchemaBounds(schema.items, `${path}.items`);
+  }
+
+  if (typeof schema.additionalProperties === 'object') {
+    normalized.additionalProperties = normalizeOpenApiSchemaBounds(
+      schema.additionalProperties,
+      `${path}.additionalProperties`,
+    );
+  }
+
+  return normalized;
+}
+
+function normalizeContent(
+  content: Record<string, OpenApiMediaTypeObject>,
+  path: string,
+): Record<string, OpenApiMediaTypeObject> {
+  const normalized: Record<string, OpenApiMediaTypeObject> = {};
+
+  for (const [mediaType, media] of Object.entries(content)) {
+    normalized[mediaType] = {
+      ...media,
+      schema: normalizeOpenApiSchemaBounds(media.schema, `${path}.${mediaType}.schema`),
+    };
+  }
+
+  return normalized;
+}
+
+function normalizeResponses(
+  responses: Record<string, OpenApiResponseObject>,
+  path: string,
+): Record<string, OpenApiResponseObject> {
+  const normalized: Record<string, OpenApiResponseObject> = {};
+
+  for (const [status, response] of Object.entries(responses)) {
+    normalized[status] = {
+      ...response,
+      ...(response.content ? { content: normalizeContent(response.content, `${path}.${status}.content`) } : {}),
+    };
+  }
+
+  return normalized;
+}
+
+function normalizeOperation(operation: OpenApiOperationObject, path: string): OpenApiOperationObject {
+  return {
+    ...operation,
+    ...(operation.parameters
+      ? {
+          parameters: operation.parameters.map((parameter, index) => ({
+            ...parameter,
+            schema: normalizeOpenApiSchemaBounds(parameter.schema, `${path}.parameters[${String(index)}].schema`),
+          })),
+        }
+      : {}),
+    ...(operation.requestBody
+      ? {
+          requestBody: {
+            ...operation.requestBody,
+            content: normalizeContent(operation.requestBody.content, `${path}.requestBody.content`),
+          },
+        }
+      : {}),
+    responses: normalizeResponses(operation.responses, `${path}.responses`),
+  };
+}
+
+function normalizePaths(paths: Record<string, OpenApiPathItemObject>): Record<string, OpenApiPathItemObject> {
+  const normalizedPaths: Record<string, OpenApiPathItemObject> = {};
+
+  for (const [path, pathItem] of Object.entries(paths)) {
+    const normalizedPathItem: OpenApiPathItemObject = {};
+
+    for (const [method, operation] of Object.entries(pathItem)) {
+      normalizedPathItem[method] = operation ? normalizeOperation(operation, `paths.${path}.${method}`) : undefined;
+    }
+
+    normalizedPaths[path] = normalizedPathItem;
+  }
+
+  return normalizedPaths;
+}
+
+/**
+ * Normalize legacy boolean exclusive-bound metadata before an OpenAPI 3.1 document is exposed.
+ *
+ * @param document Generated document, including any final caller transform.
+ * @returns A detached document whose exclusive bounds use OpenAPI 3.1 numeric keywords.
+ */
+export function normalizeOpenApiDocumentSchemaBounds(document: OpenApiDocument): OpenApiDocument {
+  return {
+    ...document,
+    ...(document.components
+      ? {
+          components: {
+            ...document.components,
+            ...(document.components.schemas
+              ? { schemas: normalizeSchemaRecord(document.components.schemas, 'components.schemas') }
+              : {}),
+          },
+        }
+      : {}),
+    paths: normalizePaths(document.paths),
+  };
+}

--- a/packages/openapi/src/schema-bounds.ts
+++ b/packages/openapi/src/schema-bounds.ts
@@ -7,14 +7,17 @@ import type {
   OpenApiSchemaObject,
 } from './schema-builder.js';
 
+type NormalizedSchemaCache = WeakMap<OpenApiSchemaObject, OpenApiSchemaObject>;
+
 function normalizeSchemaRecord(
   schemas: Record<string, OpenApiSchemaObject>,
   path: string,
+  normalizedSchemas: NormalizedSchemaCache,
 ): Record<string, OpenApiSchemaObject> {
   const normalized: Record<string, OpenApiSchemaObject> = {};
 
   for (const [name, schema] of Object.entries(schemas)) {
-    normalized[name] = normalizeOpenApiSchemaBounds(schema, `${path}.${name}`);
+    normalized[name] = normalizeOpenApiSchemaBounds(schema, `${path}.${name}`, normalizedSchemas);
   }
 
   return normalized;
@@ -23,12 +26,28 @@ function normalizeSchemaRecord(
 function normalizeSchemaList(
   schemas: readonly OpenApiSchemaObject[],
   path: string,
+  normalizedSchemas: NormalizedSchemaCache,
 ): OpenApiSchemaObject[] {
-  return schemas.map((schema, index) => normalizeOpenApiSchemaBounds(schema, `${path}[${String(index)}]`));
+  return schemas.map((schema, index) => normalizeOpenApiSchemaBounds(
+    schema,
+    `${path}[${String(index)}]`,
+    normalizedSchemas,
+  ));
 }
 
-function normalizeOpenApiSchemaBounds(schema: OpenApiSchemaObject, path: string): OpenApiSchemaObject {
+function normalizeOpenApiSchemaBounds(
+  schema: OpenApiSchemaObject,
+  path: string,
+  normalizedSchemas: NormalizedSchemaCache,
+): OpenApiSchemaObject {
+  const cachedSchema = normalizedSchemas.get(schema);
+
+  if (cachedSchema) {
+    return cachedSchema;
+  }
+
   const normalized: OpenApiSchemaObject = { ...schema };
+  normalizedSchemas.set(schema, normalized);
 
   if (typeof schema.exclusiveMinimum === 'number' && !Number.isFinite(schema.exclusiveMinimum)) {
     throw new TypeError(`OpenAPI schema ${path}.exclusiveMinimum must be a finite number.`);
@@ -65,33 +84,34 @@ function normalizeOpenApiSchemaBounds(schema: OpenApiSchemaObject, path: string)
   }
 
   if (schema.allOf) {
-    normalized.allOf = normalizeSchemaList(schema.allOf, `${path}.allOf`);
+    normalized.allOf = normalizeSchemaList(schema.allOf, `${path}.allOf`, normalizedSchemas);
   }
 
   if (schema.oneOf) {
-    normalized.oneOf = normalizeSchemaList(schema.oneOf, `${path}.oneOf`);
+    normalized.oneOf = normalizeSchemaList(schema.oneOf, `${path}.oneOf`, normalizedSchemas);
   }
 
   if (schema.anyOf) {
-    normalized.anyOf = normalizeSchemaList(schema.anyOf, `${path}.anyOf`);
+    normalized.anyOf = normalizeSchemaList(schema.anyOf, `${path}.anyOf`, normalizedSchemas);
   }
 
   if (schema.not) {
-    normalized.not = normalizeOpenApiSchemaBounds(schema.not, `${path}.not`);
+    normalized.not = normalizeOpenApiSchemaBounds(schema.not, `${path}.not`, normalizedSchemas);
   }
 
   if (schema.properties) {
-    normalized.properties = normalizeSchemaRecord(schema.properties, `${path}.properties`);
+    normalized.properties = normalizeSchemaRecord(schema.properties, `${path}.properties`, normalizedSchemas);
   }
 
   if (schema.items) {
-    normalized.items = normalizeOpenApiSchemaBounds(schema.items, `${path}.items`);
+    normalized.items = normalizeOpenApiSchemaBounds(schema.items, `${path}.items`, normalizedSchemas);
   }
 
   if (typeof schema.additionalProperties === 'object') {
     normalized.additionalProperties = normalizeOpenApiSchemaBounds(
       schema.additionalProperties,
       `${path}.additionalProperties`,
+      normalizedSchemas,
     );
   }
 
@@ -101,13 +121,14 @@ function normalizeOpenApiSchemaBounds(schema: OpenApiSchemaObject, path: string)
 function normalizeContent(
   content: Record<string, OpenApiMediaTypeObject>,
   path: string,
+  normalizedSchemas: NormalizedSchemaCache,
 ): Record<string, OpenApiMediaTypeObject> {
   const normalized: Record<string, OpenApiMediaTypeObject> = {};
 
   for (const [mediaType, media] of Object.entries(content)) {
     normalized[mediaType] = {
       ...media,
-      schema: normalizeOpenApiSchemaBounds(media.schema, `${path}.${mediaType}.schema`),
+      schema: normalizeOpenApiSchemaBounds(media.schema, `${path}.${mediaType}.schema`, normalizedSchemas),
     };
   }
 
@@ -117,27 +138,38 @@ function normalizeContent(
 function normalizeResponses(
   responses: Record<string, OpenApiResponseObject>,
   path: string,
+  normalizedSchemas: NormalizedSchemaCache,
 ): Record<string, OpenApiResponseObject> {
   const normalized: Record<string, OpenApiResponseObject> = {};
 
   for (const [status, response] of Object.entries(responses)) {
     normalized[status] = {
       ...response,
-      ...(response.content ? { content: normalizeContent(response.content, `${path}.${status}.content`) } : {}),
+      ...(response.content
+        ? { content: normalizeContent(response.content, `${path}.${status}.content`, normalizedSchemas) }
+        : {}),
     };
   }
 
   return normalized;
 }
 
-function normalizeOperation(operation: OpenApiOperationObject, path: string): OpenApiOperationObject {
+function normalizeOperation(
+  operation: OpenApiOperationObject,
+  path: string,
+  normalizedSchemas: NormalizedSchemaCache,
+): OpenApiOperationObject {
   return {
     ...operation,
     ...(operation.parameters
       ? {
           parameters: operation.parameters.map((parameter, index) => ({
             ...parameter,
-            schema: normalizeOpenApiSchemaBounds(parameter.schema, `${path}.parameters[${String(index)}].schema`),
+            schema: normalizeOpenApiSchemaBounds(
+              parameter.schema,
+              `${path}.parameters[${String(index)}].schema`,
+              normalizedSchemas,
+            ),
           })),
         }
       : {}),
@@ -145,22 +177,27 @@ function normalizeOperation(operation: OpenApiOperationObject, path: string): Op
       ? {
           requestBody: {
             ...operation.requestBody,
-            content: normalizeContent(operation.requestBody.content, `${path}.requestBody.content`),
+            content: normalizeContent(operation.requestBody.content, `${path}.requestBody.content`, normalizedSchemas),
           },
         }
       : {}),
-    responses: normalizeResponses(operation.responses, `${path}.responses`),
+    responses: normalizeResponses(operation.responses, `${path}.responses`, normalizedSchemas),
   };
 }
 
-function normalizePaths(paths: Record<string, OpenApiPathItemObject>): Record<string, OpenApiPathItemObject> {
+function normalizePaths(
+  paths: Record<string, OpenApiPathItemObject>,
+  normalizedSchemas: NormalizedSchemaCache,
+): Record<string, OpenApiPathItemObject> {
   const normalizedPaths: Record<string, OpenApiPathItemObject> = {};
 
   for (const [path, pathItem] of Object.entries(paths)) {
     const normalizedPathItem: OpenApiPathItemObject = {};
 
     for (const [method, operation] of Object.entries(pathItem)) {
-      normalizedPathItem[method] = operation ? normalizeOperation(operation, `paths.${path}.${method}`) : undefined;
+      normalizedPathItem[method] = operation
+        ? normalizeOperation(operation, `paths.${path}.${method}`, normalizedSchemas)
+        : undefined;
     }
 
     normalizedPaths[path] = normalizedPathItem;
@@ -176,6 +213,8 @@ function normalizePaths(paths: Record<string, OpenApiPathItemObject>): Record<st
  * @returns A detached document whose exclusive bounds use OpenAPI 3.1 numeric keywords.
  */
 export function normalizeOpenApiDocumentSchemaBounds(document: OpenApiDocument): OpenApiDocument {
+  const normalizedSchemas: NormalizedSchemaCache = new WeakMap();
+
   return {
     ...document,
     ...(document.components
@@ -183,11 +222,11 @@ export function normalizeOpenApiDocumentSchemaBounds(document: OpenApiDocument):
           components: {
             ...document.components,
             ...(document.components.schemas
-              ? { schemas: normalizeSchemaRecord(document.components.schemas, 'components.schemas') }
+              ? { schemas: normalizeSchemaRecord(document.components.schemas, 'components.schemas', normalizedSchemas) }
               : {}),
           },
         }
       : {}),
-    paths: normalizePaths(document.paths),
+    paths: normalizePaths(document.paths, normalizedSchemas),
   };
 }

--- a/packages/openapi/src/schema-builder.ts
+++ b/packages/openapi/src/schema-builder.ts
@@ -1,13 +1,14 @@
 import type { Constructor, MetadataPropertyKey } from '@fluojs/core';
-import { getDtoBindingSchema, getDtoValidationSchema, type DtoFieldValidationRule } from '@fluojs/core/request-pipeline';
+import { type DtoFieldValidationRule, getDtoBindingSchema, getDtoValidationSchema } from '@fluojs/core/request-pipeline';
 import type { HandlerDescriptor, HttpMethod } from '@fluojs/http';
 import {
   type ApiParameterMetadata,
+  type ApiResponseMetadata,
   getControllerTags,
   getMethodApiMetadata,
-  type ApiResponseMetadata,
   type MethodApiMetadata,
 } from './decorators.js';
+import { normalizeOpenApiDocumentSchemaBounds } from './schema-bounds.js';
 import { cloneSnapshotValue } from './snapshot.js';
 
 type OpenApiOperationMethod = Lowercase<HttpMethod>;
@@ -1320,5 +1321,5 @@ export function buildOpenApiDocument(options: BuildOpenApiDocumentOptions): Open
     paths,
   };
 
-  return options.documentTransform ? options.documentTransform(document) : document;
+  return normalizeOpenApiDocumentSchemaBounds(options.documentTransform ? options.documentTransform(document) : document);
 }


### PR DESCRIPTION
## Summary

Correct `@fluojs/openapi` document generation so every emitted OpenAPI 3.1 exclusive bound is numeric while retaining the existing typed boolean metadata forms.

Linked context: Closes #2792

## Changes

- normalize legacy `true` plus `minimum`/`maximum` metadata into numeric exclusive bounds
- omit legacy `false` flags while preserving inclusive bounds, and retain finite numeric exclusive bounds
- reject only unnormalizable exclusive metadata instead of emitting an invalid OpenAPI 3.1 schema
- apply normalization recursively across parameters, request bodies, responses, components, and final `documentTransform` output
- align package and architecture documentation in English and Korean

## Testing

- `pnpm --dir packages/openapi test` (62 tests passed)
- `pnpm --dir packages/openapi typecheck`
- `pnpm build`
- `pnpm verify` (345 files passed; 4426 tests passed, 1 skipped)
- `pnpm docs:sync-check`
- `pnpm verify:platform-consistency-governance`
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main`
- `FLUO_CLI_SANDBOX_ROOT=<dedicated-temp> pnpm verify:release-readiness`
- changed TypeScript files passed Biome checks; TypeScript LSP was unavailable, so `tsc` typecheck/build served as diagnostics

## Release impact

- [x] This PR has consumer-visible release impact and includes `.changeset/emit-valid-openapi-exclusive-bounds.md`.
- [ ] This PR has no consumer-visible release impact.
- Semver intent: patch for `@fluojs/openapi`; no public metadata form was removed.

## Public export documentation

- [x] No root public export was added or removed.
- [x] The internal exported normalization seam includes the required source-level TSDoc.
- [x] `OpenApiSchemaObject` continues to accept both numeric and boolean exclusive-bound metadata.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] The new output normalization contract is documented in both package READMEs.
- [x] Unnormalizable `true` flags and non-finite numeric exclusive bounds fail explicitly.
- [x] Regression tests cover typed boolean compatibility, numeric output, final transforms, and rejection paths.

## Platform consistency governance (SSOT)

- [x] `docs/architecture/openapi.md` and `docs/architecture/openapi.ko.md` are synchronized.
- [x] Package README English/Korean parity is preserved.
- [x] Platform consistency governance and release-readiness checks pass.
- [x] No platform adapter contract changed; platform conformance harness changes are not applicable.