### PR TITLE
Resolve #2796: Remove remote-loader abort listener after settlement

### DIFF
--- a/.changeset/cleanup-i18n-remote-aborts.md
+++ b/.changeset/cleanup-i18n-remote-aborts.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/i18n': patch
+---
+
+Remove each remote catalog load's internal abort listener after the load succeeds or fails while preserving timeout and caller cancellation behavior.

--- a/packages/i18n/src/loaders/remote.lifecycle.test.ts
+++ b/packages/i18n/src/loaders/remote.lifecycle.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { RemoteI18nLoader } from './remote.js';
+
+describe('RemoteI18nLoader abort listener lifecycle', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('removes the provider-visible abort listener after a successful load', async () => {
+    let observedSignal: AbortSignal | undefined;
+    let resolveProvider: ((catalog: { readonly title: string }) => void) | undefined;
+    const providerResult = new Promise<{ readonly title: string }>((resolve) => {
+      resolveProvider = resolve;
+    });
+    const loader = new RemoteI18nLoader({
+      provider: ({ signal }) => {
+        observedSignal = signal;
+        return providerResult;
+      },
+    });
+
+    const addEventListener = vi.spyOn(AbortSignal.prototype, 'addEventListener');
+    const load = loader.load('en', 'common');
+    if (observedSignal === undefined || resolveProvider === undefined) {
+      throw new Error('Expected the provider to start synchronously.');
+    }
+    const removeEventListener = vi.spyOn(observedSignal, 'removeEventListener');
+
+    resolveProvider({ title: 'Welcome' });
+
+    await expect(load).resolves.toEqual({ title: 'Welcome' });
+    const registeredListener = addEventListener.mock.calls[0]?.[1];
+    expect(registeredListener).toEqual(expect.any(Function));
+    expect(removeEventListener).toHaveBeenCalledWith('abort', registeredListener);
+  });
+
+  it('removes the provider-visible abort listener after a failed load', async () => {
+    let observedSignal: AbortSignal | undefined;
+    let rejectProvider: ((error: Error) => void) | undefined;
+    const providerResult = new Promise<never>((_resolve, reject) => {
+      rejectProvider = reject;
+    });
+    const loader = new RemoteI18nLoader({
+      provider: ({ signal }) => {
+        observedSignal = signal;
+        return providerResult;
+      },
+    });
+
+    const addEventListener = vi.spyOn(AbortSignal.prototype, 'addEventListener');
+    const load = loader.load('en', 'common');
+    if (observedSignal === undefined || rejectProvider === undefined) {
+      throw new Error('Expected the provider to start synchronously.');
+    }
+    const removeEventListener = vi.spyOn(observedSignal, 'removeEventListener');
+
+    rejectProvider(new Error('network unavailable'));
+
+    await expect(load).rejects.toMatchObject({ code: 'I18N_LOADER_FAILED' });
+    const registeredListener = addEventListener.mock.calls[0]?.[1];
+    expect(registeredListener).toEqual(expect.any(Function));
+    expect(removeEventListener).toHaveBeenCalledWith('abort', registeredListener);
+  });
+
+  it('removes the provider-visible abort listener after a timeout abort', async () => {
+    vi.useFakeTimers();
+    let observedSignal: AbortSignal | undefined;
+    const loader = new RemoteI18nLoader({
+      provider: ({ signal }) => {
+        observedSignal = signal;
+        return new Promise<never>(() => undefined);
+      },
+      timeoutMs: 100,
+    });
+
+    const addEventListener = vi.spyOn(AbortSignal.prototype, 'addEventListener');
+
+    try {
+      const load = loader.load('en', 'common');
+      if (observedSignal === undefined) {
+        throw new Error('Expected the provider to start synchronously.');
+      }
+      const removeEventListener = vi.spyOn(observedSignal, 'removeEventListener');
+      const rejection = expect(load).rejects.toMatchObject({ code: 'I18N_LOADER_TIMEOUT' });
+
+      await vi.advanceTimersByTimeAsync(100);
+
+      await rejection;
+      const registeredListener = addEventListener.mock.calls[0]?.[1];
+      expect(registeredListener).toEqual(expect.any(Function));
+      expect(removeEventListener).toHaveBeenCalledWith('abort', registeredListener);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/i18n/src/loaders/remote.ts
+++ b/packages/i18n/src/loaders/remote.ts
@@ -201,12 +201,10 @@ export class RemoteI18nLoader implements I18nLoader {
     const controller = new AbortController();
     const unlinkCallerAbort = linkCallerAbort(options.signal, controller);
     const timeout = setTimeout(() => controller.abort(createTimeoutError()), this.timeoutMs);
+    let rejectOnAbort: (() => void) | undefined;
     const abortRace = new Promise<never>((_resolve, reject) => {
-      controller.signal.addEventListener(
-        'abort',
-        () => reject(controller.signal.reason instanceof I18nError ? controller.signal.reason : createAbortError()),
-        { once: true },
-      );
+      rejectOnAbort = () => reject(controller.signal.reason instanceof I18nError ? controller.signal.reason : createAbortError());
+      controller.signal.addEventListener('abort', rejectOnAbort, { once: true });
     });
 
     try {
@@ -223,6 +221,9 @@ export class RemoteI18nLoader implements I18nLoader {
     } finally {
       clearTimeout(timeout);
       unlinkCallerAbort();
+      if (rejectOnAbort !== undefined) {
+        controller.signal.removeEventListener('abort', rejectOnAbort);
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Remove the provider-visible internal abort listener owned by each remote i18n catalog load once that load settles.

Linked context: https://github.com/fluojs/fluo/issues/2796

Closes #2796

## Changes

- retain the internal abort callback so `RemoteI18nLoader.load()` can unregister it in `finally`
- cover listener cleanup after successful, failed, and timeout-aborted loads
- add a patch changeset for `@fluojs/i18n`

## Testing

- `pnpm --filter @fluojs/i18n test -- src/loaders/remote.lifecycle.test.ts` — passed (11 files, 97 tests)
- `pnpm --filter @fluojs/i18n typecheck` — passed
- `pnpm --filter @fluojs/i18n build` — passed
- `pnpm exec biome check packages/i18n/src/loaders/remote.ts packages/i18n/src/loaders/remote.lifecycle.test.ts` — passed
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main` — passed
- `FLUO_CLI_SANDBOX_ROOT=/var/folders/xj/v8c228rx2ybb4g8pkm1m932r0000gn/T/opencode/fluo-cli-sandbox-2796-recovery pnpm verify:release-readiness` — passed

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Patch rationale: this fixes resource cleanup without changing the documented remote-loader API or error behavior.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No public exports or their TSDoc changed; the existing documented surface remains unchanged.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

This is a contract-preserving cleanup fix. No new caller-visible contract or documentation update is required; lifecycle regressions cover every settlement category.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests, such as `createPlatformConformanceHarness(...)` for platform component contracts or `createHttpAdapterPortabilityHarness(...)` for HTTP adapter portability contracts.

No governance docs, platform contracts, or package README claims changed; the release-readiness governance gate passed.