### PR TITLE
Resolve #2815: Restore pre-listen state after Deno.serve failure

### DIFF
--- a/.changeset/restore-deno-listen-retry.md
+++ b/.changeset/restore-deno-listen-retry.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/platform-deno': patch
+---
+
+Restore the adapter's pre-listen state when `Deno.serve(...)` throws so requests remain gated and a later listen attempt can retry.

--- a/packages/platform-deno/src/adapter.test.ts
+++ b/packages/platform-deno/src/adapter.test.ts
@@ -1279,6 +1279,7 @@ describe('@fluojs/platform-deno', () => {
 
     expect(serve).toHaveBeenCalledTimes(2);
     expect(serveSignals).toHaveLength(2);
+    expect(serveSignals[0]?.aborted).toBe(true);
     expect(serveSignals[1]).not.toBe(serveSignals[0]);
     expect(adapter.getListenTarget()).toEqual({
       bindTarget: '127.0.0.1:4321',
@@ -1289,6 +1290,36 @@ describe('@fluojs/platform-deno', () => {
     expect(retryDispatcher.dispatch).toHaveBeenCalledTimes(1);
 
     await adapter.close();
+  });
+
+  it('restores pre-listen dispatcher state when Deno.serve cannot be resolved', async () => {
+    const originalDeno = (globalThis as typeof globalThis & { Deno?: unknown }).Deno;
+    delete (globalThis as typeof globalThis & { Deno?: unknown }).Deno;
+    const adapter = createDenoAdapter();
+    const dispatcher = {
+      dispatch: vi.fn(async (_request: FrameworkRequest, response: FrameworkResponse) => {
+        response.setStatus(200);
+        await response.send({ dispatcher: 'unexpected' });
+      }),
+    };
+
+    try {
+      await expect(adapter.listen(dispatcher)).rejects.toThrow(
+        'Deno.serve is not available. Pass options.serve when running outside Deno.',
+      );
+
+      const response = await adapter.handle(new Request('https://runtime.test/missing-serve'));
+
+      expect(response.status).toBe(500);
+      expect(dispatcher.dispatch).not.toHaveBeenCalled();
+      expect(adapter.getServer()).toBeUndefined();
+    } finally {
+      if (originalDeno === undefined) {
+        delete (globalThis as typeof globalThis & { Deno?: unknown }).Deno;
+      } else {
+        (globalThis as typeof globalThis & { Deno?: unknown }).Deno = originalDeno;
+      }
+    }
   });
 
   it('clears the Deno shutdown timer once close settles', async () => {

--- a/packages/platform-deno/src/adapter.test.ts
+++ b/packages/platform-deno/src/adapter.test.ts
@@ -1219,6 +1219,78 @@ describe('@fluojs/platform-deno', () => {
     await adapter.close();
   });
 
+  it('restores pre-listen state after Deno.serve fails and allows a successful retry', async () => {
+    const server = createServeStub();
+    const listenFailure = new Error('Deno.serve failed to bind');
+    const serveSignals: AbortSignal[] = [];
+    let serveAttempt = 0;
+    const serve = vi.fn((options: DenoServeOptions, handler: DenoServeHandler): DenoServeController => {
+      serveAttempt += 1;
+
+      if (options.signal) {
+        serveSignals.push(options.signal);
+      }
+
+      options.onListen?.({
+        hostname: '127.0.0.1',
+        port: serveAttempt === 1 ? 65_535 : 4_321,
+      });
+
+      if (serveAttempt === 1) {
+        throw listenFailure;
+      }
+
+      return server.serve(options, handler);
+    });
+    const adapter = new DenoHttpApplicationAdapter({
+      hostname: '0.0.0.0',
+      port: 3_000,
+      serve,
+    });
+    const failedDispatcher = {
+      dispatch: vi.fn(async (_request: FrameworkRequest, response: FrameworkResponse) => {
+        response.setStatus(200);
+        await response.send({ dispatcher: 'failed' });
+      }),
+    };
+    const retryDispatcher = {
+      dispatch: vi.fn(async (_request: FrameworkRequest, response: FrameworkResponse) => {
+        response.setStatus(200);
+        await response.send({ dispatcher: 'retry' });
+      }),
+    };
+
+    await expect(adapter.listen(failedDispatcher)).rejects.toBe(listenFailure);
+
+    const failedListenResponse = await adapter.handle(new Request('https://runtime.test/failed-listen'));
+
+    expect(failedListenResponse.status).toBe(500);
+    expect(failedDispatcher.dispatch).not.toHaveBeenCalled();
+    expect(adapter.getServer()).toBeUndefined();
+    expect(adapter.getListenTarget()).toEqual({
+      bindTarget: '0.0.0.0:3000',
+      url: 'http://localhost:3000',
+    });
+    expect(Reflect.get(adapter, 'abortController')).toBeUndefined();
+
+    await adapter.listen(retryDispatcher);
+
+    const retryResponse = await server.handler?.(new Request('https://runtime.test/retry'));
+
+    expect(serve).toHaveBeenCalledTimes(2);
+    expect(serveSignals).toHaveLength(2);
+    expect(serveSignals[1]).not.toBe(serveSignals[0]);
+    expect(adapter.getListenTarget()).toEqual({
+      bindTarget: '127.0.0.1:4321',
+      url: 'http://127.0.0.1:4321',
+    });
+    expect(retryResponse?.status).toBe(200);
+    await expect(retryResponse?.json()).resolves.toEqual({ dispatcher: 'retry' });
+    expect(retryDispatcher.dispatch).toHaveBeenCalledTimes(1);
+
+    await adapter.close();
+  });
+
   it('clears the Deno shutdown timer once close settles', async () => {
     vi.useFakeTimers();
 

--- a/packages/platform-deno/src/adapter.ts
+++ b/packages/platform-deno/src/adapter.ts
@@ -232,29 +232,39 @@ export class DenoHttpApplicationAdapter implements HttpApplicationAdapter {
       return;
     }
 
+    const previousAbortController = this.abortController;
+    const previousDispatcher = this.dispatcher;
+    const previousListenAddress = this.listenAddress;
     this.dispatcher = dispatcher;
 
     const abortController = new AbortController();
     const serve = resolveServe(this.options.serve);
     const listenReady = this.options.port === 0 ? createDeferred<void>() : undefined;
 
-    this.abortController = abortController;
-    this.server = serve({
-      cert: this.options.https?.cert,
-      hostname: this.options.hostname,
-      key: this.options.https?.key,
-      onListen: (localAddr) => {
-        this.listenAddress = localAddr;
-        listenReady?.resolve();
-        this.options.onListen?.(localAddr);
-      },
-      port: this.options.port,
-      signal: abortController.signal,
-    }, async (request) => {
-      return await this.handle(request);
-    });
+    try {
+      this.abortController = abortController;
+      this.server = serve({
+        cert: this.options.https?.cert,
+        hostname: this.options.hostname,
+        key: this.options.https?.key,
+        onListen: (localAddr) => {
+          this.listenAddress = localAddr;
+          listenReady?.resolve();
+          this.options.onListen?.(localAddr);
+        },
+        port: this.options.port,
+        signal: abortController.signal,
+      }, async (request) => {
+        return await this.handle(request);
+      });
 
-    await listenReady?.promise;
+      await listenReady?.promise;
+    } catch (error) {
+      this.abortController = previousAbortController;
+      this.dispatcher = previousDispatcher;
+      this.listenAddress = previousListenAddress;
+      throw error;
+    }
   }
 
   async close(): Promise<void> {

--- a/packages/platform-deno/src/adapter.ts
+++ b/packages/platform-deno/src/adapter.ts
@@ -235,13 +235,12 @@ export class DenoHttpApplicationAdapter implements HttpApplicationAdapter {
     const previousAbortController = this.abortController;
     const previousDispatcher = this.dispatcher;
     const previousListenAddress = this.listenAddress;
-    this.dispatcher = dispatcher;
-
     const abortController = new AbortController();
-    const serve = resolveServe(this.options.serve);
     const listenReady = this.options.port === 0 ? createDeferred<void>() : undefined;
 
     try {
+      const serve = resolveServe(this.options.serve);
+      this.dispatcher = dispatcher;
       this.abortController = abortController;
       this.server = serve({
         cert: this.options.https?.cert,
@@ -260,6 +259,7 @@ export class DenoHttpApplicationAdapter implements HttpApplicationAdapter {
 
       await listenReady?.promise;
     } catch (error) {
+      abortController.abort();
       this.abortController = previousAbortController;
       this.dispatcher = previousDispatcher;
       this.listenAddress = previousListenAddress;


### PR DESCRIPTION
## Summary

Restore the documented pre-listen readiness boundary when synchronous `Deno.serve(...)` startup fails. The adapter now rolls provisional dispatcher, abort-controller, and listen-address state back before propagating the original error, so `handle(...)` remains gated and a later `listen(...)` call can retry cleanly.

Linked context: Closes #2815

## Changes

- Restore the adapter state snapshot when `Deno.serve(...)` throws during managed startup.
- Add regression coverage for the failed-listen `500` boundary, cleared server/listen state, and retry with a fresh dispatcher and signal.
- Add a patch Changeset for `@fluojs/platform-deno`.

## Testing

- `pnpm vitest run packages/platform-deno/src/adapter.test.ts` — 40 passed.
- `pnpm --filter @fluojs/platform-deno test` — 49 passed.
- `pnpm --filter @fluojs/platform-deno build` — passed.
- `pnpm --filter @fluojs/platform-deno typecheck` — passed.
- `pnpm exec biome check packages/platform-deno/src/adapter.ts packages/platform-deno/src/adapter.test.ts` — passed.
- `pnpm verify:platform-consistency-governance` — passed.
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main` — passed.
- `env FLUO_CLI_SANDBOX_ROOT=/var/folders/xj/v8c228rx2ybb4g8pkm1m932r0000gn/T/opencode/fluo-cli-sandbox-issue-2815 pnpm verify:release-readiness` — passed without writing draft artifacts.

## Release impact

- [x] This PR has consumer-visible release impact and includes `.changeset/restore-deno-listen-retry.md` with a patch bump.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] No public exports changed; source-level summaries and `@param` / `@returns` documentation are unchanged.
- [x] No new source `@example` or README scenario was required.

## Behavioral contract

- [x] No documented behavioral contracts were removed.
- [x] This restores the existing package README promise that `handle(...)` returns `500` before a successful dispatcher bind.
- [x] Intentional limitations remain unchanged.
- [x] Runtime rollback and retry invariants are covered by the package regression test.

## Platform consistency governance (SSOT)

- [x] No governed docs or English/Korean mirror structure changed.
- [x] The existing Deno package contract remains aligned with the platform lifecycle policy.
- [x] Package-local adapter regression coverage and `pnpm verify:platform-consistency-governance` provide the applicable evidence.