### PR TITLE
Resolve #2828: Add application-level React page renderer

### DIFF
--- a/.changeset/add-react-page-renderer.md
+++ b/.changeset/add-react-page-renderer.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/react": minor
+---
+
+Add an application-level `ReactPageRenderer` callback that `ReactModule.forRoot(...)` registers for shared document, provider, route-context, hydration, and recoverable-render composition through the existing `ReactServerEntry` response path.

--- a/packages/react/README.ko.md
+++ b/packages/react/README.ko.md
@@ -12,6 +12,7 @@ fluo 애플리케이션을 위한 런타임 중립 React 통합입니다.
 - [런타임 및 피어 계약](#런타임-및-피어-계약)
 - [Phase Boundaries](#phase-boundaries)
 - [ReactModule Registration](#reactmodule-registration)
+- [Application Page Renderer](#application-page-renderer)
 - [Router 및 Path Decorators](#router-및-path-decorators)
 - [Web Streams SSR](#web-streams-ssr)
 - [Hydration Asset Contract](#hydration-asset-contract)
@@ -128,6 +129,82 @@ class AppModule {}
 `ReactModule`은 URL matching을 소유하지 않습니다. 이 module을 통해 등록한 router는 일반 HTTP handler
 source가 되므로 `createHandlerMapping(...)`과 `Dispatcher`가 계속 duplicate route detection,
 module-level middleware, request scope 생성, guard 및 interceptor 실행, route versioning을 담당합니다.
+
+## Application Page Renderer
+
+모든 page가 같은 document shell, provider, hydration asset, route snapshot wiring,
+recoverable-render policy를 공유해야 한다면 application-owned `renderPage` callback 하나를 등록하세요.
+Callback은 `ReactPageRenderer`를 구현하고 하나의 `ReactElement`와 활성 `ReactRenderContext`를 받아
+`ReactServerEntry`를 반환해야 합니다. `ReactModule.forRoot(...)`는 callback을
+`REACT_PAGE_RENDERER`로 등록하고 export하므로 router는 별도 response path를 만들지 않고 callback을
+inject할 수 있습니다.
+
+```tsx
+import { Inject, Module } from '@fluojs/core';
+import {
+  Path,
+  REACT_PAGE_RENDERER,
+  ReactModule,
+  Router,
+  createReactServerEntry,
+  type ReactPageRenderer,
+  type ReactRenderContext,
+} from '@fluojs/react';
+import {
+  ReactClientRouterProvider,
+  createReactRouteSnapshot,
+} from '@fluojs/react/client';
+
+const hydrationOptions = {
+  assetMap: { 'client.js': '/assets/client.123.js' },
+  bootstrapModules: ['/assets/client.123.js'],
+} as const;
+
+const renderPage: ReactPageRenderer = (page, context) => {
+  const initialSnapshot = createReactRouteSnapshot({
+    params: context.request.params,
+    url: context.request.url,
+  });
+
+  return createReactServerEntry(
+    <html lang="ko">
+      <body>
+        <ReactClientRouterProvider initialSnapshot={initialSnapshot}>
+          {page}
+        </ReactClientRouterProvider>
+      </body>
+    </html>,
+    hydrationOptions,
+  );
+};
+
+@Inject(REACT_PAGE_RENDERER)
+@Router('/products')
+class ProductRouter {
+  constructor(private readonly renderPage: ReactPageRenderer) {}
+
+  @Path('/:id')
+  show(_input: undefined, context: ReactRenderContext) {
+    return this.renderPage(<main>Product {context.request.params.id}</main>, context);
+  }
+}
+
+@Module({
+  imports: [ReactModule.forRoot({ controllers: [ProductRouter], renderPage })],
+})
+class AppModule {}
+```
+
+Root package는 `@fluojs/react/client`나 `@fluojs/react/vite`를 import하지 않습니다. 애플리케이션은 위와
+같이 client helper를 명시적으로 compose할 수 있고, 이미 로드한 manifest를
+`createReactViteAssetManifest(...)`로 처리해 얻은 hydration option을 callback closure에서 사용할 수
+있습니다. Renderer는 manifest discovery, bundle generation, route matching을 수행하지 않으며 DTO
+binding, middleware, guard, interceptor, request scope, abort propagation, shell failure handling,
+recoverable streaming behavior를 우회하지 않습니다.
+
+이 phase는 JSX return 값을 암묵적으로 변환하지 않습니다. Handler는 `REACT_PAGE_RENDERER`를 inject해
+호출하거나 계속 `createReactServerEntry(...)`를 직접 반환해야 합니다. 명시적인 `ReactServerEntry` 값은
+그대로 유지되며 configured callback을 통과하지 않습니다.
 
 ## Router 및 Path Decorators
 
@@ -643,14 +720,18 @@ stable subpath를 추가하지 않고 deprecation window도 시작하지 않습�
 - `getReactPathMetadata` — router method에서 React render metadata를 읽습니다.
 - `ReactModule` — `forRoot(...)`가 기존 fluo module/controller metadata path를 통해 React router를
   등록하는 런타임 중립 module facade입니다.
+- `REACT_PAGE_RENDERER` — `ReactModule.forRoot({ renderPage })`가 등록하는 application page renderer의
+  dependency-injection token입니다.
+- `ReactPageRenderer` — `ReactElement`와 활성 `ReactRenderContext`를 기존 `ReactServerEntry`로 compose하는
+  type-only application callback입니다.
 - `createReactServerEntry` — page handler가 Web Streams SSR을 위해 반환하는 runtime-neutral React server
   entry를 생성합니다.
 - `renderReactResponse` — lazy `react-dom/server` loading으로 React server entry 하나를 fluo HTML
   response에 렌더링합니다.
 - `ReactAssetMap`, `ReactBootstrapAsset`, `ReactBootstrapScriptDescriptor` — build-produced asset map 및
   React DOM bootstrap script/module entry를 위한 type-only contract입니다.
-- `ReactModuleOptions` — `controllers`, `imports`, `providers`, `exports`, module-level `middleware`를 포함하는
-  `ReactModule.forRoot(...)` option입니다.
+- `ReactModuleOptions` — `controllers`, `imports`, `providers`, `exports`, module-level `middleware`, optional
+  `renderPage` registration을 포함하는 `ReactModule.forRoot(...)` option입니다.
 - `ReactServerEntry`, `ReactServerEntryOptions`, `ReactServerEntryHeaders`,
   `ReactRecoverableErrorHandler`, `ReactRecoverableErrorContext`, `ReactRenderContext`,
   `ReactReadableStream`, `ReactReadableStreamRenderer`, `ReactReadableStreamRenderOptions`,
@@ -723,6 +804,7 @@ stable subpath를 추가하지 않고 deprecation window도 시작하지 않습�
 - `packages/react/src/server-entry.ts`
 - `packages/react/src/render.ts`
 - `packages/react/src/module.ts`
+- `packages/react/src/page-renderer.ts`
 - `packages/react/src/render.test.ts`
 - `packages/react/src/dispatcher-ssr.test.ts`
 - `packages/react/src/hydration-assets.test.ts`

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -12,6 +12,7 @@ Runtime-neutral React integration for fluo applications.
 - [Runtime and Peer Contract](#runtime-and-peer-contract)
 - [Phase Boundaries](#phase-boundaries)
 - [ReactModule Registration](#reactmodule-registration)
+- [Application Page Renderer](#application-page-renderer)
 - [Router and Path Decorators](#router-and-path-decorators)
 - [Web Streams SSR](#web-streams-ssr)
 - [Hydration Asset Contract](#hydration-asset-contract)
@@ -132,6 +133,80 @@ class AppModule {}
 sources, so `createHandlerMapping(...)` and `Dispatcher` still detect duplicate routes, apply
 module-level middleware, create request scopes, run guards and interceptors, and resolve route
 versioning.
+
+## Application Page Renderer
+
+Register one application-owned `renderPage` callback when every page should share the same document
+shell, providers, hydration assets, route snapshot wiring, and recoverable-render policy. The callback
+implements `ReactPageRenderer`, receives one `ReactElement` plus the active `ReactRenderContext`, and
+must return `ReactServerEntry`. `ReactModule.forRoot(...)` registers and exports it through
+`REACT_PAGE_RENDERER`, so routers can inject the callback without creating a second response path.
+
+```tsx
+import { Inject, Module } from '@fluojs/core';
+import {
+  Path,
+  REACT_PAGE_RENDERER,
+  ReactModule,
+  Router,
+  createReactServerEntry,
+  type ReactPageRenderer,
+  type ReactRenderContext,
+} from '@fluojs/react';
+import {
+  ReactClientRouterProvider,
+  createReactRouteSnapshot,
+} from '@fluojs/react/client';
+
+const hydrationOptions = {
+  assetMap: { 'client.js': '/assets/client.123.js' },
+  bootstrapModules: ['/assets/client.123.js'],
+} as const;
+
+const renderPage: ReactPageRenderer = (page, context) => {
+  const initialSnapshot = createReactRouteSnapshot({
+    params: context.request.params,
+    url: context.request.url,
+  });
+
+  return createReactServerEntry(
+    <html lang="en">
+      <body>
+        <ReactClientRouterProvider initialSnapshot={initialSnapshot}>
+          {page}
+        </ReactClientRouterProvider>
+      </body>
+    </html>,
+    hydrationOptions,
+  );
+};
+
+@Inject(REACT_PAGE_RENDERER)
+@Router('/products')
+class ProductRouter {
+  constructor(private readonly renderPage: ReactPageRenderer) {}
+
+  @Path('/:id')
+  show(_input: undefined, context: ReactRenderContext) {
+    return this.renderPage(<main>Product {context.request.params.id}</main>, context);
+  }
+}
+
+@Module({
+  imports: [ReactModule.forRoot({ controllers: [ProductRouter], renderPage })],
+})
+class AppModule {}
+```
+
+The root package does not import `@fluojs/react/client` or `@fluojs/react/vite`. Applications may
+compose client helpers explicitly as above and may close over hydration options produced from an
+already-loaded manifest by `createReactViteAssetManifest(...)`. The renderer does not discover
+manifests, generate bundles, match routes, or bypass DTO binding, middleware, guards, interceptors,
+request scopes, abort propagation, shell failure handling, or recoverable streaming behavior.
+
+This phase does not implicitly convert a JSX return value. A handler must inject and call
+`REACT_PAGE_RENDERER`, or continue returning `createReactServerEntry(...)` directly. Explicit
+`ReactServerEntry` values remain unchanged and do not pass through the configured callback.
 
 ## Router and Path Decorators
 
@@ -655,6 +730,10 @@ This package currently does **not** provide:
 - `getReactPathMetadata` — reads React render metadata from a router method.
 - `ReactModule` — runtime-neutral module facade whose `forRoot(...)` registers React routers through
   the existing fluo module/controller metadata path.
+- `REACT_PAGE_RENDERER` — dependency-injection token for the application page renderer registered by
+  `ReactModule.forRoot({ renderPage })`.
+- `ReactPageRenderer` — type-only application callback that composes a `ReactElement` and active
+  `ReactRenderContext` into an existing `ReactServerEntry`.
 - `createReactServerEntry` — creates a runtime-neutral React server entry returned by page handlers
   for Web Streams SSR.
 - `renderReactResponse` — renders one React server entry to a fluo HTML response with lazy
@@ -662,7 +741,7 @@ This package currently does **not** provide:
 - `ReactAssetMap`, `ReactBootstrapAsset`, and `ReactBootstrapScriptDescriptor` — type-only contracts
   for build-produced asset maps and React DOM bootstrap script/module entries.
 - `ReactModuleOptions` — options accepted by `ReactModule.forRoot(...)`, including `controllers`,
-  `imports`, `providers`, `exports`, and module-level `middleware`.
+  `imports`, `providers`, `exports`, module-level `middleware`, and optional `renderPage` registration.
 - `ReactServerEntry`, `ReactServerEntryOptions`, `ReactServerEntryHeaders`,
   `ReactRecoverableErrorHandler`, `ReactRecoverableErrorContext`, `ReactRenderContext`,
   `ReactReadableStream`, `ReactReadableStreamRenderer`, `ReactReadableStreamRenderOptions`, and
@@ -736,6 +815,7 @@ This package currently does **not** provide:
 - `packages/react/src/server-entry.ts`
 - `packages/react/src/render.ts`
 - `packages/react/src/module.ts`
+- `packages/react/src/page-renderer.ts`
 - `packages/react/src/render.test.ts`
 - `packages/react/src/dispatcher-ssr.test.ts`
 - `packages/react/src/hydration-assets.test.ts`

--- a/packages/react/src/index.test.ts
+++ b/packages/react/src/index.test.ts
@@ -16,6 +16,7 @@ describe('@fluojs/react root package scaffold', () => {
 
     expect(Object.keys(react).sort()).toEqual([
       'Path',
+      'REACT_PAGE_RENDERER',
       'ReactModule',
       'Router',
       'createReactServerEntry',
@@ -39,6 +40,7 @@ describe('@fluojs/react root package scaffold', () => {
 
       expect(react).toHaveProperty('Path');
       expect(react).toHaveProperty('ReactModule');
+      expect(react).toHaveProperty('REACT_PAGE_RENDERER');
       expect(react).toHaveProperty('Router');
       expect(react).toHaveProperty('createReactServerEntry');
       expect(react).toHaveProperty('renderReactResponse');
@@ -55,6 +57,7 @@ describe('@fluojs/react root package scaffold', () => {
     const renderEntrypoint = readFileSync(new URL('./render.ts', import.meta.url), 'utf8');
 
     expect(rootEntrypoint).toContain("from './module.js'");
+    expect(rootEntrypoint).toContain("from './page-renderer.js'");
     expect(rootEntrypoint).toContain("from './decorators.js'");
     expect(rootEntrypoint).toContain("from './server-entry.js'");
     expect(rootEntrypoint).toContain("from './render.js'");

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -7,6 +7,8 @@ export {
 export type { ReactPathMetadata, ReactPathOptions, ReactRouterMetadata } from './decorators.js';
 export { ReactModule } from './module.js';
 export type { ReactModuleOptions } from './module.js';
+export { REACT_PAGE_RENDERER } from './page-renderer.js';
+export type { ReactPageRenderer } from './page-renderer.js';
 export { renderReactResponse } from './render.js';
 export type {
   ReactReadableStream,

--- a/packages/react/src/module.ts
+++ b/packages/react/src/module.ts
@@ -3,6 +3,8 @@ import type { Provider } from '@fluojs/di';
 import type { MiddlewareLike } from '@fluojs/http';
 import { defineModule, type ModuleDefinition, type ModuleType } from '@fluojs/runtime';
 
+import { REACT_PAGE_RENDERER, type ReactPageRenderer } from './page-renderer.js';
+
 /**
  * Options for registering React routers through the fluo module graph.
  */
@@ -17,6 +19,8 @@ export type ReactModuleOptions = {
   readonly middleware?: readonly MiddlewareLike[];
   /** Providers local to this dynamic React module and visible to registered routers. */
   readonly providers?: readonly Provider[];
+  /** Application callback that composes page elements into existing React server entries. */
+  readonly renderPage?: ReactPageRenderer;
 };
 
 /**
@@ -41,12 +45,23 @@ export class ReactModule {
   static forRoot(options: ReactModuleOptions): ModuleType {
     class ReactRootModule extends ReactModule {}
 
+    const pageRendererProvider: Provider<ReactPageRenderer> | undefined = options.renderPage === undefined
+      ? undefined
+      : { provide: REACT_PAGE_RENDERER, useValue: options.renderPage };
+    const exports = [
+      ...(options.exports ?? []),
+      ...(pageRendererProvider === undefined ? [] : [REACT_PAGE_RENDERER]),
+    ];
+    const providers = [
+      ...(options.providers ?? []),
+      ...(pageRendererProvider === undefined ? [] : [pageRendererProvider]),
+    ];
     const definition = {
       controllers: [...options.controllers],
-      ...(options.exports ? { exports: [...options.exports] } : {}),
+      ...(exports.length > 0 ? { exports } : {}),
       ...(options.imports ? { imports: [...options.imports] } : {}),
       ...(options.middleware ? { middleware: [...options.middleware] } : {}),
-      ...(options.providers ? { providers: [...options.providers] } : {}),
+      ...(providers.length > 0 ? { providers } : {}),
     } satisfies ModuleDefinition;
 
     return defineModule(ReactRootModule, definition);

--- a/packages/react/src/page-renderer.test.ts
+++ b/packages/react/src/page-renderer.test.ts
@@ -1,0 +1,150 @@
+import { Inject, Module } from '@fluojs/core';
+import type { FrameworkRequest, FrameworkResponse } from '@fluojs/http';
+import { bootstrapApplication } from '@fluojs/runtime';
+import { createElement } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { Path, Router } from './decorators.js';
+import { ReactModule } from './module.js';
+import { REACT_PAGE_RENDERER, type ReactPageRenderer } from './page-renderer.js';
+import type { ReactRenderContext } from './render.js';
+import { createReactServerEntry } from './server-entry.js';
+
+type TestResponse = FrameworkResponse & { body?: unknown };
+
+function createRequest(path: string): FrameworkRequest {
+  return {
+    body: undefined,
+    cookies: {},
+    headers: {},
+    method: 'GET',
+    params: {},
+    path,
+    query: {},
+    raw: {},
+    url: path,
+  };
+}
+
+function createResponse(): TestResponse {
+  return {
+    committed: false,
+    headers: {},
+    redirect(status: number, location: string) {
+      this.setStatus(status);
+      this.setHeader('Location', location);
+      this.committed = true;
+    },
+    send(body: unknown) {
+      this.body = body;
+      this.committed = true;
+    },
+    setHeader(name: string, value: string | string[]) {
+      this.headers[name] = value;
+    },
+    setStatus(code: number) {
+      this.statusCode = code;
+    },
+  };
+}
+
+function decodeBufferedBody(response: TestResponse): string {
+  expect(response.body).toBeInstanceOf(Uint8Array);
+  if (!(response.body instanceof Uint8Array)) {
+    throw new TypeError('Expected the buffered React response to contain bytes.');
+  }
+  return new TextDecoder().decode(response.body);
+}
+
+describe('ReactPageRenderer', () => {
+  it('registers one application renderPage callback that receives the active request context', async () => {
+    const renderedRequests: Array<{
+      readonly params: Readonly<Record<string, string>>;
+      readonly url: string;
+    }> = [];
+    const applicationRenderPage: ReactPageRenderer = (page, context) => {
+      renderedRequests.push({ params: context.request.params, url: context.request.url });
+      return createReactServerEntry(
+        createElement('html', null, createElement('body', null, page)),
+        { headers: { 'x-react-page-renderer': 'application' } },
+      );
+    };
+
+    @Inject(REACT_PAGE_RENDERER)
+    @Router('/products')
+    class ProductRouter {
+      constructor(private readonly renderPage: ReactPageRenderer) {}
+
+      @Path('/:id')
+      show(_input: undefined, context: ReactRenderContext) {
+        return this.renderPage(
+          createElement('main', null, `Product ${context.request.params.id ?? 'missing'}`),
+          context,
+        );
+      }
+    }
+
+    @Inject(REACT_PAGE_RENDERER)
+    class PageRendererConsumer {
+      constructor(readonly renderPage: ReactPageRenderer) {}
+    }
+
+    @Module({
+      imports: [ReactModule.forRoot({ controllers: [ProductRouter], renderPage: applicationRenderPage })],
+      providers: [PageRendererConsumer],
+    })
+    class AppModule {}
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+
+    try {
+      const response = createResponse();
+      await app.dispatch(createRequest('/products/42'), response);
+      const consumer = await app.get(PageRendererConsumer);
+
+      expect(renderedRequests).toEqual([{ params: { id: '42' }, url: '/products/42' }]);
+      expect(consumer.renderPage).toBe(applicationRenderPage);
+      expect(response.headers['Content-Type']).toBe('text/html; charset=utf-8');
+      expect(response.headers['x-react-page-renderer']).toBe('application');
+      expect(decodeBufferedBody(response)).toContain('Product 42');
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('leaves explicit ReactServerEntry handlers unchanged when renderPage is configured', async () => {
+    let rendererCalls = 0;
+    const applicationRenderPage: ReactPageRenderer = (page) => {
+      rendererCalls += 1;
+      return createReactServerEntry(page);
+    };
+
+    @Router('/explicit')
+    class ExplicitEntryRouter {
+      @Path('/')
+      show() {
+        return createReactServerEntry(createElement('main', null, 'Explicit entry'));
+      }
+    }
+
+    @Module({
+      imports: [ReactModule.forRoot({
+        controllers: [ExplicitEntryRouter],
+        renderPage: applicationRenderPage,
+      })],
+    })
+    class AppModule {}
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+
+    try {
+      const response = createResponse();
+      await app.dispatch(createRequest('/explicit'), response);
+
+      expect(rendererCalls).toBe(0);
+      expect(decodeBufferedBody(response)).toContain('Explicit entry');
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/packages/react/src/page-renderer.ts
+++ b/packages/react/src/page-renderer.ts
@@ -1,0 +1,27 @@
+import type { Token } from '@fluojs/core';
+import type { ReactElement } from 'react';
+
+import type { ReactRenderContext } from './render.js';
+import type { ReactServerEntry } from './server-entry.js';
+
+/**
+ * Application-owned page composition callback registered through `ReactModule.forRoot(...)`.
+ *
+ * @remarks
+ * The callback can wrap one page element with an application document, shared providers,
+ * request-derived client route state, hydration assets, and recoverable-error policy. It must
+ * return `ReactServerEntry` so the existing HTTP response-writer lifecycle remains authoritative.
+ * Browser and Vite helpers stay application-owned and may be composed without widening the
+ * runtime-neutral root import boundary.
+ *
+ * @param page React page element produced by an application handler.
+ * @param context Active render context containing the matched request URL, params, and response.
+ * @returns An existing React server entry finalized by the fluo HTTP dispatcher.
+ */
+export type ReactPageRenderer = (
+  page: ReactElement,
+  context: ReactRenderContext,
+) => ReactServerEntry;
+
+/** Dependency-injection token for the application `ReactPageRenderer`. */
+export const REACT_PAGE_RENDERER: Token<ReactPageRenderer> = Symbol.for('fluo.react.page-renderer');


### PR DESCRIPTION
## Summary

Add one application-level `ReactPageRenderer` / `renderPage` seam to `ReactModule.forRoot(...)` while preserving HTTP-owned routing and the existing `ReactServerEntry` response-writer lifecycle.

Linked context: Closes #2828

## Changes

- add the TSDoc-documented `ReactPageRenderer` callback and `REACT_PAGE_RENDERER` DI token to the runtime-neutral root
- register and export `renderPage` from `ReactModule.forRoot(...)` alongside existing module metadata
- cover active URL/params delivery, imported-token visibility, existing response writing, and explicit `ReactServerEntry` bypass
- document application-owned document/client/Vite composition in synchronized English and Korean package READMEs
- add a minor Changeset for `@fluojs/react`

## Testing

- `pnpm --dir packages/react build` — passed
- `pnpm --dir packages/react typecheck` — passed
- `pnpm --dir packages/react test` — 25 files, 84 tests passed
- `pnpm verify:public-export-tsdoc` — passed
- `pnpm docs:sync-check` — passed (42 EN/KO pairs, 10 navigation pairs)
- `pnpm verify:platform-consistency-governance` — passed
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=20558847c34b17df5f0726510d5a71e1ff132de2` — passed
- `FLUO_CLI_SANDBOX_ROOT=<isolated-temp-path> pnpm verify:release-readiness` — passed without writing draft artifacts
- `pnpm test` — 361 files passed; 4477 passed, 1 skipped
- `pnpm lint` — passed; only pre-existing diagnostics in untouched files were reported

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

`.changeset/add-react-page-renderer.md` records a minor `@fluojs/react` feature.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

`ReactPageRenderer`, `REACT_PAGE_RENDERER`, and `ReactModuleOptions.renderPage` are documented at their declarations; the scenario workflow remains in the bilingual README pair.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

Explicit `ReactServerEntry` values remain unchanged. The new callback must return that existing entry type, so guards, interceptors, middleware, request scopes, aborts, shell failures, recoverable streaming, and response writing remain on the established lifecycle.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests, such as `createPlatformConformanceHarness(...)` for platform component contracts or `createHttpAdapterPortabilityHarness(...)` for HTTP adapter portability contracts.

No platform adapter contract changed, so a new platform harness is not applicable. Root-import isolation, package lifecycle coverage, docs parity, platform governance, and release-readiness checks passed.