### PR TITLE
Resolve #2803: Cancel unfinished React SSR and Flight readers

### DIFF
--- a/.changeset/cancel-react-stream-readers.md
+++ b/.changeset/cancel-react-stream-readers.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/react": patch
+---
+
+Cancel unfinished SSR and experimental Flight readers when response sinks close or writes fail, releasing reader locks without masking sink errors.

--- a/packages/react/README.ko.md
+++ b/packages/react/README.ko.md
@@ -27,8 +27,8 @@ fluo 애플리케이션을 위한 런타임 중립 React 통합입니다.
 
 ## 설치
 
-이 패키지의 첫 공개 릴리스 목표는 `0.1.0`입니다. manifest는 `0.0.0`에서 시작해
-Changesets가 표준 릴리스 워크플로를 통해 초기 `0.1.0` 버전을 게시할 수 있게 합니다.
+이 패키지는 초기 `0.1.0` 릴리스를 완료했으며 더 이상 `0.0.0` bootstrap placeholder를 사용하지
+않습니다. 이후 버전은 commit된 Changeset으로 기록하고 canonical release workflow를 통해서만 게시합니다.
 
 패키지가 게시되면 React와 React DOM을 peer로 함께 설치합니다.
 
@@ -212,6 +212,9 @@ Renderer는 기본적으로 `react-dom/server`의 `renderToReadableStream(...)`�
 throw합니다. Recoverable Suspense error는 `onRecoverableError`로 보고되며 이미 committed된 status를 다시
 쓰지 않습니다. Handler가 entry를 dispatcher에 반환하지 않고 직접 response를 finalize해야 할 때만
 `renderReactResponse(entry, requestContext)`를 호출하세요.
+Streaming host에서는 response sink가 일찍 닫히거나 `write(...)` / `waitForDrain()`이 실패하면 완료되지
+않은 React reader를 정확히 한 번 cancel하고 lock을 해제합니다. Sink failure는 reader cancellation cleanup에
+의해 대체되지 않고 원래 failure로 보고됩니다.
 
 ## Hydration Asset Contract
 
@@ -474,6 +477,10 @@ Flight encoding도 애플리케이션이 소유합니다. 선택한 renderer가 
 interceptor, request scope, error, adapter response writing을 계속 소유합니다. Helper는 고정된
 `text/x-component; charset=utf-8` content type만 추가하며 별도 router를 만들지 않습니다.
 
+Streamed Flight payload도 stable SSR과 같은 lifecycle guarantee를 사용합니다. Response sink가 일찍 닫히거나
+write/drain이 실패하면 완료되지 않은 reader를 정확히 한 번 cancel하고 lock을 해제하며, sink failure는 일반
+HTTP error pipeline에 그대로 전달합니다.
+
 ```ts
 import { Controller, Get } from '@fluojs/http';
 import { createReactFlightResponse } from '@fluojs/react/experimental/rsc';
@@ -659,13 +666,28 @@ stable subpath를 추가하지 않고 deprecation window도 시작하지 않습�
   `ReactViteResolvedEntry`를 제공합니다.
 - `@fluojs/react/client` subpath — root package를 넓히거나 client route grammar를 추가하지 않고
   progressive HTTP-first browser navigation을 제공하는 `Link`, `ReactClientRouterProvider`,
-  `createReactRouteSnapshot(...)`, `useRouter()`, `usePathname()`, `useParams()`,
-  `useSearchParams()`, `useNavigation()`, `useRouterState()`를 제공합니다.
-- `@fluojs/react/experimental/rsc` subpath — root re-export 없이 `inspectReactRscEnvironment(...)`,
-  `createReactRscManifest(...)`, `createReactFlightResponse(...)`, exact-version 및 Flight content type
-  constant, diagnostic, client-reference/server-module mapping type, signed
-  `createReactServerFunctionRegistry(...)`, 명시적인 `createReactServerFunctionClient(...)`, stable Server
-  Function error code와 관련 transport type을 제공하며 root나 stable-client에서 re-export하지 않습니다.
+  `ReactClientNavigationError`, `ReactClientRouterContextError`, `createReactRouteSnapshot(...)`,
+  `useRouter()`, `usePathname()`, `useParams()`, `useSearchParams()`, `useNavigation()`,
+  `useRouterState()`를 제공합니다. Type export는 `LinkProps`, `ReactClientNavigationErrorCode`,
+  `ReactClientRouterProviderProps`, `ReactNavigationSnapshot`, `ReactNavigationStatus`,
+  `ReactNavigationType`, `ReactReadonlySearchParams`, `ReactRouteSnapshot`,
+  `ReactRouteSnapshotInput`, `ReactRouter`입니다.
+- `@fluojs/react/experimental/rsc` subpath — runtime export는 `REACT_RSC_DIAGNOSTIC_CODES`,
+  `REACT_RSC_FLIGHT_CONTENT_TYPE`, `REACT_RSC_SUPPORTED_VERSION`,
+  `REACT_SERVER_FUNCTION_ERROR_CODES`, `REACT_SERVER_FUNCTION_REQUEST_HEADER`,
+  `ReactServerFunctionClientError`, `ReactServerFunctionConfigurationError`,
+  `createReactFlightResponse(...)`, `createReactRscManifest(...)`,
+  `createReactServerFunctionClient(...)`, `createReactServerFunctionRegistry(...)`,
+  `inspectReactRscEnvironment(...)`입니다. Type export는 `ReactFlightPayload`, `ReactFlightResponse`,
+  `ReactFlightResponseHeaders`, `ReactFlightResponseOptions`, `ReactRscBuildCapabilities`,
+  `ReactRscClientReference`, `ReactRscClientReferenceManifest`, `ReactRscDiagnostic`,
+  `ReactRscDiagnosticCode`, `ReactRscEnvironmentOptions`, `ReactRscManifest`,
+  `ReactRscManifestInput`, `ReactRscManifestResult`, `ReactRscRuntimeCapabilities`,
+  `ReactRscServerClientModuleMap`, `ReactRscSupportResult`, `ReactServerFunctionClient`,
+  `ReactServerFunctionClientOptions`, `ReactServerFunctionErrorCode`, `ReactServerFunctionFetch`,
+  `ReactServerFunctionHandler`, `ReactServerFunctionReference`, `ReactServerFunctionRegistry`,
+  `ReactServerFunctionRegistryOptions`, `ReactServerFunctionResponse`,
+  `ReactServerFunctionValue`이며 root나 stable client subpath에서 re-export하지 않습니다.
 
 ## 관련 패키지
 
@@ -689,6 +711,7 @@ stable subpath를 추가하지 않고 deprecation window도 시작하지 않습�
 - `packages/react/src/experimental/rsc.test.ts`
 - `packages/react/src/experimental/rsc-diagnostics.test.ts`
 - `packages/react/src/experimental/rsc-flight.test.ts`
+- `packages/react/src/experimental/rsc-flight-stream-lifecycle.test.ts`
 - `packages/react/src/experimental/rsc-manifest.test.ts`
 - `packages/react/src/experimental/server-functions-server.ts`
 - `packages/react/src/experimental/server-functions-client.ts`

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -27,9 +27,9 @@ Runtime-neutral React integration for fluo applications.
 
 ## Installation
 
-The first public release target for this package is `0.1.0`. The manifest starts at
-`0.0.0` so Changesets can publish the initial `0.1.0` version through the canonical
-release workflow.
+The package has completed its initial `0.1.0` release and no longer uses the `0.0.0` bootstrap
+placeholder. Future versions are recorded through committed Changesets and published only through
+the canonical release workflow.
 
 When the package is published, install it with React and React DOM as peers:
 
@@ -216,6 +216,9 @@ when an adapter provides one, and throws shell render failures before response b
 Recoverable Suspense errors are reported through `onRecoverableError` and do not rewrite an already
 committed status. Call `renderReactResponse(entry, requestContext)` directly only when a custom
 handler needs to finalize the response itself instead of returning the entry to the dispatcher.
+On streaming hosts, an early response-sink close or a failed `write(...)` / `waitForDrain()` cancels
+the unfinished React reader exactly once and releases its lock. Sink failures remain the reported
+failure rather than being replaced by reader-cancellation cleanup.
 
 ## Hydration Asset Contract
 
@@ -483,6 +486,10 @@ metadata, middleware, guards, interceptors, request scopes, errors, and adapter 
 the helper adds the fixed `text/x-component; charset=utf-8` content type and does not create a
 parallel router.
 
+Streamed Flight payloads use the same lifecycle guarantee as stable SSR: an early response-sink
+close or a failed write/drain cancels the unfinished reader exactly once, releases its lock, and
+preserves the sink failure for the ordinary HTTP error pipeline.
+
 ```ts
 import { Controller, Get } from '@fluojs/http';
 import { createReactFlightResponse } from '@fluojs/react/experimental/rsc';
@@ -670,15 +677,29 @@ This package currently does **not** provide:
   `ReactViteJavaScriptAssets`, `ReactViteBootstrapData`, and `ReactViteResolvedEntry` for parsing Vite
   manifests into the stable hydration asset contract without importing Vite from the root.
 - `@fluojs/react/client` subpath — `Link`, `ReactClientRouterProvider`,
-  `createReactRouteSnapshot(...)`, `useRouter()`, `usePathname()`, `useParams()`,
-  `useSearchParams()`, `useNavigation()`, and `useRouterState()` for progressive HTTP-first browser
-  navigation without widening the root package or adding a client route grammar.
-- `@fluojs/react/experimental/rsc` subpath — `inspectReactRscEnvironment(...)`,
-  `createReactRscManifest(...)`, `createReactFlightResponse(...)`, exact-version and Flight content
-  type constants, diagnostics, client-reference/server-module mapping types, signed
-  `createReactServerFunctionRegistry(...)`, explicit `createReactServerFunctionClient(...)`, stable
-  Server Function error codes, and related transport types without any root or stable-client
-  re-export.
+  `ReactClientNavigationError`, `ReactClientRouterContextError`, `createReactRouteSnapshot(...)`,
+  `useRouter()`, `usePathname()`, `useParams()`, `useSearchParams()`, `useNavigation()`, and
+  `useRouterState()` for progressive HTTP-first browser navigation without widening the root package
+  or adding a client route grammar. Type exports are `LinkProps`, `ReactClientNavigationErrorCode`,
+  `ReactClientRouterProviderProps`, `ReactNavigationSnapshot`, `ReactNavigationStatus`,
+  `ReactNavigationType`, `ReactReadonlySearchParams`, `ReactRouteSnapshot`,
+  `ReactRouteSnapshotInput`, and `ReactRouter`.
+- `@fluojs/react/experimental/rsc` subpath — runtime exports are `REACT_RSC_DIAGNOSTIC_CODES`,
+  `REACT_RSC_FLIGHT_CONTENT_TYPE`, `REACT_RSC_SUPPORTED_VERSION`,
+  `REACT_SERVER_FUNCTION_ERROR_CODES`, `REACT_SERVER_FUNCTION_REQUEST_HEADER`,
+  `ReactServerFunctionClientError`, `ReactServerFunctionConfigurationError`,
+  `createReactFlightResponse(...)`, `createReactRscManifest(...)`,
+  `createReactServerFunctionClient(...)`, `createReactServerFunctionRegistry(...)`, and
+  `inspectReactRscEnvironment(...)`. Type exports are `ReactFlightPayload`, `ReactFlightResponse`,
+  `ReactFlightResponseHeaders`, `ReactFlightResponseOptions`, `ReactRscBuildCapabilities`,
+  `ReactRscClientReference`, `ReactRscClientReferenceManifest`, `ReactRscDiagnostic`,
+  `ReactRscDiagnosticCode`, `ReactRscEnvironmentOptions`, `ReactRscManifest`,
+  `ReactRscManifestInput`, `ReactRscManifestResult`, `ReactRscRuntimeCapabilities`,
+  `ReactRscServerClientModuleMap`, `ReactRscSupportResult`, `ReactServerFunctionClient`,
+  `ReactServerFunctionClientOptions`, `ReactServerFunctionErrorCode`, `ReactServerFunctionFetch`,
+  `ReactServerFunctionHandler`, `ReactServerFunctionReference`, `ReactServerFunctionRegistry`,
+  `ReactServerFunctionRegistryOptions`, `ReactServerFunctionResponse`, and
+  `ReactServerFunctionValue`. None are re-exported from the root or stable client subpath.
 
 ## Related Packages
 
@@ -703,6 +724,7 @@ This package currently does **not** provide:
 - `packages/react/src/experimental/rsc.test.ts`
 - `packages/react/src/experimental/rsc-diagnostics.test.ts`
 - `packages/react/src/experimental/rsc-flight.test.ts`
+- `packages/react/src/experimental/rsc-flight-stream-lifecycle.test.ts`
 - `packages/react/src/experimental/rsc-manifest.test.ts`
 - `packages/react/src/experimental/server-functions-server.ts`
 - `packages/react/src/experimental/server-functions-client.ts`

--- a/packages/react/src/experimental/rsc-flight-stream-lifecycle.test.ts
+++ b/packages/react/src/experimental/rsc-flight-stream-lifecycle.test.ts
@@ -13,8 +13,9 @@ import { createReactFlightResponse } from './rsc.js';
 
 type TestStreamOptions = {
   readonly closeAfterFlush?: boolean;
+  readonly onCloseListenerRemoved?: () => void;
   readonly onUnobservedClose?: () => void;
-  readonly waitForDrain?: () => Promise<void>;
+  readonly waitForDrain?: (emitClose: () => void) => Promise<void>;
   readonly write?: (chunk: string | Uint8Array) => boolean;
 };
 
@@ -57,20 +58,24 @@ function createResponse(stream: FrameworkResponseStream): FrameworkResponse {
 
 function createResponseStream(options: TestStreamOptions = {}): FrameworkResponseStream {
   const closeListeners = new Set<() => void>();
+  const waitForDrain = options.waitForDrain;
   let closed = false;
+  const emitClose = (): void => {
+    const listeners = [...closeListeners];
+    for (const listener of listeners) {
+      listener();
+    }
+    if (listeners.length === 0) {
+      options.onUnobservedClose?.();
+    }
+  };
   const stream: FrameworkResponseStream = {
     close() {
       if (closed) {
         return;
       }
       closed = true;
-      const listeners = [...closeListeners];
-      for (const listener of listeners) {
-        listener();
-      }
-      if (listeners.length === 0) {
-        options.onUnobservedClose?.();
-      }
+      emitClose();
     },
     get closed() {
       return closed;
@@ -87,10 +92,11 @@ function createResponseStream(options: TestStreamOptions = {}): FrameworkRespons
       }
       closeListeners.add(listener);
       return () => {
+        options.onCloseListenerRemoved?.();
         closeListeners.delete(listener);
       };
     },
-    waitForDrain: options.waitForDrain ?? (() => Promise.resolve()),
+    waitForDrain: waitForDrain ? () => waitForDrain(emitClose) : () => Promise.resolve(),
     write: options.write ?? (() => !closed),
   };
 
@@ -157,6 +163,55 @@ describe('experimental RSC Flight stream lifecycle', () => {
     }
   });
 
+  it('cancels before another Flight read when sink close resolves drain without marking the response closed', async () => {
+    // Given: a Node-like Flight sink whose close event resolves backpressure without setting closed.
+    const cancel = vi.fn();
+    const removeCloseListener = vi.fn();
+    let hostClosed = false;
+    let pullCount = 0;
+    let readAfterClose = false;
+    const source = new ReadableStream<Uint8Array>({
+      cancel,
+      pull(controller) {
+        pullCount += 1;
+        if (pullCount === 1) {
+          controller.enqueue(new Uint8Array([1]));
+          return;
+        }
+
+        readAfterClose = hostClosed;
+        controller.close();
+      },
+    }, { highWaterMark: 0 });
+    const stream = createResponseStream({
+      onCloseListenerRemoved: removeCloseListener,
+      waitForDrain: (emitClose) => {
+        return new Promise<void>((resolve) => {
+          queueMicrotask(() => {
+            hostClosed = true;
+            emitClose();
+            resolve();
+          });
+        });
+      },
+      write: () => false,
+    });
+    const app = await bootstrapStreamingFlightApp(source);
+
+    try {
+      // When: ordinary dispatch observes host close while the shared stream pipe waits for drain.
+      await app.dispatch(createRequest(), createResponse(stream));
+
+      // Then: Flight shares the same persistent close observation and exactly-once cleanup.
+      expect(readAfterClose).toBe(false);
+      expect(cancel).toHaveBeenCalledTimes(1);
+      expect(removeCloseListener).toHaveBeenCalledTimes(1);
+      expect(source.locked).toBe(false);
+    } finally {
+      await app.close();
+    }
+  });
+
   it('preserves a sink write failure while cancelling the unfinished reader once and releasing its lock', async () => {
     // Given: an unfinished Flight source and a response sink whose write throws.
     const cancel = vi.fn();
@@ -192,7 +247,9 @@ describe('experimental RSC Flight stream lifecycle', () => {
 
   it('cancels the unfinished reader once and releases its lock when sink drain fails', async () => {
     // Given: an unfinished Flight source and a backpressured sink whose drain wait rejects.
-    const cancel = vi.fn();
+    const cancel = vi.fn(() => {
+      throw new Error('reader cancellation failed');
+    });
     const source = new ReadableStream<Uint8Array>({
       cancel,
       pull(controller) {
@@ -206,13 +263,17 @@ describe('experimental RSC Flight stream lifecycle', () => {
       },
       write: () => false,
     });
-    const app = await bootstrapStreamingFlightApp(source);
+    let observedFailure: unknown;
+    const app = await bootstrapStreamingFlightApp(source, (error) => {
+      observedFailure = error;
+    });
 
     try {
       // When: ordinary HTTP dispatch reaches the failed drain boundary.
       await app.dispatch(createRequest(), createResponse(stream));
 
-      // Then: cleanup cancels exactly once and releases the reader lock.
+      // Then: cleanup retains the drain failure, cancels exactly once, and releases the reader lock.
+      expect(observedFailure).toBe(drainFailure);
       expect(cancel).toHaveBeenCalledTimes(1);
       expect(source.locked).toBe(false);
     } finally {

--- a/packages/react/src/experimental/rsc-flight-stream-lifecycle.test.ts
+++ b/packages/react/src/experimental/rsc-flight-stream-lifecycle.test.ts
@@ -1,0 +1,222 @@
+import { Module } from '@fluojs/core';
+import {
+  Controller,
+  type FrameworkRequest,
+  type FrameworkResponse,
+  type FrameworkResponseStream,
+  Get,
+} from '@fluojs/http';
+import { bootstrapApplication } from '@fluojs/runtime';
+import { describe, expect, it, vi } from 'vitest';
+
+import { createReactFlightResponse } from './rsc.js';
+
+type TestStreamOptions = {
+  readonly closeAfterFlush?: boolean;
+  readonly onUnobservedClose?: () => void;
+  readonly waitForDrain?: () => Promise<void>;
+  readonly write?: (chunk: string | Uint8Array) => boolean;
+};
+
+function createRequest(): FrameworkRequest {
+  return {
+    body: undefined,
+    cookies: {},
+    headers: {},
+    method: 'GET',
+    params: {},
+    path: '/rsc/flight',
+    query: {},
+    raw: {},
+    url: '/rsc/flight',
+  };
+}
+
+function createResponse(stream: FrameworkResponseStream): FrameworkResponse {
+  return {
+    committed: false,
+    headers: {},
+    redirect(status: number, location: string) {
+      this.setStatus(status);
+      this.setHeader('Location', location);
+      this.committed = true;
+    },
+    send() {
+      this.committed = true;
+    },
+    setHeader(name: string, value: string | string[]) {
+      this.headers[name] = value;
+    },
+    setStatus(code: number) {
+      this.statusCode = code;
+      this.statusSet = true;
+    },
+    stream,
+  };
+}
+
+function createResponseStream(options: TestStreamOptions = {}): FrameworkResponseStream {
+  const closeListeners = new Set<() => void>();
+  let closed = false;
+  const stream: FrameworkResponseStream = {
+    close() {
+      if (closed) {
+        return;
+      }
+      closed = true;
+      const listeners = [...closeListeners];
+      for (const listener of listeners) {
+        listener();
+      }
+      if (listeners.length === 0) {
+        options.onUnobservedClose?.();
+      }
+    },
+    get closed() {
+      return closed;
+    },
+    flush() {
+      if (options.closeAfterFlush === true) {
+        queueMicrotask(() => stream.close());
+      }
+    },
+    onClose(listener: () => void) {
+      if (closed) {
+        listener();
+        return () => undefined;
+      }
+      closeListeners.add(listener);
+      return () => {
+        closeListeners.delete(listener);
+      };
+    },
+    waitForDrain: options.waitForDrain ?? (() => Promise.resolve()),
+    write: options.write ?? (() => !closed),
+  };
+
+  return stream;
+}
+
+async function bootstrapStreamingFlightApp(
+  payload: ReadableStream<Uint8Array>,
+  observeError: (error: unknown) => void = () => undefined,
+) {
+  @Controller('/rsc')
+  class StreamingFlightController {
+    @Get('/flight')
+    show() {
+      return createReactFlightResponse(payload);
+    }
+  }
+
+  @Module({ controllers: [StreamingFlightController] })
+  class StreamingFlightAppModule {}
+
+  return bootstrapApplication({
+    filters: [{
+      catch(error: unknown) {
+        observeError(error);
+        return true;
+      },
+    }],
+    rootModule: StreamingFlightAppModule,
+  });
+}
+
+describe('experimental RSC Flight stream lifecycle', () => {
+  it('cancels a pending reader once and releases its lock when the response sink closes early', async () => {
+    // Given: a pending Flight source and a sink that closes after response metadata is flushed.
+    const cancel = vi.fn();
+    let sourceController: ReadableStreamDefaultController<Uint8Array> | undefined;
+    let producedAfterClose = false;
+    const source = new ReadableStream<Uint8Array>({
+      cancel,
+      start(controller) {
+        sourceController = controller;
+      },
+    });
+    const stream = createResponseStream({
+      closeAfterFlush: true,
+      onUnobservedClose() {
+        producedAfterClose = true;
+        sourceController?.enqueue(new Uint8Array([1]));
+      },
+    });
+    const app = await bootstrapStreamingFlightApp(source);
+
+    try {
+      // When: ordinary HTTP dispatch starts consuming the Flight response.
+      await app.dispatch(createRequest(), createResponse(stream));
+
+      // Then: sink closure cancels before another source chunk is consumed and releases the lock.
+      expect(producedAfterClose).toBe(false);
+      expect(cancel).toHaveBeenCalledTimes(1);
+      expect(source.locked).toBe(false);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('preserves a sink write failure while cancelling the unfinished reader once and releasing its lock', async () => {
+    // Given: an unfinished Flight source and a response sink whose write throws.
+    const cancel = vi.fn();
+    const source = new ReadableStream<Uint8Array>({
+      cancel,
+      pull(controller) {
+        controller.enqueue(new Uint8Array([1]));
+      },
+    });
+    const writeFailure = new Error('response write failed');
+    const stream = createResponseStream({
+      write: () => {
+        throw writeFailure;
+      },
+    });
+    let observedFailure: unknown;
+    const app = await bootstrapStreamingFlightApp(source, (error) => {
+      observedFailure = error;
+    });
+
+    try {
+      // When: ordinary HTTP dispatch writes the first Flight chunk.
+      await app.dispatch(createRequest(), createResponse(stream));
+
+      // Then: dispatcher semantics retain the original failure after exactly-once reader cleanup.
+      expect(observedFailure).toBe(writeFailure);
+      expect(cancel).toHaveBeenCalledTimes(1);
+      expect(source.locked).toBe(false);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('cancels the unfinished reader once and releases its lock when sink drain fails', async () => {
+    // Given: an unfinished Flight source and a backpressured sink whose drain wait rejects.
+    const cancel = vi.fn();
+    const source = new ReadableStream<Uint8Array>({
+      cancel,
+      pull(controller) {
+        controller.enqueue(new Uint8Array([1]));
+      },
+    });
+    const drainFailure = new Error('response drain failed');
+    const stream = createResponseStream({
+      waitForDrain: async () => {
+        throw drainFailure;
+      },
+      write: () => false,
+    });
+    const app = await bootstrapStreamingFlightApp(source);
+
+    try {
+      // When: ordinary HTTP dispatch reaches the failed drain boundary.
+      await app.dispatch(createRequest(), createResponse(stream));
+
+      // Then: cleanup cancels exactly once and releases the reader lock.
+      expect(cancel).toHaveBeenCalledTimes(1);
+      expect(source.locked).toBe(false);
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/packages/react/src/render-stream-lifecycle.test.ts
+++ b/packages/react/src/render-stream-lifecycle.test.ts
@@ -27,7 +27,10 @@ function createRequest(): FrameworkRequest {
   };
 }
 
-function createResponse(onWrite: () => void): FrameworkResponse {
+function createResponse(
+  onWrite: () => void,
+  streamOverride?: FrameworkResponseStream,
+): FrameworkResponse {
   let closed = false;
   const stream: FrameworkResponseStream = {
     close() {
@@ -63,7 +66,7 @@ function createResponse(onWrite: () => void): FrameworkResponse {
       this.statusCode = code;
       this.statusSet = true;
     },
-    stream,
+    stream: streamOverride ?? stream,
   };
 }
 
@@ -103,6 +106,78 @@ describe('renderReactResponse stream lifecycle', () => {
 
     // Then: source work is cancelled exactly once and no reader lock remains held.
     expect(cancel).toHaveBeenCalledTimes(1);
+    expect(source.locked).toBe(false);
+  });
+
+  it('cancels before another read when sink close resolves drain without marking the response closed', async () => {
+    // Given: Node-like backpressure where close resolves drain while writableEnded-backed closed stays false.
+    const cancel = vi.fn();
+    const removeCloseListener = vi.fn();
+    const closeListeners = new Set<() => void>();
+    let hostClosed = false;
+    let pullCount = 0;
+    let readAfterClose = false;
+    const source = new ReadableStream<Uint8Array>({
+      cancel,
+      pull(controller) {
+        pullCount += 1;
+        if (pullCount === 1) {
+          controller.enqueue(TEXT_ENCODER.encode('<main>partial</main>'));
+          return;
+        }
+
+        readAfterClose = hostClosed;
+        controller.close();
+      },
+    }, { highWaterMark: 0 });
+    const stream: FrameworkResponseStream = {
+      close() {},
+      get closed() {
+        return false;
+      },
+      onClose(listener) {
+        closeListeners.add(listener);
+        return () => {
+          removeCloseListener();
+          closeListeners.delete(listener);
+        };
+      },
+      waitForDrain() {
+        return new Promise<void>((resolve) => {
+          queueMicrotask(() => {
+            hostClosed = true;
+            for (const listener of [...closeListeners]) {
+              listener();
+            }
+            resolve();
+          });
+        });
+      },
+      write() {
+        return false;
+      },
+    };
+    const response = createResponse(() => undefined, stream);
+    const context = createRequestContext({
+      container: new Container(),
+      metadata: {},
+      request: createRequest(),
+      response,
+    });
+    const renderToReadableStream = vi.fn<ReactReadableStreamRenderer>(async () => source);
+
+    // When: the host emits close while the renderer is waiting for drain.
+    await renderReactResponse(
+      createReactServerEntry(createElement('main', null, 'Dashboard')),
+      context,
+      { renderToReadableStream },
+    );
+
+    // Then: the close is retained across backpressure and cleanup is exactly once.
+    expect(readAfterClose).toBe(false);
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(removeCloseListener).toHaveBeenCalledTimes(1);
+    expect(closeListeners.size).toBe(0);
     expect(source.locked).toBe(false);
   });
 

--- a/packages/react/src/render-stream-lifecycle.test.ts
+++ b/packages/react/src/render-stream-lifecycle.test.ts
@@ -1,0 +1,137 @@
+import { Container } from '@fluojs/di';
+import {
+  createRequestContext,
+  type FrameworkRequest,
+  type FrameworkResponse,
+  type FrameworkResponseStream,
+} from '@fluojs/http';
+import { createElement } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { type ReactReadableStreamRenderer, renderReactResponse } from './render.js';
+import { createReactServerEntry } from './server-entry.js';
+
+const TEXT_ENCODER = new TextEncoder();
+
+function createRequest(): FrameworkRequest {
+  return {
+    body: undefined,
+    cookies: {},
+    headers: {},
+    method: 'GET',
+    params: {},
+    path: '/dashboard',
+    query: {},
+    raw: {},
+    url: '/dashboard',
+  };
+}
+
+function createResponse(onWrite: () => void): FrameworkResponse {
+  let closed = false;
+  const stream: FrameworkResponseStream = {
+    close() {
+      closed = true;
+    },
+    get closed() {
+      return closed;
+    },
+    waitForDrain() {
+      return Promise.resolve();
+    },
+    write() {
+      onWrite();
+      return true;
+    },
+  };
+
+  return {
+    committed: false,
+    headers: {},
+    redirect(status: number, location: string) {
+      this.setStatus(status);
+      this.setHeader('Location', location);
+      this.committed = true;
+    },
+    send() {
+      this.committed = true;
+    },
+    setHeader(name: string, value: string | string[]) {
+      this.headers[name] = value;
+    },
+    setStatus(code: number) {
+      this.statusCode = code;
+      this.statusSet = true;
+    },
+    stream,
+  };
+}
+
+function createUnfinishedSource(cancel: () => void): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    cancel,
+    pull(controller) {
+      controller.enqueue(TEXT_ENCODER.encode('<main>partial</main>'));
+    },
+  });
+}
+
+describe('renderReactResponse stream lifecycle', () => {
+  it('cancels the unfinished reader once and releases its lock when the response sink closes early', async () => {
+    // Given: an unfinished React stream and a response sink that closes after its first write.
+    const cancel = vi.fn();
+    const source = createUnfinishedSource(cancel);
+    let closeSink = (): void => {};
+    const response = createResponse(() => closeSink());
+    closeSink = () => {
+      response.stream?.close();
+    };
+    const context = createRequestContext({
+      container: new Container(),
+      metadata: {},
+      request: createRequest(),
+      response,
+    });
+    const renderToReadableStream = vi.fn<ReactReadableStreamRenderer>(async () => source);
+
+    // When: rendering observes that the committed response sink closed before the source completed.
+    await renderReactResponse(
+      createReactServerEntry(createElement('main', null, 'Dashboard')),
+      context,
+      { renderToReadableStream },
+    );
+
+    // Then: source work is cancelled exactly once and no reader lock remains held.
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(source.locked).toBe(false);
+  });
+
+  it('preserves a response write failure while cancelling the unfinished reader once and releasing its lock', async () => {
+    // Given: an unfinished React stream and a response sink whose write throws.
+    const cancel = vi.fn();
+    const source = createUnfinishedSource(cancel);
+    const writeFailure = new Error('response write failed');
+    const response = createResponse(() => {
+      throw writeFailure;
+    });
+    const context = createRequestContext({
+      container: new Container(),
+      metadata: {},
+      request: createRequest(),
+      response,
+    });
+    const renderToReadableStream = vi.fn<ReactReadableStreamRenderer>(async () => source);
+
+    // When: rendering writes the first source chunk to the failed sink.
+    const render = renderReactResponse(
+      createReactServerEntry(createElement('main', null, 'Dashboard')),
+      context,
+      { renderToReadableStream },
+    );
+
+    // Then: the original sink failure remains observable after exactly-once reader cleanup.
+    await expect(render).rejects.toBe(writeFailure);
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(source.locked).toBe(false);
+  });
+});

--- a/packages/react/src/render-stream.ts
+++ b/packages/react/src/render-stream.ts
@@ -7,6 +7,12 @@ type StreamStopWait = {
   readonly promise: Promise<StreamStop>;
 };
 
+type ResponseCloseObserver = {
+  readonly cleanup: () => void;
+  readonly isClosed: () => boolean;
+  readonly promise: Promise<'closed'> | undefined;
+};
+
 /** Minimal request abort surface used while React Web Streams are read. */
 export type ReactAbortSource = Pick<FrameworkRequest, 'isAborted' | 'signal'>;
 
@@ -35,36 +41,32 @@ function createAbortWait(signal: AbortSignal | undefined): StreamStopWait | unde
   };
 }
 
-function createResponseCloseWait(target: FrameworkResponseStream | undefined): StreamStopWait | undefined {
-  if (!target) {
-    return undefined;
-  }
-
-  if (target.closed) {
-    return { cleanup: () => undefined, promise: Promise.resolve('closed') };
-  }
-
-  if (!target.onClose) {
-    return undefined;
-  }
-
+function createResponseCloseObserver(target: FrameworkResponseStream): ResponseCloseObserver {
+  let closeObserved = target.closed;
   let removeListener: (() => void) | undefined;
-  const promise = new Promise<'closed'>((resolve) => {
-    removeListener = target.onClose?.(() => resolve('closed')) ?? undefined;
-  });
+  const promise = closeObserved
+    ? Promise.resolve<'closed'>('closed')
+    : target.onClose
+      ? new Promise<'closed'>((resolve) => {
+        removeListener = target.onClose?.(() => {
+          closeObserved = true;
+          resolve('closed');
+        }) ?? undefined;
+      })
+      : undefined;
 
   return {
-    cleanup: () => removeListener?.(),
+    cleanup: () => {
+      removeListener?.();
+      removeListener = undefined;
+    },
+    isClosed: () => closeObserved || target.closed,
     promise,
   };
 }
 
 function isReactRequestAborted(source: ReactAbortSource): boolean {
   return source.isAborted?.() === true || source.signal?.aborted === true;
-}
-
-function isResponseSinkClosed(target: FrameworkResponseStream | undefined): boolean {
-  return target?.closed === true;
 }
 
 /**
@@ -85,31 +87,30 @@ async function readNextChunk(
 async function readNextChunk(
   reader: ReadableStreamDefaultReader<Uint8Array>,
   abortSource: ReactAbortSource,
-  target: FrameworkResponseStream,
+  responseClose: ResponseCloseObserver,
 ): Promise<ReadableStreamReadResult<Uint8Array> | StreamStop>;
 async function readNextChunk(
   reader: ReadableStreamDefaultReader<Uint8Array>,
   abortSource: ReactAbortSource,
-  target?: FrameworkResponseStream,
+  responseClose?: ResponseCloseObserver,
 ): Promise<ReadableStreamReadResult<Uint8Array> | StreamStop> {
   if (isReactRequestAborted(abortSource)) {
     return 'aborted';
   }
 
-  if (isResponseSinkClosed(target)) {
+  if (responseClose?.isClosed()) {
     return 'closed';
   }
 
-  const stops: StreamStopWait[] = [];
+  const stops: Promise<StreamStop>[] = [];
   const abort = createAbortWait(abortSource.signal);
-  const responseClose = createResponseCloseWait(target);
 
   if (abort) {
-    stops.push(abort);
+    stops.push(abort.promise);
   }
 
-  if (responseClose) {
-    stops.push(responseClose);
+  if (responseClose?.promise) {
+    stops.push(responseClose.promise);
   }
 
   if (stops.length === 0) {
@@ -117,22 +118,20 @@ async function readNextChunk(
     if (isReactRequestAborted(abortSource)) {
       return 'aborted';
     }
-    return isResponseSinkClosed(target) ? 'closed' : next;
+    return responseClose?.isClosed() ? 'closed' : next;
   }
 
   try {
-    const next = await Promise.race([reader.read(), ...stops.map((stop) => stop.promise)]);
+    const next = await Promise.race([reader.read(), ...stops]);
     if (next === 'aborted' || isReactRequestAborted(abortSource)) {
       return 'aborted';
     }
-    if (next === 'closed' || isResponseSinkClosed(target)) {
+    if (next === 'closed' || responseClose?.isClosed()) {
       return 'closed';
     }
     return next;
   } finally {
-    for (const stop of stops) {
-      stop.cleanup();
-    }
+    abort?.cleanup();
   }
 }
 
@@ -201,6 +200,7 @@ export async function pipeReadableStream(
   abortSource: ReactAbortSource,
 ): Promise<void> {
   const reader = stream.getReader();
+  let responseClose: ResponseCloseObserver | undefined;
   let cancelPromise: Promise<void> | undefined;
   let sourceCompleted = false;
   let stopped = false;
@@ -210,8 +210,10 @@ export async function pipeReadableStream(
   };
 
   try {
-    while (!isReactRequestAborted(abortSource) && !target.closed) {
-      const next = await readNextChunk(reader, abortSource, target);
+    responseClose = createResponseCloseObserver(target);
+
+    while (!isReactRequestAborted(abortSource) && !responseClose.isClosed()) {
+      const next = await readNextChunk(reader, abortSource, responseClose);
 
       if (next === 'aborted' || next === 'closed') {
         stopped = true;
@@ -226,8 +228,21 @@ export async function pipeReadableStream(
       try {
         const accepted = target.write(next.value);
 
+        if (responseClose.isClosed()) {
+          stopped = true;
+          break;
+        }
+
         if (!accepted) {
-          await target.waitForDrain?.();
+          const drain = target.waitForDrain?.();
+          if (drain) {
+            await (responseClose.promise ? Promise.race([drain, responseClose.promise]) : drain);
+          }
+
+          if (responseClose.isClosed()) {
+            stopped = true;
+            break;
+          }
         }
       } catch (error) {
         await Promise.allSettled([cancelReaderOnce()]);
@@ -235,10 +250,11 @@ export async function pipeReadableStream(
       }
     }
 
-    if (!sourceCompleted && (stopped || isReactRequestAborted(abortSource) || target.closed)) {
+    if (!sourceCompleted && (stopped || isReactRequestAborted(abortSource) || responseClose.isClosed())) {
       await cancelReaderOnce();
     }
   } finally {
+    responseClose?.cleanup();
     reader.releaseLock();
 
     if (!target.closed) {

--- a/packages/react/src/render-stream.ts
+++ b/packages/react/src/render-stream.ts
@@ -1,14 +1,16 @@
-import { RequestAbortedError, type FrameworkRequest, type FrameworkResponseStream } from '@fluojs/http';
+import { type FrameworkRequest, type FrameworkResponseStream, RequestAbortedError } from '@fluojs/http';
 
-type AbortWait = {
+type StreamStop = 'aborted' | 'closed';
+
+type StreamStopWait = {
   readonly cleanup: () => void;
-  readonly promise: Promise<'aborted'>;
+  readonly promise: Promise<StreamStop>;
 };
 
 /** Minimal request abort surface used while React Web Streams are read. */
 export type ReactAbortSource = Pick<FrameworkRequest, 'isAborted' | 'signal'>;
 
-function createAbortWait(signal: AbortSignal | undefined): AbortWait | undefined {
+function createAbortWait(signal: AbortSignal | undefined): StreamStopWait | undefined {
   if (!signal) {
     return undefined;
   }
@@ -33,8 +35,36 @@ function createAbortWait(signal: AbortSignal | undefined): AbortWait | undefined
   };
 }
 
+function createResponseCloseWait(target: FrameworkResponseStream | undefined): StreamStopWait | undefined {
+  if (!target) {
+    return undefined;
+  }
+
+  if (target.closed) {
+    return { cleanup: () => undefined, promise: Promise.resolve('closed') };
+  }
+
+  if (!target.onClose) {
+    return undefined;
+  }
+
+  let removeListener: (() => void) | undefined;
+  const promise = new Promise<'closed'>((resolve) => {
+    removeListener = target.onClose?.(() => resolve('closed')) ?? undefined;
+  });
+
+  return {
+    cleanup: () => removeListener?.(),
+    promise,
+  };
+}
+
 function isReactRequestAborted(source: ReactAbortSource): boolean {
   return source.isAborted?.() === true || source.signal?.aborted === true;
+}
+
+function isResponseSinkClosed(target: FrameworkResponseStream | undefined): boolean {
+  return target?.closed === true;
 }
 
 /**
@@ -51,23 +81,58 @@ export function throwIfReactRequestAborted(source: ReactAbortSource): void {
 async function readNextChunk(
   reader: ReadableStreamDefaultReader<Uint8Array>,
   abortSource: ReactAbortSource,
-): Promise<ReadableStreamReadResult<Uint8Array> | 'aborted'> {
+): Promise<ReadableStreamReadResult<Uint8Array> | 'aborted'>;
+async function readNextChunk(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  abortSource: ReactAbortSource,
+  target: FrameworkResponseStream,
+): Promise<ReadableStreamReadResult<Uint8Array> | StreamStop>;
+async function readNextChunk(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  abortSource: ReactAbortSource,
+  target?: FrameworkResponseStream,
+): Promise<ReadableStreamReadResult<Uint8Array> | StreamStop> {
   if (isReactRequestAborted(abortSource)) {
     return 'aborted';
   }
 
-  const abort = createAbortWait(abortSource.signal);
+  if (isResponseSinkClosed(target)) {
+    return 'closed';
+  }
 
-  if (!abort) {
+  const stops: StreamStopWait[] = [];
+  const abort = createAbortWait(abortSource.signal);
+  const responseClose = createResponseCloseWait(target);
+
+  if (abort) {
+    stops.push(abort);
+  }
+
+  if (responseClose) {
+    stops.push(responseClose);
+  }
+
+  if (stops.length === 0) {
     const next = await reader.read();
-    return isReactRequestAborted(abortSource) ? 'aborted' : next;
+    if (isReactRequestAborted(abortSource)) {
+      return 'aborted';
+    }
+    return isResponseSinkClosed(target) ? 'closed' : next;
   }
 
   try {
-    const next = await Promise.race([reader.read(), abort.promise]);
-    return next === 'aborted' || isReactRequestAborted(abortSource) ? 'aborted' : next;
+    const next = await Promise.race([reader.read(), ...stops.map((stop) => stop.promise)]);
+    if (next === 'aborted' || isReactRequestAborted(abortSource)) {
+      return 'aborted';
+    }
+    if (next === 'closed' || isResponseSinkClosed(target)) {
+      return 'closed';
+    }
+    return next;
   } finally {
-    abort.cleanup();
+    for (const stop of stops) {
+      stop.cleanup();
+    }
   }
 }
 
@@ -136,28 +201,42 @@ export async function pipeReadableStream(
   abortSource: ReactAbortSource,
 ): Promise<void> {
   const reader = stream.getReader();
+  let cancelPromise: Promise<void> | undefined;
+  let sourceCompleted = false;
+  let stopped = false;
+  const cancelReaderOnce = (): Promise<void> => {
+    cancelPromise ??= reader.cancel();
+    return cancelPromise;
+  };
 
   try {
     while (!isReactRequestAborted(abortSource) && !target.closed) {
-      const next = await readNextChunk(reader, abortSource);
+      const next = await readNextChunk(reader, abortSource, target);
 
-      if (next === 'aborted') {
+      if (next === 'aborted' || next === 'closed') {
+        stopped = true;
         break;
       }
 
       if (next.done) {
+        sourceCompleted = true;
         break;
       }
 
-      const accepted = target.write(next.value);
+      try {
+        const accepted = target.write(next.value);
 
-      if (!accepted) {
-        await target.waitForDrain?.();
+        if (!accepted) {
+          await target.waitForDrain?.();
+        }
+      } catch (error) {
+        await Promise.allSettled([cancelReaderOnce()]);
+        throw error;
       }
     }
 
-    if (isReactRequestAborted(abortSource)) {
-      await reader.cancel();
+    if (!sourceCompleted && (stopped || isReactRequestAborted(abortSource) || target.closed)) {
+      await cancelReaderOnce();
     }
   } finally {
     reader.releaseLock();


### PR DESCRIPTION
## Summary

Cancel unfinished `@fluojs/react` SSR and experimental Flight readers when a committed response sink closes early or its write/drain path fails. Reader cancellation is exactly once, reader locks are released, and existing sink failures remain authoritative.

Linked context: Closes #2803

## Changes

- Race pending streamed reads against request abort and `FrameworkResponseStream.onClose(...)`.
- Cancel unfinished readers once on sink closure, `write(...)` failure, or `waitForDrain()` failure while always releasing the reader lock.
- Add public-seam SSR and Flight regressions for early close, direct write failure, drain failure, exactly-once cancellation, lock release, and original error preservation.
- Align `packages/react/README.md` and `README.ko.md` with the completed `0.1.0` release, cleanup contract, and exact client/experimental subpath export inventories.
- Add `.changeset/cancel-react-stream-readers.md` with a patch bump for `@fluojs/react`.

Docs/examples impact: package READMEs are the canonical lifecycle surface and were updated in EN/KO. No repository docs, book, website, or example source changes are needed because the public API and usage model are unchanged; both React examples passed their existing tests and do not access response-sink internals.

## Testing

- `pnpm --dir packages/react test` — 24 files, 80 tests passed.
- `pnpm --dir packages/react build` — passed.
- `pnpm --dir packages/react typecheck` — passed.
- `pnpm exec biome check packages/react/src/render-stream.ts packages/react/src/render-stream-lifecycle.test.ts packages/react/src/experimental/rsc-flight-stream-lifecycle.test.ts` — passed.
- `pnpm lint` — passed; only pre-existing repository diagnostics were reported.
- `pnpm verify:platform-consistency-governance` — passed.
- `pnpm verify:docs` — locale parity, docs typecheck, and docs production build passed.
- `pnpm vitest run examples/react-stable-ssr examples/react-vite-ssr` — 3 files, 4 tests passed.
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main` — passed.
- `FLUO_CLI_SANDBOX_ROOT=<dedicated-temp-dir> pnpm verify:release-readiness` — passed without draft artifacts. The first default-root attempt reached the CLI sandbox and stopped on an unrelated shared sandbox safety-marker collision; the isolated rerun passed.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Patch rationale: this fixes resource cleanup without changing public APIs or requiring consumer migration.

## Public export documentation

No public export changed, so source-level TSDoc additions are not applicable. The EN/KO README inventories now exactly list the existing `@fluojs/react/client` and `@fluojs/react/experimental/rsc` runtime and type exports; the Vite and root inventories remain unchanged.

- [x] Changed public exports include a source-level summary, or no public exports changed.
- [x] Exported function `@param` / `@returns` tags remain unchanged because signatures did not change.
- [x] README scenario examples remain complementary to source TSDoc.

## Behavioral contract

- [x] No documented behavioral contracts were removed.
- [x] The new stream cleanup guarantee is documented in both package READMEs.
- [x] Existing stable/experimental boundaries and failure semantics remain intact.
- [x] SSR and Flight runtime invariants are covered through their public response seams.

## Platform consistency governance (SSOT)

- [x] EN/KO package README lifecycle and export documentation remains synchronized.
- [x] No platform contract SSOT changed; the fix uses the existing runtime-neutral `FrameworkResponseStream` contract.
- [x] Platform harness changes are not applicable because no adapter contract or platform implementation changed.
