### PR TITLE
Resolve #2808: Align queue payload and dead-letter documentation

### DIFF
--- a/book/intermediate/ch11-queue.ko.md
+++ b/book/intermediate/ch11-queue.ko.md
@@ -58,6 +58,8 @@ export class BackgroundJobsModule {}
 
 Job은 직렬화된 작업 단위입니다. Worker는 그 job을 처리하는 방식을 소유합니다. 이 분리는 단순하지만 중요합니다. job payload는 durable handoff이고, worker 구현은 그 경계 뒤에서 독립적으로 바뀔 수 있습니다.
 
+Queue는 `new GenerateInvoiceJob(orderId)` 같은 class instance를 포함한 job object를 입력으로 받습니다. Enqueue 전에 job을 JSON으로 직렬화하며, 직렬화 결과는 `null`이나 array가 아닌 JSON object여야 합니다. Worker는 그 data 위에 등록된 job prototype이 다시 입혀진 값을 받으므로, 영속 payload에는 직렬화된 data만 포함되어도 `job.someMethod()` 같은 메서드를 사용할 수 있습니다.
+
 ### 11.3.1 Invoice generation job
 
 Invoice PDF 생성은 전형적인 queue task입니다. checkout confirmation path 안에서 처리하기에는 오래 걸립니다. file storage나 rendering outage 같은 일시적인 원인으로 실패할 수도 있습니다.
@@ -129,7 +131,7 @@ fixed backoff는 예측하기 쉽습니다. exponential backoff는 부하를 받
 
 ## 11.5 Dead-letter handling
 
-모든 retry attempt 이후에도 실패하는 job이 있습니다. 그런 실패가 조용히 사라지면 안 됩니다. Queue 패키지는 `fluo:queue:dead-letter:<jobName>` 아래의 Redis dead-letter list에 dead-letter record를 append하며, BullMQ job 자체를 옮기지는 않습니다. 운영자는 이 목록을 통해 무엇이 실패했는지 확인할 수 있는 durable place를 얻습니다. README는 기본 retention policy도 명시합니다. 별도 설정이 없으면 `QueueModule.forRoot()`는 job당 가장 최근 `1_000`개의 dead-letter entry를 유지합니다. 이는 운영상 중요한 기본값입니다. 무한 성장을 막으면서도 최근 실패 증거를 보존하기 때문입니다.
+모든 retry attempt 이후에도 실패하는 job이 있습니다. 그런 실패가 조용히 사라지면 안 됩니다. Queue 패키지는 `fluo:queue:dead-letter:<jobName>` 아래의 Redis dead-letter list에 별도의 dead-letter record를 append하며, BullMQ job 자체를 그 list로 옮기지는 않습니다. 운영자는 이 목록을 통해 무엇이 실패했는지 확인할 수 있는 durable place를 얻습니다. README는 기본 retention policy도 명시합니다. 별도 설정이 없으면 `QueueModule.forRoot()`는 job당 가장 최근 `1_000`개의 dead-letter entry를 유지합니다. 이는 운영상 중요한 기본값입니다. 무한 성장을 막으면서도 최근 실패 증거를 보존하기 때문입니다.
 
 ### 11.5.1 What FluoShop stores in dead letters
 
@@ -164,7 +166,7 @@ v2.0.0에서 대표적인 background flow는 다음과 같습니다.
 5. Billing이 반응하여 `GenerateInvoiceJob`을 enqueue합니다.
 6. `InvoiceWorker`가 background에서 job을 처리합니다.
 7. rendering이 일시적으로 실패하면 retry와 backoff가 적용됩니다.
-8. 그래도 실패하면 job은 dead-letter list에 남습니다.
+8. 그래도 실패하면 Queue는 BullMQ job 자체를 옮기지 않고 dead-letter list에 별도의 record를 append합니다.
 
 이 경계는 PDF generation을 inline으로 수행하는 방식보다 운영적으로 낫습니다. 고객은 시의적절한 API 응답을 받고, 운영자는 통제된 failure model을 얻으며, 시스템은 회복할 여지를 확보합니다.
 
@@ -192,7 +194,7 @@ v2.0.0으로 넘어가면서 FluoShop은 더 이상 event-aware 수준에 머무
 - NestJS migration에는 `handle(job)`을 가진 명시적 singleton `@QueueWorker(JobClass)` provider, module-graph reachability, 애플리케이션이 검증한 `jobName`/payload cutover가 필요하며 legacy processor metadata는 compatibility surface가 아닙니다.
 - job은 invoice generation, email batch, catalog sync처럼 느리거나 failure-prone한 작업을 위한 durable handoff입니다.
 - retry attempt와 backoff strategy는 무비판적으로 복사하지 말고 workload별로 선택해야 합니다.
-- dead-letter list는 bounded retention policy 아래에서 반복 실패 job을 보존하며, read-only inspection API는 Queue의 Redis key 형식을 노출하지 않고 최신순 typed metadata를 반환합니다.
+- dead-letter list는 bounded retention policy 아래에서 반복 실패 job의 별도 record를 보존하며, BullMQ job 자체를 소유하거나 옮기지는 않습니다. Read-only inspection API는 Queue의 Redis key 형식을 노출하지 않고 최신순 typed metadata를 반환합니다.
 - Queue는 bootstrap-ready handoff 이후 processor를 시작합니다. Queue가 `started`이고 탐색된 모든 processor가 ready인 동안에만 pending dead-letter write가 readiness를 `ready`로 유지하고 health를 `degraded`로 만들며, `stopping`은 not-ready/degraded, `stopped`는 not-ready/unhealthy입니다. 종료는 각 write의 `5_000ms` drain과 stuck processor를 위한 `workerShutdownTimeoutMs`로 제한됩니다.
 - FluoShop v2.0.0은 이제 post-order의 expensive work를 customer request path를 늘리는 대신 queue boundary 뒤로 이동시킵니다.
 

--- a/book/intermediate/ch11-queue.md
+++ b/book/intermediate/ch11-queue.md
@@ -58,6 +58,8 @@ This contract keeps the same shape as the rest of fluo. A Module registers the p
 
 A job is a serialized unit of work. A worker owns how that job is processed. This split is simple but important. The job payload is the durable handoff, while the worker implementation can evolve independently behind that boundary.
 
+Queue accepts job objects, including class instances such as `new GenerateInvoiceJob(orderId)`. Before enqueueing, it JSON-serializes the job and requires the serialized payload to be a non-null, non-array JSON object. The worker receives that data with the registered job prototype rehydrated, so methods such as `job.someMethod()` remain available even though the persisted payload contains only serialized data.
+
 ### 11.3.1 Invoice generation job
 
 Invoice PDF generation is a typical queue task. It takes too long to run inside the checkout confirmation path. It may also fail for temporary reasons such as file storage or rendering outages.
@@ -129,7 +131,7 @@ Fixed backoff is easy to predict. Exponential backoff is often safer for depende
 
 ## 11.5 Dead-letter handling
 
-Some jobs still fail after every retry attempt. Those failures must not disappear silently. The Queue package appends a dead-letter record to a Redis list under `fluo:queue:dead-letter:<jobName>`; it does not move the BullMQ job itself. That list gives operators a durable place to inspect what failed. The README also states the default retention policy. Without separate configuration, `QueueModule.forRoot()` keeps the most recent `1_000` dead-letter entries per job. This is an important operational default. It prevents unbounded growth while preserving recent failure evidence.
+Some jobs still fail after every retry attempt. Those failures must not disappear silently. The Queue package appends a separate dead-letter record to a Redis list under `fluo:queue:dead-letter:<jobName>`; it does not move the BullMQ job itself into that list. That list gives operators a durable place to inspect what failed. The README also states the default retention policy. Without separate configuration, `QueueModule.forRoot()` keeps the most recent `1_000` dead-letter entries per job. This is an important operational default. It prevents unbounded growth while preserving recent failure evidence.
 
 ### 11.5.1 What FluoShop stores in dead letters
 
@@ -164,7 +166,7 @@ In v2.0.0, a representative background flow looks like this:
 5. Billing reacts and enqueues `GenerateInvoiceJob`.
 6. `InvoiceWorker` processes the job in the background.
 7. If rendering fails temporarily, retry and backoff apply.
-8. If it still fails, the job remains in the dead-letter list.
+8. If it still fails, Queue appends a separate record to the dead-letter list without moving the BullMQ job itself.
 
 This boundary is operationally better than generating the PDF inline. The customer gets a timely API response, operators get a controlled failure model, and the system keeps room to recover.
 
@@ -192,7 +194,7 @@ As FluoShop moves to v2.0.0, it no longer stops at being event-aware. It recogni
 - NestJS migration requires an explicit singleton `@QueueWorker(JobClass)` provider with `handle(job)`, module-graph reachability, and an application-verified `jobName`/payload cutover; legacy processor metadata is not a compatibility surface.
 - A job is a durable handoff for slow or failure-prone work such as invoice generation, email batches, and catalog syncs.
 - Retry attempts and backoff strategies should be chosen per workload rather than copied uncritically.
-- The dead-letter list preserves repeatedly failed jobs under a bounded retention policy, and the read-only inspection API returns newest-first typed metadata without exposing Queue's Redis key format.
+- The dead-letter list preserves separate records for repeatedly failed jobs under a bounded retention policy; it does not own or move the BullMQ jobs themselves. The read-only inspection API returns newest-first typed metadata without exposing Queue's Redis key format.
 - Queue starts processors after the bootstrap-ready handoff. Only while Queue is `started` and all discovered processors are ready do pending dead-letter writes leave readiness `ready` while health is `degraded`; `stopping` is not-ready/degraded and `stopped` is not-ready/unhealthy. Shutdown is bounded by a `5_000ms` per-write drain plus `workerShutdownTimeoutMs` for stuck processors.
 - FluoShop v2.0.0 now moves expensive post-order work behind a queue boundary instead of extending the customer request path.
 

--- a/packages/queue/README.ko.md
+++ b/packages/queue/README.ko.md
@@ -155,7 +155,7 @@ Queue는 애플리케이션 부트스트랩 중 worker를 탐색하고 Queue가 
 
 ### 데드 레터 처리 (Dead-Letter Handling)
 
-워커가 모든 재시도를 소진하면 Queue는 Redis의 데드 레터 리스트(`fluo:queue:dead-letter:<jobName>`)에 레코드를 append하여, 나중에 수동으로 확인하거나 복구할 수 있게 합니다. BullMQ job 자체를 이동시키는 것은 아닙니다.
+워커가 모든 재시도를 소진하면 Queue는 Redis의 데드 레터 리스트(`fluo:queue:dead-letter:<jobName>`)에 별도의 레코드를 append하여, 나중에 수동으로 확인하거나 복구할 수 있게 합니다. BullMQ job 자체를 그 리스트로 이동시키지는 않습니다.
 
 `QueueModule.forRoot()`는 기본적으로 작업별 최근 데드 레터 엔트리 `1_000`개만 유지합니다. 무제한 보관이 꼭 필요하면 `defaultDeadLetterMaxEntries: false`로 opt-out 하고, 더 엄격한 운영 예산이 필요하면 더 작은 양의 정수를 지정하세요.
 
@@ -171,7 +171,7 @@ for (const record of inspection.records) {
 
 Inspection은 read-only이며 유효한 record를 최신순으로 반환합니다. Redis read를 worker lifecycle state로 gate하지 않으므로 inspection이 worker를 시작하지 않으며, backing Redis client에 접근 가능한 동안에는 Queue가 `idle`이거나 worker startup이 `failed`에 도달한 뒤에도 사용할 수 있습니다. Queue는 shared Redis client를 소유하지 않습니다. `RedisModule`이 해당 client를 종료한 뒤에는 post-shutdown availability를 보장하지 않고 backing Redis operation error를 그대로 전달합니다. Limit은 기본적으로 저장된 entry `100`개이며 최대 `1_000`개로 제한되고, 잘못된 limit은 기본값으로 대체됩니다. Malformed stored value는 결과에서 제외되고 해당 inspection window의 `malformedRecordCount`에 집계됩니다. `payload`는 `unknown`으로 유지되므로 애플리케이션 코드가 자신의 job data를 직접 narrow해야 합니다. Inspection은 job이나 dead-letter record를 삭제, replay 또는 mutate하지 않습니다.
 
-Job은 JSON으로 직렬화 가능한 plain object여야 합니다. Queue는 enqueue 전에 job payload를 직렬화하고, worker 측에서 job prototype을 다시 입힙니다.
+Queue는 `new ProcessOrderJob(id)` 같은 class instance를 포함한 job object를 입력으로 받습니다. Enqueue 전에 Queue는 job을 JSON으로 직렬화하며, 직렬화 결과는 `null`이나 array가 아닌 JSON object여야 합니다. Worker 측에서는 그 직렬화된 object 위에 등록된 job prototype을 다시 입힙니다.
 
 저수준 provider 조합을 루트 barrel API의 일부가 아니라 내부 구현 세부사항으로 취급해야 합니다. 저수준 provider helper는 문서화된 루트 barrel 계약에 포함되지 않습니다.
 

--- a/packages/queue/README.md
+++ b/packages/queue/README.md
@@ -155,7 +155,7 @@ Workers can be configured with a maximum number of attempts and backoff strategi
 
 ### Dead-Letter Handling
 
-When a worker exhausts its retry attempts, Queue appends a dead-letter record to Redis (`fluo:queue:dead-letter:<jobName>`) for manual inspection or recovery. Queue does not move the BullMQ job itself.
+When a worker exhausts its retry attempts, Queue appends a separate dead-letter record to Redis (`fluo:queue:dead-letter:<jobName>`) for manual inspection or recovery. Queue does not move the BullMQ job itself into that list.
 
 `QueueModule.forRoot()` keeps the most recent `1_000` dead-letter entries per job by default. Set `defaultDeadLetterMaxEntries: false` to opt out, or provide a smaller positive number when operators need a tighter retention budget.
 
@@ -171,7 +171,7 @@ for (const record of inspection.records) {
 
 Inspection is read-only and returns valid records in newest-first order. It reads Redis without lifecycle-gating the operation, so inspection does not start workers and remains usable while Queue is `idle` or after worker startup reaches `failed`, as long as the backing Redis client is reachable. Queue does not own the shared Redis client; after `RedisModule` shuts that client down, inspection propagates the backing Redis operation error instead of promising post-shutdown availability. The limit defaults to `100` stored entries and is capped at `1_000`; invalid limits fall back to the default. Malformed stored values are omitted and counted in `malformedRecordCount` for the inspected window, and `payload` remains `unknown` so application code must narrow its own job data. Inspection does not delete, replay, or mutate jobs or dead-letter records.
 
-Jobs must be JSON-serializable plain objects. Queue serializes the job payload before enqueueing and rehydrates the job prototype on the worker side.
+Queue accepts job objects, including class instances such as `new ProcessOrderJob(id)`. Before enqueueing, Queue JSON-serializes the job and requires the serialized payload to be a non-null, non-array JSON object. On the worker side, Queue rehydrates the registered job prototype over that serialized object.
 
 Treat low-level provider assembly as an internal implementation detail: low-level provider helpers are not part of the documented root-barrel contract.
 

--- a/packages/queue/src/metadata.ts
+++ b/packages/queue/src/metadata.ts
@@ -19,20 +19,20 @@ function getStandardQueueWorkerMetadata(target: Function): QueueWorkerMetadata |
 }
 
 /**
- * Define queue worker metadata.
+ * Stores queue worker metadata for a decorated worker class.
  *
- * @param target The target.
- * @param metadata The metadata.
+ * @param target Decorated worker class that owns the metadata.
+ * @param metadata Job type and worker options to store for the class.
  */
 export function defineQueueWorkerMetadata(target: Function, metadata: QueueWorkerMetadata): void {
   queueWorkerMetadataStore.set(target, cloneQueueWorkerMetadata(metadata));
 }
 
 /**
- * Get queue worker metadata.
+ * Reads queue worker metadata for a decorated worker class.
  *
- * @param target The target.
- * @returns The get queue worker metadata result.
+ * @param target Worker class whose metadata should be read.
+ * @returns A cloned metadata snapshot, or `undefined` when the class has no queue worker metadata.
  */
 export function getQueueWorkerMetadata(target: Function): QueueWorkerMetadata | undefined {
   const stored = queueWorkerMetadataStore.get(target);


### PR DESCRIPTION
## Summary

Align the `@fluojs/queue` package and learning documentation with the existing payload serialization and dead-letter implementation contracts. This PR changes documentation and TSDoc only.

Linked context: Closes #2808

## Changes

- clarify in package README EN/KO that enqueue accepts job objects including class instances, while the JSON-serialized payload must be a non-null, non-array object
- clarify that dead-letter handling appends a separate Redis record and does not move the BullMQ job
- synchronize the same payload and dead-letter wording in Chapter 11 EN/KO
- replace placeholder queue metadata helper TSDoc with complete parameter and return descriptions

## Testing

- `pnpm docs:sync-check`
- `pnpm docs:typecheck`
- `pnpm docs:build`
- `pnpm verify:public-export-tsdoc`
- `pnpm exec biome lint packages/queue/src/metadata.ts`
- `pnpm -r --filter "@fluojs/queue..." --if-present run build`
- `pnpm --dir packages/queue typecheck`
- `pnpm --dir packages/queue build`
- `pnpm --dir packages/queue test` (59 tests passed)
- `pnpm verify:platform-consistency-governance`
- `pnpm vitest run tooling/governance/verify-platform-consistency-governance.test.ts` (115 tests passed)
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main`
- `git diff --check`

`pnpm verify:public-export-tsdoc:baseline` still reports the existing repository-wide TSDoc backlog on `main`; the changed-file gate passes and the queue metadata helper is not among those baseline failures.

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

No Changeset was added because the diff changes only prose and source comments. It does not change runtime statements, signatures, exports, package contents, or public behavior.

## Public export documentation

- [x] Changed helper documentation includes source-level summaries.
- [x] Changed exported functions document matching `@param` / `@returns` tags.
- [x] Source TSDoc remains concise while scenario guidance stays in README and book surfaces.

## Behavioral contract

- [x] No documented behavioral contracts were removed.
- [x] Existing payload and dead-letter behavior is now described consistently in the affected package README.
- [x] The serialized-object requirement and separate dead-letter-record ownership boundary are explicit.
- [x] Existing queue regression tests cover class-instance rehydration, serialized payload rejection, and dead-letter writes.

## Platform consistency governance (SSOT)

- [x] Package README and Chapter 11 English/Korean mirrors remain synchronized.
- [x] No platform contract SSOT changed; the platform consistency governance script and test pass.
- [x] No platform adapter alignment or conformance claim is introduced.