### PR TITLE
Resolve #2829: Allow direct ReactElement page returns

### DIFF
--- a/.changeset/add-react-direct-page-returns.md
+++ b/.changeset/add-react-direct-page-returns.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/react": minor
+---
+
+Allow `@Path(...)` handlers to return one `ReactElement` through the configured application page renderer, and add stable SSR diagnostic codes and phases for HTTP pipeline failures, pre-commit shell failures, request aborts, and post-shell recoverable errors.

--- a/.changeset/add-react-direct-page-returns.md
+++ b/.changeset/add-react-direct-page-returns.md
@@ -1,5 +1,6 @@
 ---
+"@fluojs/http": patch
 "@fluojs/react": minor
 ---
 
-Allow `@Path(...)` handlers to return one `ReactElement` through the configured application page renderer, and add stable SSR diagnostic codes and phases for HTTP pipeline failures, pre-commit shell failures, request aborts, and post-shell recoverable errors.
+Add the request-local HTTP response-finalization seam used by React page rendering. Allow `@Path(...)` handlers to return one `ReactElement` through the configured application page renderer, and add stable SSR diagnostic codes and phases for HTTP pipeline failures, pre-commit shell failures, request aborts, and post-shell recoverable errors.

--- a/examples/react-stable-ssr/README.ko.md
+++ b/examples/react-stable-ssr/README.ko.md
@@ -13,9 +13,12 @@ lifecycle ownership은 `@fluojs/http`에 남겨 두고, React는 page 형태의 
 - HTTP-owned route grammar: literal segment와 full-segment `:param` placeholder만 지원합니다.
 - React server entry가 HTML을 commit하기 전에 guard, interceptor, module middleware, route header,
   entry header가 실행되는 request lifecycle.
-- `createReactServerEntry(...)`와 lazy `react-dom/server` rendering을 통한 Web Streams SSR.
+- `@Path(...)`가 직접 반환한 `ReactElement`를 application `renderPage` callback이
+  `createReactServerEntry(...)`로 compose한 뒤 lazy `react-dom/server` Web Streams로 렌더링하는 흐름.
 - Stable root의 명시적 hydration asset option: `bootstrapModules`, 신뢰된 `bootstrapScriptContent`,
   `nonce`, `identifierPrefix`, 신뢰된 `assetMap` snapshot.
+- HTTP-pipeline, pre-commit shell, request-abort, post-shell recoverable phase를 위한 stable SSR
+  diagnostics는 package README에 문서화되어 있습니다.
 
 ## 안정 경계
 
@@ -47,7 +50,7 @@ examples/react-stable-ssr/
 ├── src/
 │   ├── app.ts       # AppModule imports ReactModule.forRoot(...)
 │   ├── main.ts      # 로컬 수동 실행용 optional Fastify startup
-│   ├── pages.ts     # Router, DTO, guard, interceptor, middleware, SSR entry
+│   ├── pages.ts     # Router, direct page return, application renderer, HTTP lifecycle helper
 │   └── app.test.ts  # createTestApp request-pipeline SSR assertion
 ├── README.md
 └── README.ko.md

--- a/examples/react-stable-ssr/README.md
+++ b/examples/react-stable-ssr/README.md
@@ -14,9 +14,12 @@ request lifecycle ownership in `@fluojs/http` while using React for page-shaped 
 - HTTP-owned route grammar: literal segments plus full-segment `:param` placeholders only.
 - Guards, interceptors, module middleware, route headers, and entry headers running before the React
   server entry commits HTML.
-- Web Streams SSR through `createReactServerEntry(...)` and lazy `react-dom/server` rendering.
+- A direct `ReactElement` return from `@Path(...)`, composed by the application `renderPage` callback
+  into `createReactServerEntry(...)` before lazy `react-dom/server` Web Streams rendering.
 - Explicit hydration asset options from the stable root: `bootstrapModules`, trusted
   `bootstrapScriptContent`, `nonce`, `identifierPrefix`, and a trusted `assetMap` snapshot.
+- Stable SSR diagnostics for HTTP-pipeline, pre-commit shell, request-abort, and post-shell
+  recoverable phases are documented in the package README.
 
 ## stable boundaries
 
@@ -48,7 +51,7 @@ examples/react-stable-ssr/
 ├── src/
 │   ├── app.ts       # AppModule imports ReactModule.forRoot(...)
 │   ├── main.ts      # Optional Fastify startup for local manual runs
-│   ├── pages.ts     # Router, DTO, guard, interceptor, middleware, and SSR entry
+│   ├── pages.ts     # Router, direct page return, application renderer, and HTTP lifecycle helpers
 │   └── app.test.ts  # createTestApp request-pipeline SSR assertion
 ├── README.md
 └── README.ko.md

--- a/examples/react-stable-ssr/src/app.ts
+++ b/examples/react-stable-ssr/src/app.ts
@@ -7,6 +7,7 @@ import {
   ProductPageRouter,
   ReactSsrTraceMiddleware,
   RenderPhaseInterceptor,
+  renderProductPage,
 } from './pages';
 
 @Module({
@@ -15,6 +16,7 @@ import {
       controllers: [ProductPageRouter],
       middleware: [ReactSsrTraceMiddleware],
       providers: [ProductCatalogService, PreviewGuard, RenderPhaseInterceptor],
+      renderPage: renderProductPage,
     }),
   ],
 })

--- a/examples/react-stable-ssr/src/pages.ts
+++ b/examples/react-stable-ssr/src/pages.ts
@@ -16,7 +16,13 @@ import {
   UseGuards,
   UseInterceptors,
 } from '@fluojs/http';
-import { Path, Router, createReactServerEntry, type ReactAssetMap } from '@fluojs/react';
+import {
+  Path,
+  Router,
+  createReactServerEntry,
+  type ReactAssetMap,
+  type ReactPageRenderer,
+} from '@fluojs/react';
 import { Suspense, createElement } from 'react';
 
 const HYDRATION_ASSETS = {
@@ -103,6 +109,15 @@ function ProductPage({ assetMap, model }: ProductPageProps) {
   );
 }
 
+export const renderProductPage: ReactPageRenderer = (page) => createReactServerEntry(page, {
+  assetMap: HYDRATION_ASSETS,
+  bootstrapModules: [HYDRATION_ASSETS['client.js'], HYDRATION_ASSETS['client.js']],
+  bootstrapScriptContent: 'window.__FLUO_REACT_STABLE_SSR__ = true;',
+  headers: { 'x-example-entry': 'react-server-entry' },
+  identifierPrefix: 'fluo-react-stable-',
+  nonce: 'example-nonce',
+});
+
 @Inject(ProductCatalogService)
 @UseGuards(PreviewGuard)
 @UseInterceptors(RenderPhaseInterceptor)
@@ -116,13 +131,6 @@ export class ProductPageRouter {
   show(input: ProductPageRequest) {
     const model = this.catalog.renderProduct(input);
 
-    return createReactServerEntry(createElement(ProductPage, { assetMap: HYDRATION_ASSETS, model }), {
-      assetMap: HYDRATION_ASSETS,
-      bootstrapModules: [HYDRATION_ASSETS['client.js'], HYDRATION_ASSETS['client.js']],
-      bootstrapScriptContent: 'window.__FLUO_REACT_STABLE_SSR__ = true;',
-      headers: { 'x-example-entry': 'react-server-entry' },
-      identifierPrefix: 'fluo-react-stable-',
-      nonce: 'example-nonce',
-    });
+    return createElement(ProductPage, { assetMap: HYDRATION_ASSETS, model });
   }
 }

--- a/examples/react-vite-ssr/README.ko.md
+++ b/examples/react-vite-ssr/README.ko.md
@@ -10,6 +10,8 @@ SSR, Vite manifest asset, hydrated browser runtime을 연결합니다.
 
 - fluo HTTP module graph가 발견하는 `@Router('/products')` 및 `@Path('/:sku')` page route.
 - `@RequestDto(...)`, `@FromPath('sku')`, `@FromQuery('preview')`를 통한 typed path/search input.
+- Application `renderPage` callback이 manifest-derived hydration option과 compose하는 직접적인
+  `ReactElement` page return.
 - Web Streams SSR이 fallback과 resolve된 recommendation content를 emit하는 `Suspense` boundary.
 - `dist/client/.vite/manifest.json`을 생성하는 Vite client build와, 이미 로드한 manifest를 ordered
   CSS 및 hydration module asset으로 바꾸는 `@fluojs/react/vite`.
@@ -48,6 +50,8 @@ state가 일치하지 않는 client navigation이 있으면 실패합니다.
 
 - 안정 `0.1.0` root contract는 계속 HTTP-first React SSR을 소유합니다. 이 `0.2.0` 예제는 초기
   SSR 예제 이후 추가된 `@fluojs/react/vite` manifest parser와 그 contract를 조합합니다.
+- Direct page return은 두 번째 response path를 만들지 않습니다. Application renderer는 계속
+  `ReactServerEntry`를 반환하고 기존 HTTP writer가 status, header, error, streaming을 소유합니다.
 - `src/entry-client.ts`가 browser-only boundary입니다. Server module은 `window`나 `document`에
   접근하지 않으며, server는 application boundary에서 Vite manifest를 명시적으로 로드합니다.
 - `ReactClientRouterProvider`는 SSR과 hydration에서 같은 request URL과 HTTP-matched param을 받습니다.

--- a/examples/react-vite-ssr/README.md
+++ b/examples/react-vite-ssr/README.md
@@ -11,6 +11,8 @@ hydrated browser runtime without introducing a second routing model.
 - `@Router('/products')` and `@Path('/:sku')` page routes discovered by the fluo HTTP module graph.
 - Typed path and search input through `@RequestDto(...)`, `@FromPath('sku')`, and
   `@FromQuery('preview')`.
+- A direct `ReactElement` page return composed by the application `renderPage` callback with
+  manifest-derived hydration options.
 - A `Suspense` boundary whose fallback and resolved recommendation content are emitted by Web
   Streams SSR.
 - A Vite client build that writes `dist/client/.vite/manifest.json`, then
@@ -50,6 +52,8 @@ client navigation whose URL and server-rendered route state do not agree.
 
 - The stable `0.1.0` root contract still owns HTTP-first React SSR. This `0.2.0` example composes
   that contract with the `@fluojs/react/vite` manifest parser added after the initial SSR example.
+- Direct page returns do not create a second response path: the application renderer still returns
+  `ReactServerEntry`, and the existing HTTP writer owns status, headers, errors, and streaming.
 - `src/entry-client.ts` is the browser-only boundary. Server modules do not access `window` or
   `document`, and the server loads the Vite manifest explicitly from the application boundary.
 - `ReactClientRouterProvider` receives the same request URL and HTTP-matched params during SSR and

--- a/examples/react-vite-ssr/src/app.ts
+++ b/examples/react-vite-ssr/src/app.ts
@@ -11,7 +11,13 @@ import {
   RequestDto,
   type RequestContext,
 } from '@fluojs/http';
-import { Path, ReactModule, Router, createReactServerEntry } from '@fluojs/react';
+import {
+  Path,
+  ReactModule,
+  Router,
+  createReactServerEntry,
+  type ReactPageRenderer,
+} from '@fluojs/react';
 import { createReactViteAssetManifest } from '@fluojs/react/vite';
 import { IsIn, IsString, MinLength } from '@fluojs/validation';
 import { createElement } from 'react';
@@ -63,22 +69,20 @@ export function createReactViteExampleModule(options: ReactViteExampleModuleOpti
   }
 
   const assets = result.manifest;
+  const renderPage: ReactPageRenderer = (page) => createReactServerEntry(page, assets.hydrationOptions);
 
   @Router('/products')
   class ProductPageRouter {
     @Path('/:sku')
     @RequestDto(ProductPageRequest)
     show(input: ProductPageRequest, context: RequestContext) {
-      return createReactServerEntry(
-        createElement(ProductDocument, {
-          preview: input.preview === 'true',
-          routeParams: context.request.params,
-          routeUrl: context.request.url,
-          sku: input.sku,
-          stylesheets: assets.css,
-        }),
-        assets.hydrationOptions,
-      );
+      return createElement(ProductDocument, {
+        preview: input.preview === 'true',
+        routeParams: context.request.params,
+        routeUrl: context.request.url,
+        sku: input.sku,
+        stylesheets: assets.css,
+      });
     }
   }
 
@@ -109,7 +113,7 @@ export function createReactViteExampleModule(options: ReactViteExampleModuleOpti
 
   @Module({
     controllers: [ViteAssetController],
-    imports: [ReactModule.forRoot({ controllers: [ProductPageRouter] })],
+    imports: [ReactModule.forRoot({ controllers: [ProductPageRouter], renderPage })],
   })
   class ReactViteExampleModule {}
 

--- a/packages/http/src/dispatch/dispatch-response-policy.test.ts
+++ b/packages/http/src/dispatch/dispatch-response-policy.test.ts
@@ -5,10 +5,12 @@ import {
   Controller,
   createDispatcher,
   createHandlerMapping,
-  type FrameworkRequest,
-  type FrameworkResponse,
-  Get,
-  Header,
+    type FrameworkRequest,
+    type FrameworkResponse,
+    Get,
+    Header,
+    type MiddlewareContext,
+    type Next,
 } from '../index.js';
 
 type CustomResponseWriterContext = {
@@ -100,5 +102,51 @@ describe('dispatch response policy', () => {
     expect(response.headers['x-react-route']).toBe('html');
     expect(response.headers['Content-Type']).toBe('text/html; charset=utf-8');
     expect(response.body).toBe('<main>React SSR</main>');
+  });
+
+  it('finalizes an integration-owned handler value before selecting its response writer', async () => {
+    const pageValue = { kind: 'page' };
+    const htmlEntry = { html: '<main>Finalized page</main>' };
+
+    Object.defineProperty(htmlEntry, Symbol.for('fluo.http.responseWriter'), {
+      enumerable: false,
+      value(context: CustomResponseWriterContext) {
+        context.applySuccessResponseMetadata();
+        context.response.setHeader('Content-Type', 'text/html; charset=utf-8');
+        return context.response.send(htmlEntry.html);
+      },
+    });
+
+    @Controller('/response-finalizer')
+    class ResponseFinalizerController {
+      @Get('/page')
+      getValue() {
+        return pageValue;
+      }
+    }
+
+    const root = new Container().register(ResponseFinalizerController);
+    const dispatcher = createDispatcher({
+      appMiddleware: [{
+        async handle(context: MiddlewareContext, next: Next) {
+          context.requestContext.metadata[Symbol.for('fluo.http.responseValueFinalizer')] = ({ value }: { value: unknown }) => (
+            value === pageValue ? htmlEntry : value
+          );
+          await next();
+        },
+      }],
+      handlerMapping: createHandlerMapping([{ controllerToken: ResponseFinalizerController }]),
+      rootContainer: root,
+    });
+    const response = createResponse();
+
+    // Given: an integration installs a request-local result finalizer through middleware metadata.
+    // When: the controller result reaches the shared success-response policy.
+    await dispatcher.dispatch(createRequest('/response-finalizer/page'), response);
+
+    // Then: the finalized value uses its custom writer instead of ordinary object serialization.
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['Content-Type']).toBe('text/html; charset=utf-8');
+    expect(response.body).toBe('<main>Finalized page</main>');
   });
 });

--- a/packages/http/src/dispatch/dispatch-response-policy.ts
+++ b/packages/http/src/dispatch/dispatch-response-policy.ts
@@ -14,6 +14,7 @@ import { writeErrorResponse } from './dispatch-error-policy.js';
 
 type SimpleJsonResponseBody = Record<string, unknown> | unknown[];
 const responseWriterKey = Symbol.for('fluo.http.responseWriter');
+const responseValueFinalizerKey = Symbol.for('fluo.http.responseValueFinalizer');
 
 type FrameworkResponseWriterContext = {
   readonly applySuccessResponseMetadata: () => void;
@@ -24,6 +25,16 @@ type FrameworkResponseWriterContext = {
 };
 
 type FrameworkResponseWriter = (context: FrameworkResponseWriterContext) => ReturnType<FrameworkResponse['send']> | void;
+
+type FrameworkResponseValueFinalizerContext = {
+  readonly handler: HandlerDescriptor;
+  readonly request: FrameworkRequest;
+  readonly requestContext: RequestContext;
+  readonly response: FrameworkResponse;
+  readonly value: unknown;
+};
+
+type FrameworkResponseValueFinalizer = (context: FrameworkResponseValueFinalizerContext) => unknown;
 
 type SimpleJsonFrameworkResponse = FrameworkResponse & {
   sendSimpleJson(body: SimpleJsonResponseBody): ReturnType<FrameworkResponse['send']>;
@@ -79,6 +90,16 @@ function readFrameworkResponseWriter(value: unknown): FrameworkResponseWriter | 
   const writer = Reflect.get(value, responseWriterKey);
 
   return typeof writer === 'function' ? writer : undefined;
+}
+
+function readFrameworkResponseValueFinalizer(requestContext: RequestContext): FrameworkResponseValueFinalizer | undefined {
+  const finalizer = requestContext.metadata[responseValueFinalizerKey];
+
+  if (typeof finalizer !== 'function') {
+    return undefined;
+  }
+
+  return (context) => Reflect.apply(finalizer, undefined, [context]);
 }
 
 function isResponseBodyForbidden(status: number | undefined): boolean {
@@ -149,7 +170,11 @@ export function writeSuccessResponse(
     return;
   }
 
-  const responseWriter = readFrameworkResponseWriter(value);
+  const responseValueFinalizer = readFrameworkResponseValueFinalizer(requestContext);
+  const responseValue = responseValueFinalizer
+    ? responseValueFinalizer({ handler, request, requestContext, response, value })
+    : value;
+  const responseWriter = readFrameworkResponseWriter(responseValue);
 
   if (responseWriter) {
     let successResponseMetadataApplied = false;
@@ -159,7 +184,7 @@ export function writeSuccessResponse(
       }
 
       successResponseMetadataApplied = true;
-      applySuccessResponseMetadata({ formatter: undefined, handler, response, value });
+      applySuccessResponseMetadata({ formatter: undefined, handler, response, value: responseValue });
     };
 
     return responseWriter({
@@ -175,15 +200,15 @@ export function writeSuccessResponse(
     ? selectResponseFormatter(handler, request, contentNegotiation)
     : undefined;
 
-  applySuccessResponseMetadata({ formatter, handler, response, value });
+  applySuccessResponseMetadata({ formatter, handler, response, value: responseValue });
 
-  if (!formatter && hasSimpleJsonResponseWriter(response) && canUseSimpleJsonFastPath(response, value)) {
-    return response.sendSimpleJson(value);
+  if (!formatter && hasSimpleJsonResponseWriter(response) && canUseSimpleJsonFastPath(response, responseValue)) {
+    return response.sendSimpleJson(responseValue);
   }
 
   const responseBody = formatter
-    ? formatter.format(value)
-    : value;
+    ? formatter.format(responseValue)
+    : responseValue;
   return response.send(responseBody);
 }
 

--- a/packages/react/README.ko.md
+++ b/packages/react/README.ko.md
@@ -13,6 +13,7 @@ fluo 애플리케이션을 위한 런타임 중립 React 통합입니다.
 - [Phase Boundaries](#phase-boundaries)
 - [ReactModule Registration](#reactmodule-registration)
 - [Application Page Renderer](#application-page-renderer)
+- [SSR Diagnostic Phases](#ssr-diagnostic-phases)
 - [Router 및 Path Decorators](#router-및-path-decorators)
 - [Web Streams SSR](#web-streams-ssr)
 - [Hydration Asset Contract](#hydration-asset-contract)
@@ -57,8 +58,9 @@ guards, interceptors, headers, module middleware, request scope, request lifecyc
 따라서 이 패키지는 Next.js App Router clone, React Server Components framework, TanStack route tree,
 Angular `Routes[]` table, file-route scanner, primary React-owned `routes: []` configuration model이
 **아닙니다**. React router는 page 형태를 가진 HTTP handler로 이해하세요. Route discovery와 dispatch는
-기존 fluo module/controller pipeline에 남아 있고, page handler는 일반 값을 반환하거나 streamed HTML이
-필요할 때 `createReactServerEntry(...)`를 반환합니다.
+기존 fluo module/controller pipeline에 남아 있습니다. Page handler는 일반 HTTP 값을 반환하거나,
+configured application page renderer가 처리할 유효한 `ReactElement` 하나를 반환하거나, route별 SSR option이
+필요할 때 `createReactServerEntry(...)`를 명시적으로 반환할 수 있습니다.
 
 ## 런타임 및 피어 계약
 
@@ -140,10 +142,9 @@ Callback은 `ReactPageRenderer`를 구현하고 하나의 `ReactElement`와 활�
 inject할 수 있습니다.
 
 ```tsx
-import { Inject, Module } from '@fluojs/core';
+import { Module } from '@fluojs/core';
 import {
   Path,
-  REACT_PAGE_RENDERER,
   ReactModule,
   Router,
   createReactServerEntry,
@@ -178,14 +179,11 @@ const renderPage: ReactPageRenderer = (page, context) => {
   );
 };
 
-@Inject(REACT_PAGE_RENDERER)
 @Router('/products')
 class ProductRouter {
-  constructor(private readonly renderPage: ReactPageRenderer) {}
-
   @Path('/:id')
   show(_input: undefined, context: ReactRenderContext) {
-    return this.renderPage(<main>Product {context.request.params.id}</main>, context);
+    return <main>Product {context.request.params.id}</main>;
   }
 }
 
@@ -202,9 +200,47 @@ Root package는 `@fluojs/react/client`나 `@fluojs/react/vite`를 import하지 �
 binding, middleware, guard, interceptor, request scope, abort propagation, shell failure handling,
 recoverable streaming behavior를 우회하지 않습니다.
 
-이 phase는 JSX return 값을 암묵적으로 변환하지 않습니다. Handler는 `REACT_PAGE_RENDERER`를 inject해
-호출하거나 계속 `createReactServerEntry(...)`를 직접 반환해야 합니다. 명시적인 `ReactServerEntry` 값은
-그대로 유지되며 configured callback을 통과하지 않습니다.
+`renderPage`가 configured 상태라면 `@Path(...)` request의 최종 값 중 React
+`isValidElement(...)`가 단일 `ReactElement`로 판별한 값만 callback에 전달합니다. Plain object, string,
+array, `null`, 그 밖의 일반 값은 기존 HTTP response path를 유지합니다. 명시적인 `ReactServerEntry`는
+그대로 유지되고 configured callback을 통과하지 않습니다. 다른 application provider가 같은 renderer를
+명시적으로 호출해야 할 때는 `REACT_PAGE_RENDERER` token을 계속 사용할 수 있습니다.
+
+`renderPage`를 설정하지 않고 `ReactElement`를 반환하면 response commit 전에
+`ReactSsrDiagnosticError`가 발생합니다. Code는 `react-ssr-missing-page-renderer`이고 해결 방법을 포함한
+message를 제공합니다. `ReactModule.forRoot({ ..., renderPage })`를 설정하거나
+`createReactServerEntry(...)`를 명시적으로 반환하세요.
+
+## SSR Diagnostic Phases
+
+Application logging이나 diagnostics tooling이 HTTP 및 React rendering boundary 전체에서 하나의 안정된 event
+shape를 사용해야 한다면 `ReactModule.forRoot(...)`에 `onDiagnostic`을 등록하세요.
+
+```tsx
+ReactModule.forRoot({
+  controllers: [ProductRouter],
+  renderPage,
+  onDiagnostic(diagnostic) {
+    applicationDiagnostics.report(diagnostic);
+  },
+});
+```
+
+각 `ReactSsrDiagnostic`은 `code`, `phase`, 원본 `error`, 활성 `request`, optional `requestId`를
+포함합니다. Callback은 observational contract입니다. Callback이 throw해도 request outcome을 대체하지
+않습니다. Stable phase와 code는 다음과 같습니다.
+
+| Phase | Code | Boundary |
+| --- | --- | --- |
+| `http-pipeline` | `react-ssr-http-pipeline-failure` | React shell rendering 전 DTO binding, middleware, guard, interceptor, handler 및 기타 HTTP pipeline failure입니다. |
+| `http-pipeline` | `react-ssr-missing-page-renderer` | 유효한 `ReactElement`가 `renderPage` 설정 없이 `@Path(...)` response에 도달했습니다. |
+| `pre-commit-shell` | `react-ssr-pre-commit-shell-failure` | Response commit 전 React shell 생성 또는 buffered stream collection이 실패했습니다. 원본 throw된 `Error` identity를 보존합니다. |
+| `request-abort` | `react-ssr-request-abort` | Request signal 또는 abort probe가 React rendering을 중단했습니다. 기존 no-commit 또는 committed-stream abort behavior는 바뀌지 않습니다. |
+| `post-shell-recoverable` | `react-ssr-post-shell-recoverable-error` | Shell을 쓸 수 있게 된 뒤 React가 recoverable render error를 보고했습니다. Status와 header를 다시 쓰지 않습니다. |
+
+`REACT_SSR_DIAGNOSTIC_PHASES`와 `REACT_SSR_DIAGNOSTIC_CODES`는 비교에 사용할 수 있는 이 값을
+노출합니다. 기존 entry `onRecoverableError` hook도 `ReactRecoverableErrorContext`의 `code`와 `phase`를
+받습니다.
 
 ## Router 및 Path Decorators
 
@@ -251,7 +287,8 @@ route를 유지해야 하며, 향후 catch-all은 먼저 승인된 `@fluojs/http
 
 ## Web Streams SSR
 
-React page handler에서 `createReactServerEntry(...)`를 반환하면 기존 fluo HTTP dispatcher를 통해 HTML을
+Configured application page renderer를 통해 `ReactElement` 하나를 반환하거나
+`createReactServerEntry(...)`를 명시적으로 반환하면 기존 fluo HTTP dispatcher를 통해 HTML을
 streaming합니다. Guard, interceptor, module middleware, route header, `@HttpCode(...)`, DTO binding,
 request scope, duplicate route detection은 모두 `renderReactResponse(...)`가 HTML response를 finalize하기
 전에 실행됩니다.
@@ -724,6 +761,13 @@ stable subpath를 추가하지 않고 deprecation window도 시작하지 않습�
   dependency-injection token입니다.
 - `ReactPageRenderer` — `ReactElement`와 활성 `ReactRenderContext`를 기존 `ReactServerEntry`로 compose하는
   type-only application callback입니다.
+- `REACT_SSR_DIAGNOSTIC_PHASES` 및 `REACT_SSR_DIAGNOSTIC_CODES` — stable machine-readable SSR
+  lifecycle phase 및 diagnostic code constant입니다.
+- `ReactSsrDiagnosticError` — stable `code`와 `phase` metadata를 가진 typed pre-commit
+  configuration/render failure입니다.
+- `ReactSsrDiagnostic`, `ReactSsrDiagnosticCode`, `ReactSsrDiagnosticErrorOptions`,
+  `ReactSsrDiagnosticHandler`, `ReactSsrDiagnosticPhase` — application diagnostics tooling을 위한
+  type-only contract입니다.
 - `createReactServerEntry` — page handler가 Web Streams SSR을 위해 반환하는 runtime-neutral React server
   entry를 생성합니다.
 - `renderReactResponse` — lazy `react-dom/server` loading으로 React server entry 하나를 fluo HTML

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -13,6 +13,7 @@ Runtime-neutral React integration for fluo applications.
 - [Phase Boundaries](#phase-boundaries)
 - [ReactModule Registration](#reactmodule-registration)
 - [Application Page Renderer](#application-page-renderer)
+- [SSR Diagnostic Phases](#ssr-diagnostic-phases)
 - [Router and Path Decorators](#router-and-path-decorators)
 - [Web Streams SSR](#web-streams-ssr)
 - [Hydration Asset Contract](#hydration-asset-contract)
@@ -59,8 +60,9 @@ validation, guards, interceptors, headers, module middleware, request scopes, an
 This package is therefore **not** a Next.js App Router clone, React Server Components framework,
 TanStack route tree, Angular `Routes[]` table, file-route scanner, or primary React-owned
 `routes: []` configuration model. Treat React routers as page-shaped HTTP handlers. Route discovery
-and dispatch stay in the existing fluo module/controller pipeline, and page handlers return either
-ordinary values or `createReactServerEntry(...)` when they want streamed HTML.
+and dispatch stay in the existing fluo module/controller pipeline. Page handlers may return ordinary
+HTTP values, return one valid `ReactElement` for the configured application page renderer, or return
+`createReactServerEntry(...)` explicitly when they need per-route SSR options.
 
 ## Runtime and Peer Contract
 
@@ -143,10 +145,9 @@ must return `ReactServerEntry`. `ReactModule.forRoot(...)` registers and exports
 `REACT_PAGE_RENDERER`, so routers can inject the callback without creating a second response path.
 
 ```tsx
-import { Inject, Module } from '@fluojs/core';
+import { Module } from '@fluojs/core';
 import {
   Path,
-  REACT_PAGE_RENDERER,
   ReactModule,
   Router,
   createReactServerEntry,
@@ -181,14 +182,11 @@ const renderPage: ReactPageRenderer = (page, context) => {
   );
 };
 
-@Inject(REACT_PAGE_RENDERER)
 @Router('/products')
 class ProductRouter {
-  constructor(private readonly renderPage: ReactPageRenderer) {}
-
   @Path('/:id')
   show(_input: undefined, context: ReactRenderContext) {
-    return this.renderPage(<main>Product {context.request.params.id}</main>, context);
+    return <main>Product {context.request.params.id}</main>;
   }
 }
 
@@ -204,9 +202,47 @@ already-loaded manifest by `createReactViteAssetManifest(...)`. The renderer doe
 manifests, generate bundles, match routes, or bypass DTO binding, middleware, guards, interceptors,
 request scopes, abort propagation, shell failure handling, or recoverable streaming behavior.
 
-This phase does not implicitly convert a JSX return value. A handler must inject and call
-`REACT_PAGE_RENDERER`, or continue returning `createReactServerEntry(...)` directly. Explicit
-`ReactServerEntry` values remain unchanged and do not pass through the configured callback.
+When `renderPage` is configured, the final value from an `@Path(...)` request is passed to that
+callback only when React `isValidElement(...)` recognizes it as one `ReactElement`. Plain objects,
+strings, arrays, `null`, and other ordinary values keep the normal HTTP response path. Explicit
+`ReactServerEntry` values remain unchanged and do not pass through the configured callback. The
+`REACT_PAGE_RENDERER` token remains available when another application provider needs to invoke the
+same renderer explicitly.
+
+Returning a `ReactElement` without configuring `renderPage` fails before response commit with
+`ReactSsrDiagnosticError`, code `react-ssr-missing-page-renderer`, and an actionable message. Configure
+`ReactModule.forRoot({ ..., renderPage })` or return `createReactServerEntry(...)` explicitly.
+
+## SSR Diagnostic Phases
+
+Register `onDiagnostic` on `ReactModule.forRoot(...)` when application logging or diagnostics tooling
+needs one stable event shape across HTTP and React rendering boundaries:
+
+```tsx
+ReactModule.forRoot({
+  controllers: [ProductRouter],
+  renderPage,
+  onDiagnostic(diagnostic) {
+    applicationDiagnostics.report(diagnostic);
+  },
+});
+```
+
+Each `ReactSsrDiagnostic` contains `code`, `phase`, the original `error`, the active `request`, and an
+optional `requestId`. The callback is observational: an exception thrown by it does not replace the
+request outcome. Stable phases and codes are:
+
+| Phase | Code | Boundary |
+| --- | --- | --- |
+| `http-pipeline` | `react-ssr-http-pipeline-failure` | DTO binding, middleware, guards, interceptors, handlers, and other failures before React shell rendering. |
+| `http-pipeline` | `react-ssr-missing-page-renderer` | A valid `ReactElement` reached an `@Path(...)` response without `renderPage` configuration. |
+| `pre-commit-shell` | `react-ssr-pre-commit-shell-failure` | React shell creation or buffered stream collection failed before response commit. The original thrown `Error` identity is preserved. |
+| `request-abort` | `react-ssr-request-abort` | The request signal or abort probe stopped React rendering; existing no-commit or committed-stream abort behavior remains unchanged. |
+| `post-shell-recoverable` | `react-ssr-post-shell-recoverable-error` | React reported a recoverable render error after a shell could be written; status and headers are not rewritten. |
+
+`REACT_SSR_DIAGNOSTIC_PHASES` and `REACT_SSR_DIAGNOSTIC_CODES` expose these values for comparisons.
+The existing `onRecoverableError` entry hook also receives `code` and `phase` in
+`ReactRecoverableErrorContext`.
 
 ## Router and Path Decorators
 
@@ -253,10 +289,10 @@ server routes, and any future catch-all must first become an approved `@fluojs/h
 
 ## Web Streams SSR
 
-Return `createReactServerEntry(...)` from a React page handler to stream HTML through the existing
-fluo HTTP dispatcher. Guards, interceptors, module middleware, route headers, `@HttpCode(...)`, DTO
-binding, request scopes, and duplicate route detection all run before `renderReactResponse(...)`
-finalizes the HTML response.
+Return one `ReactElement` through a configured application page renderer, or return
+`createReactServerEntry(...)` explicitly, to stream HTML through the existing fluo HTTP dispatcher.
+Guards, interceptors, module middleware, route headers, `@HttpCode(...)`, DTO binding, request scopes,
+and duplicate route detection all run before `renderReactResponse(...)` finalizes the HTML response.
 
 ```tsx
 import { HttpCode, RequestDto, FromPath } from '@fluojs/http';
@@ -734,6 +770,13 @@ This package currently does **not** provide:
   `ReactModule.forRoot({ renderPage })`.
 - `ReactPageRenderer` — type-only application callback that composes a `ReactElement` and active
   `ReactRenderContext` into an existing `ReactServerEntry`.
+- `REACT_SSR_DIAGNOSTIC_PHASES` and `REACT_SSR_DIAGNOSTIC_CODES` — stable machine-readable SSR
+  lifecycle phase and diagnostic code constants.
+- `ReactSsrDiagnosticError` — typed pre-commit configuration/render failure with stable `code` and
+  `phase` metadata.
+- `ReactSsrDiagnostic`, `ReactSsrDiagnosticCode`, `ReactSsrDiagnosticErrorOptions`,
+  `ReactSsrDiagnosticHandler`, and `ReactSsrDiagnosticPhase` — type-only contracts for application
+  diagnostics tooling.
 - `createReactServerEntry` — creates a runtime-neutral React server entry returned by page handlers
   for Web Streams SSR.
 - `renderReactResponse` — renders one React server entry to a fluo HTML response with lazy

--- a/packages/react/src/diagnostics.ts
+++ b/packages/react/src/diagnostics.ts
@@ -86,11 +86,30 @@ type ReactSsrDiagnosticMarker = {
   readonly phase: ReactSsrDiagnosticPhase;
 };
 
-const diagnosticMarkers = new WeakMap<object, ReactSsrDiagnosticMarker>();
 const diagnosticHandlerKey = Symbol.for('fluo.react.ssrDiagnosticHandler');
+const diagnosticMarkerKey = Symbol.for('fluo.react.ssrDiagnosticMarker');
+
+class ReactSsrDiagnosticMarkerStore {
+  private readonly markers = new WeakMap<object, ReactSsrDiagnosticMarker>();
+
+  set(error: object, marker: ReactSsrDiagnosticMarker): void {
+    this.markers.set(error, marker);
+  }
+
+  take(error: object): ReactSsrDiagnosticMarker | undefined {
+    const marker = this.markers.get(error);
+    this.markers.delete(error);
+    return marker;
+  }
+}
 
 function isDiagnosticMarkerKey(value: unknown): value is object {
   return (typeof value === 'object' && value !== null) || typeof value === 'function';
+}
+
+function readReactSsrDiagnosticMetadata(context: object): object | undefined {
+  const metadata: unknown = Reflect.get(context, 'metadata');
+  return typeof metadata === 'object' && metadata !== null ? metadata : undefined;
 }
 
 /**
@@ -120,8 +139,8 @@ export function bindReactSsrDiagnosticHandler(
 export function readReactSsrDiagnosticHandler(
   context: object,
 ): ReactSsrDiagnosticHandler | undefined {
-  const metadata: unknown = Reflect.get(context, 'metadata');
-  if (typeof metadata !== 'object' || metadata === null) {
+  const metadata = readReactSsrDiagnosticMetadata(context);
+  if (metadata === undefined) {
     return undefined;
   }
 
@@ -136,34 +155,48 @@ export function readReactSsrDiagnosticHandler(
 /**
  * Associates a diagnostic classification with an error without changing its identity.
  *
+ * @param context Render context that owns the request-local marker.
  * @param error Original lifecycle failure.
  * @param marker Stable code and phase retained for the request error boundary.
  */
 export function markReactSsrDiagnostic(
+  context: object,
   error: unknown,
   marker: ReactSsrDiagnosticMarker,
 ): void {
-  if (isDiagnosticMarkerKey(error)) {
-    diagnosticMarkers.set(error, marker);
+  const metadata = readReactSsrDiagnosticMetadata(context);
+  if (metadata !== undefined && isDiagnosticMarkerKey(error)) {
+    const state: unknown = Reflect.get(metadata, diagnosticMarkerKey);
+    const store = state instanceof ReactSsrDiagnosticMarkerStore
+      ? state
+      : new ReactSsrDiagnosticMarkerStore();
+    store.set(error, marker);
+    Reflect.set(metadata, diagnosticMarkerKey, store);
   }
 }
 
 /**
  * Reads and consumes the diagnostic classification associated with an error.
  *
+ * @param context Request context that owns the request-local marker.
  * @param error Original lifecycle failure.
  * @returns The retained classification, when one exists.
  */
 export function readReactSsrDiagnosticMarker(
+  context: object,
   error: unknown,
 ): ReactSsrDiagnosticMarker | undefined {
-  if (!isDiagnosticMarkerKey(error)) {
+  const metadata = readReactSsrDiagnosticMetadata(context);
+  if (metadata === undefined || !isDiagnosticMarkerKey(error)) {
     return undefined;
   }
 
-  const marker = diagnosticMarkers.get(error);
-  diagnosticMarkers.delete(error);
-  return marker;
+  const state: unknown = Reflect.get(metadata, diagnosticMarkerKey);
+  if (!(state instanceof ReactSsrDiagnosticMarkerStore)) {
+    return undefined;
+  }
+
+  return state.take(error);
 }
 
 /**

--- a/packages/react/src/diagnostics.ts
+++ b/packages/react/src/diagnostics.ts
@@ -1,0 +1,143 @@
+import { FluoError } from '@fluojs/core';
+import type { FrameworkRequest } from '@fluojs/http';
+
+/** Stable machine-readable phases for the React SSR request lifecycle. */
+export const REACT_SSR_DIAGNOSTIC_PHASES = {
+  httpPipeline: 'http-pipeline',
+  postShellRecoverable: 'post-shell-recoverable',
+  preCommitShell: 'pre-commit-shell',
+  requestAbort: 'request-abort',
+} as const;
+
+/** Stable machine-readable codes emitted by React SSR diagnostics. */
+export const REACT_SSR_DIAGNOSTIC_CODES = {
+  httpPipelineFailure: 'react-ssr-http-pipeline-failure',
+  missingPageRenderer: 'react-ssr-missing-page-renderer',
+  postShellRecoverableError: 'react-ssr-post-shell-recoverable-error',
+  preCommitShellFailure: 'react-ssr-pre-commit-shell-failure',
+  requestAbort: 'react-ssr-request-abort',
+} as const;
+
+/** Machine-readable React SSR lifecycle phase. */
+export type ReactSsrDiagnosticPhase =
+  (typeof REACT_SSR_DIAGNOSTIC_PHASES)[keyof typeof REACT_SSR_DIAGNOSTIC_PHASES];
+
+/** Machine-readable React SSR diagnostic code. */
+export type ReactSsrDiagnosticCode =
+  (typeof REACT_SSR_DIAGNOSTIC_CODES)[keyof typeof REACT_SSR_DIAGNOSTIC_CODES];
+
+/** Structured diagnostic emitted while a React page request is processed. */
+export type ReactSsrDiagnostic = {
+  /** Stable machine-readable diagnostic code. */
+  readonly code: ReactSsrDiagnosticCode;
+  /** Original failure reported at this lifecycle boundary. */
+  readonly error: unknown;
+  /** Stable lifecycle phase associated with the failure. */
+  readonly phase: ReactSsrDiagnosticPhase;
+  /** Active framework request. */
+  readonly request: FrameworkRequest;
+  /** Adapter-provided request id, when available. */
+  readonly requestId?: string;
+};
+
+/** Application callback for observing structured React SSR diagnostics. */
+export type ReactSsrDiagnosticHandler = (diagnostic: ReactSsrDiagnostic) => void;
+
+/** Options for creating a typed React SSR diagnostic error. */
+export type ReactSsrDiagnosticErrorOptions = {
+  /** Stable machine-readable diagnostic code. */
+  readonly code: ReactSsrDiagnosticCode;
+  /** Original failure, when one exists. */
+  readonly cause?: unknown;
+  /** Stable lifecycle phase associated with the failure. */
+  readonly phase: ReactSsrDiagnosticPhase;
+};
+
+/** Typed React SSR failure carrying stable code and phase metadata. */
+export class ReactSsrDiagnosticError extends FluoError {
+  /** Stable machine-readable diagnostic code for this failure. */
+  override readonly code: ReactSsrDiagnosticCode;
+  /** Stable lifecycle phase associated with this failure. */
+  readonly phase: ReactSsrDiagnosticPhase;
+
+  /**
+   * Creates a typed React SSR lifecycle failure.
+   *
+   * @param message Actionable human-readable failure description.
+   * @param options Stable code, phase, and optional original failure.
+   */
+  constructor(
+    message: string,
+    options: ReactSsrDiagnosticErrorOptions,
+  ) {
+    super(message, {
+      code: options.code,
+      ...(options.cause === undefined ? {} : { cause: options.cause }),
+      meta: { phase: options.phase },
+    });
+    this.code = options.code;
+    this.phase = options.phase;
+  }
+}
+
+type ReactSsrDiagnosticMarker = {
+  readonly code: ReactSsrDiagnosticCode;
+  readonly error: unknown;
+  readonly phase: ReactSsrDiagnosticPhase;
+};
+
+const diagnosticMarkers = new WeakMap<object, ReactSsrDiagnosticMarker>();
+
+function isDiagnosticMarkerKey(value: unknown): value is object {
+  return (typeof value === 'object' && value !== null) || typeof value === 'function';
+}
+
+export function markReactSsrDiagnostic(
+  error: unknown,
+  marker: ReactSsrDiagnosticMarker,
+): void {
+  if (isDiagnosticMarkerKey(error)) {
+    diagnosticMarkers.set(error, marker);
+  }
+}
+
+export function readReactSsrDiagnosticMarker(
+  error: unknown,
+): ReactSsrDiagnosticMarker | undefined {
+  if (!isDiagnosticMarkerKey(error)) {
+    return undefined;
+  }
+
+  const marker = diagnosticMarkers.get(error);
+  diagnosticMarkers.delete(error);
+  return marker;
+}
+
+export function createReactSsrDiagnostic(
+  diagnostic: ReactSsrDiagnostic,
+): ReactSsrDiagnostic {
+  return {
+    code: diagnostic.code,
+    error: diagnostic.error,
+    phase: diagnostic.phase,
+    request: diagnostic.request,
+    ...(diagnostic.requestId === undefined ? {} : { requestId: diagnostic.requestId }),
+  };
+}
+
+export function reportReactSsrDiagnostic(
+  handler: ReactSsrDiagnosticHandler | undefined,
+  diagnostic: ReactSsrDiagnostic,
+): void {
+  if (handler === undefined) {
+    return;
+  }
+
+  try {
+    handler(diagnostic);
+  } catch (error) {
+    if (error instanceof Error) {
+      return;
+    }
+  }
+}

--- a/packages/react/src/diagnostics.ts
+++ b/packages/react/src/diagnostics.ts
@@ -1,5 +1,5 @@
 import { FluoError } from '@fluojs/core';
-import type { FrameworkRequest } from '@fluojs/http';
+import type { FrameworkRequest, RequestContext } from '@fluojs/http';
 
 /** Stable machine-readable phases for the React SSR request lifecycle. */
 export const REACT_SSR_DIAGNOSTIC_PHASES = {
@@ -87,11 +87,58 @@ type ReactSsrDiagnosticMarker = {
 };
 
 const diagnosticMarkers = new WeakMap<object, ReactSsrDiagnosticMarker>();
+const diagnosticHandlerKey = Symbol.for('fluo.react.ssrDiagnosticHandler');
 
 function isDiagnosticMarkerKey(value: unknown): value is object {
   return (typeof value === 'object' && value !== null) || typeof value === 'function';
 }
 
+/**
+ * Stores the module diagnostic handler on the active request context.
+ *
+ * @param context Request context that owns the render lifecycle.
+ * @param handler Module diagnostic handler, when configured.
+ */
+export function bindReactSsrDiagnosticHandler(
+  context: RequestContext,
+  handler: ReactSsrDiagnosticHandler | undefined,
+): void {
+  if (handler === undefined) {
+    delete context.metadata[diagnosticHandlerKey];
+    return;
+  }
+
+  context.metadata[diagnosticHandlerKey] = handler;
+}
+
+/**
+ * Reads the module diagnostic handler from a render request context.
+ *
+ * @param context Render context that may carry request metadata.
+ * @returns The request-local diagnostic handler, when one exists.
+ */
+export function readReactSsrDiagnosticHandler(
+  context: object,
+): ReactSsrDiagnosticHandler | undefined {
+  const metadata: unknown = Reflect.get(context, 'metadata');
+  if (typeof metadata !== 'object' || metadata === null) {
+    return undefined;
+  }
+
+  const handler: unknown = Reflect.get(metadata, diagnosticHandlerKey);
+  if (typeof handler !== 'function') {
+    return undefined;
+  }
+
+  return (diagnostic) => Reflect.apply(handler, undefined, [diagnostic]);
+}
+
+/**
+ * Associates a diagnostic classification with an error without changing its identity.
+ *
+ * @param error Original lifecycle failure.
+ * @param marker Stable code and phase retained for the request error boundary.
+ */
 export function markReactSsrDiagnostic(
   error: unknown,
   marker: ReactSsrDiagnosticMarker,
@@ -101,6 +148,12 @@ export function markReactSsrDiagnostic(
   }
 }
 
+/**
+ * Reads and consumes the diagnostic classification associated with an error.
+ *
+ * @param error Original lifecycle failure.
+ * @returns The retained classification, when one exists.
+ */
 export function readReactSsrDiagnosticMarker(
   error: unknown,
 ): ReactSsrDiagnosticMarker | undefined {
@@ -113,6 +166,12 @@ export function readReactSsrDiagnosticMarker(
   return marker;
 }
 
+/**
+ * Creates a structured diagnostic snapshot for an SSR lifecycle event.
+ *
+ * @param diagnostic Diagnostic values observed at the active request boundary.
+ * @returns A request-safe diagnostic object.
+ */
 export function createReactSsrDiagnostic(
   diagnostic: ReactSsrDiagnostic,
 ): ReactSsrDiagnostic {
@@ -125,6 +184,12 @@ export function createReactSsrDiagnostic(
   };
 }
 
+/**
+ * Reports an SSR diagnostic without allowing observer failures to replace the request outcome.
+ *
+ * @param handler Application diagnostic observer, when configured.
+ * @param diagnostic Structured lifecycle event to report.
+ */
 export function reportReactSsrDiagnostic(
   handler: ReactSsrDiagnosticHandler | undefined,
   diagnostic: ReactSsrDiagnostic,

--- a/packages/react/src/direct-page-return.test.ts
+++ b/packages/react/src/direct-page-return.test.ts
@@ -1,0 +1,218 @@
+import { Module } from '@fluojs/core';
+import {
+  type FrameworkRequest,
+  type FrameworkResponse,
+  Header,
+  HttpCode,
+} from '@fluojs/http';
+import { bootstrapApplication } from '@fluojs/runtime';
+import { createElement } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { Path, Router } from './decorators.js';
+import { ReactModule } from './module.js';
+import type { ReactPageRenderer } from './page-renderer.js';
+import { createReactServerEntry } from './server-entry.js';
+
+type TestResponse = FrameworkResponse & { body?: unknown };
+type ObservedDiagnostic = {
+  readonly code: string;
+  readonly phase: string;
+};
+
+function createRequest(path: string): FrameworkRequest {
+  return {
+    body: undefined,
+    cookies: {},
+    headers: {},
+    method: 'GET',
+    params: {},
+    path,
+    query: {},
+    raw: {},
+    url: path,
+  };
+}
+
+function createResponse(): TestResponse {
+  return {
+    committed: false,
+    headers: {},
+    redirect(status: number, location: string) {
+      this.setStatus(status);
+      this.setHeader('Location', location);
+      this.committed = true;
+    },
+    send(body: unknown) {
+      this.body = body;
+      this.committed = true;
+    },
+    setHeader(name: string, value: string | string[]) {
+      this.headers[name] = value;
+    },
+    setStatus(code: number) {
+      this.statusCode = code;
+      this.statusSet = true;
+    },
+  };
+}
+
+function decodeBufferedBody(response: TestResponse): string {
+  expect(response.body).toBeInstanceOf(Uint8Array);
+  if (!(response.body instanceof Uint8Array)) {
+    throw new TypeError('Expected the buffered React response to contain bytes.');
+  }
+  return new TextDecoder().decode(response.body);
+}
+
+describe('direct React page returns', () => {
+  it('finalizes a ReactElement returned by a Path handler through the application page renderer', async () => {
+    const renderedPages: string[] = [];
+    const renderPage: ReactPageRenderer = (page, context) => {
+      renderedPages.push(context.request.url);
+      return createReactServerEntry(
+        createElement('html', null, createElement('body', null, page)),
+        { headers: { 'x-react-renderer': 'application' } },
+      );
+    };
+
+    @Router('/products')
+    class ProductRouter {
+      @Header('x-react-route', 'product')
+      @HttpCode(206)
+      @Path('/:id')
+      show(_input: undefined, context: { readonly request: FrameworkRequest }) {
+        return createElement('main', null, `Product ${context.request.params.id ?? 'missing'}`);
+      }
+    }
+
+    @Module({
+      imports: [ReactModule.forRoot({ controllers: [ProductRouter], renderPage })],
+    })
+    class AppModule {}
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+
+    try {
+      // Given: an application page renderer is configured for a React router.
+      const response = createResponse();
+
+      // When: a @Path handler returns one valid ReactElement directly.
+      await app.dispatch(createRequest('/products/42'), response);
+
+      // Then: the renderer composes the element and the existing HTTP writer applies route metadata.
+      expect(renderedPages).toEqual(['/products/42']);
+      expect(response.statusCode).toBe(206);
+      expect(response.headers['Content-Type']).toBe('text/html; charset=utf-8');
+      expect(response.headers['x-react-renderer']).toBe('application');
+      expect(response.headers['x-react-route']).toBe('product');
+      expect(decodeBufferedBody(response)).toContain('Product 42');
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('does not convert ordinary Path handler values into React responses', async () => {
+    let rendererCalls = 0;
+    const renderPage: ReactPageRenderer = (page) => {
+      rendererCalls += 1;
+      return createReactServerEntry(page);
+    };
+
+    @Router('/values')
+    class ValueRouter {
+      @Path('/object')
+      object() {
+        return { kind: 'object' };
+      }
+
+      @Path('/string')
+      string() {
+        return 'plain string';
+      }
+
+      @Path('/array')
+      array() {
+        return ['plain', 'array'];
+      }
+
+      @Path('/null')
+      nullValue() {
+        return null;
+      }
+    }
+
+    @Module({
+      imports: [ReactModule.forRoot({ controllers: [ValueRouter], renderPage })],
+    })
+    class AppModule {}
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+
+    try {
+      // Given: ordinary values are returned from @Path handlers while renderPage is configured.
+      const responses = [createResponse(), createResponse(), createResponse(), createResponse()];
+
+      // When: the dispatcher writes each result through the normal HTTP response path.
+      await Promise.all([
+        app.dispatch(createRequest('/values/object'), responses[0]),
+        app.dispatch(createRequest('/values/string'), responses[1]),
+        app.dispatch(createRequest('/values/array'), responses[2]),
+        app.dispatch(createRequest('/values/null'), responses[3]),
+      ]);
+
+      // Then: no ordinary value is treated as a ReactElement.
+      expect(rendererCalls).toBe(0);
+      expect(responses.map((response) => response.body)).toEqual([
+        { kind: 'object' },
+        'plain string',
+        ['plain', 'array'],
+        null,
+      ]);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('reports an actionable pre-commit diagnostic when renderPage is not configured', async () => {
+    const diagnostics: ObservedDiagnostic[] = [];
+
+    @Router('/missing-renderer')
+    class MissingRendererRouter {
+      @Path('/')
+      show() {
+        return createElement('main', null, 'Missing renderer');
+      }
+    }
+
+    @Module({
+      imports: [ReactModule.forRoot({
+        controllers: [MissingRendererRouter],
+        onDiagnostic(diagnostic) {
+          diagnostics.push({ code: diagnostic.code, phase: diagnostic.phase });
+        },
+      })],
+    })
+    class AppModule {}
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+
+    try {
+      // Given: a @Path handler can return JSX but its React module has no renderPage callback.
+      const response = createResponse();
+
+      // When: the dispatcher reaches React page result finalization.
+      await app.dispatch(createRequest('/missing-renderer'), response);
+
+      // Then: the HTTP error path commits once and diagnostics identify the missing configuration.
+      expect(response.statusCode).toBe(500);
+      expect(response.headers['Content-Type']).toBeUndefined();
+      expect(diagnostics).toEqual([{
+        code: 'react-ssr-missing-page-renderer',
+        phase: 'http-pipeline',
+      }]);
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/packages/react/src/dispatcher-ssr-abort-diagnostic.test.ts
+++ b/packages/react/src/dispatcher-ssr-abort-diagnostic.test.ts
@@ -1,5 +1,5 @@
 import { Module } from '@fluojs/core';
-import type { FrameworkRequest, FrameworkResponse } from '@fluojs/http';
+import type { FrameworkRequest, FrameworkResponse, FrameworkResponseStream } from '@fluojs/http';
 import { bootstrapApplication } from '@fluojs/runtime';
 import { createElement } from 'react';
 import { describe, expect, it } from 'vitest';
@@ -51,6 +51,43 @@ function createResponse(): TestResponse {
       this.statusCode = code;
       this.statusSet = true;
     },
+  };
+}
+
+function createStreamingResponse(onWrite: () => void): FrameworkResponse {
+  let closed = false;
+  const stream: FrameworkResponseStream = {
+    close() {
+      closed = true;
+    },
+    get closed() {
+      return closed;
+    },
+    write() {
+      onWrite();
+      return true;
+    },
+  };
+
+  return {
+    committed: false,
+    headers: {},
+    redirect(status: number, location: string) {
+      this.setStatus(status);
+      this.setHeader('Location', location);
+      this.committed = true;
+    },
+    send() {
+      this.committed = true;
+    },
+    setHeader(name: string, value: string | string[]) {
+      this.headers[name] = value;
+    },
+    setStatus(code: number) {
+      this.statusCode = code;
+      this.statusSet = true;
+    },
+    stream,
   };
 }
 
@@ -111,6 +148,71 @@ describe('React SSR abort diagnostics', () => {
       // Then: no response is committed and diagnostics identify the abort phase.
       expect(response.committed).toBe(false);
       expect(response.body).toBeUndefined();
+      expect(diagnostics).toEqual([{
+        code: 'react-ssr-request-abort',
+        phase: 'request-abort',
+      }]);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('reports request abort after a committed stream resolves its abort lifecycle', async () => {
+    const abortController = new AbortController();
+    const diagnostics: Array<{ readonly code: string; readonly phase: string }> = [];
+    const renderToReadableStream: ReactReadableStreamRenderer = async () => new ReadableStream<Uint8Array>({
+      pull(controller) {
+        controller.enqueue(new TextEncoder().encode('<main>partial</main>'));
+      },
+    });
+    const entry: ReactServerEntry = {
+      assetMap: {},
+      bootstrapModules: [],
+      bootstrapScripts: [],
+      headers: {},
+      node: createElement('main', null, 'Streaming abort'),
+    };
+
+    Object.defineProperty(entry, Symbol.for('fluo.react.serverEntry'), { value: true });
+    Object.defineProperty(entry, Symbol.for('fluo.http.responseWriter'), {
+      enumerable: false,
+      value: async (context: ReactResponseWriterContext): Promise<void> => {
+        await renderReactResponse(entry, context.requestContext, {
+          applySuccessResponseMetadata: context.applySuccessResponseMetadata,
+          renderToReadableStream,
+        });
+      },
+    });
+
+    @Router('/aborted')
+    class AbortedRouter {
+      @Path('/')
+      show() {
+        return entry;
+      }
+    }
+
+    @Module({
+      imports: [ReactModule.forRoot({
+        controllers: [AbortedRouter],
+        onDiagnostic(diagnostic) {
+          diagnostics.push({ code: diagnostic.code, phase: diagnostic.phase });
+        },
+      })],
+    })
+    class AppModule {}
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+
+    try {
+      // Given: a streaming React response aborts after its first committed chunk.
+      const response = createStreamingResponse(() => abortController.abort());
+
+      // When: the committed stream completes its existing abort cleanup path.
+      await app.dispatch(createRequest(abortController.signal), response);
+
+      // Then: dispatch still resolves and diagnostics identify the request-abort phase.
+      expect(response.committed).toBe(true);
       expect(diagnostics).toEqual([{
         code: 'react-ssr-request-abort',
         phase: 'request-abort',

--- a/packages/react/src/dispatcher-ssr-abort-diagnostic.test.ts
+++ b/packages/react/src/dispatcher-ssr-abort-diagnostic.test.ts
@@ -1,0 +1,122 @@
+import { Module } from '@fluojs/core';
+import type { FrameworkRequest, FrameworkResponse } from '@fluojs/http';
+import { bootstrapApplication } from '@fluojs/runtime';
+import { createElement } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { Path, Router } from './decorators.js';
+import { ReactModule } from './module.js';
+import { type ReactReadableStreamRenderer, type ReactRenderContext, renderReactResponse } from './render.js';
+import type { ReactServerEntry } from './server-entry.js';
+
+type TestResponse = FrameworkResponse & { body?: unknown };
+
+type ReactResponseWriterContext = {
+  readonly applySuccessResponseMetadata: () => void;
+  readonly requestContext: ReactRenderContext;
+};
+
+function createRequest(signal: AbortSignal): FrameworkRequest {
+  return {
+    body: undefined,
+    cookies: {},
+    headers: {},
+    method: 'GET',
+    params: {},
+    path: '/aborted',
+    query: {},
+    raw: {},
+    signal,
+    url: '/aborted',
+  };
+}
+
+function createResponse(): TestResponse {
+  return {
+    committed: false,
+    headers: {},
+    redirect(status: number, location: string) {
+      this.setStatus(status);
+      this.setHeader('Location', location);
+      this.committed = true;
+    },
+    send(body: unknown) {
+      this.body = body;
+      this.committed = true;
+    },
+    setHeader(name: string, value: string | string[]) {
+      this.headers[name] = value;
+    },
+    setStatus(code: number) {
+      this.statusCode = code;
+      this.statusSet = true;
+    },
+  };
+}
+
+describe('React SSR abort diagnostics', () => {
+  it('reports request abort separately without committing a buffered response', async () => {
+    const abortController = new AbortController();
+    const diagnostics: Array<{ readonly code: string; readonly phase: string }> = [];
+    const renderToReadableStream: ReactReadableStreamRenderer = async () => {
+      abortController.abort();
+      return new ReadableStream<Uint8Array>();
+    };
+    const entry: ReactServerEntry = {
+      assetMap: {},
+      bootstrapModules: [],
+      bootstrapScripts: [],
+      headers: {},
+      node: createElement('main', null, 'Aborted'),
+    };
+
+    Object.defineProperty(entry, Symbol.for('fluo.react.serverEntry'), { value: true });
+    Object.defineProperty(entry, Symbol.for('fluo.http.responseWriter'), {
+      enumerable: false,
+      value: async (context: ReactResponseWriterContext): Promise<void> => {
+        await renderReactResponse(entry, context.requestContext, {
+          applySuccessResponseMetadata: context.applySuccessResponseMetadata,
+          renderToReadableStream,
+        });
+      },
+    });
+
+    @Router('/aborted')
+    class AbortedRouter {
+      @Path('/')
+      show() {
+        return entry;
+      }
+    }
+
+    @Module({
+      imports: [ReactModule.forRoot({
+        controllers: [AbortedRouter],
+        onDiagnostic(diagnostic) {
+          diagnostics.push({ code: diagnostic.code, phase: diagnostic.phase });
+        },
+      })],
+    })
+    class AppModule {}
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+
+    try {
+      // Given: the active request aborts after React starts shell rendering.
+      const response = createResponse();
+
+      // When: the dispatcher finalizes the explicit React server entry.
+      await app.dispatch(createRequest(abortController.signal), response);
+
+      // Then: no response is committed and diagnostics identify the abort phase.
+      expect(response.committed).toBe(false);
+      expect(response.body).toBeUndefined();
+      expect(diagnostics).toEqual([{
+        code: 'react-ssr-request-abort',
+        phase: 'request-abort',
+      }]);
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/packages/react/src/dispatcher-ssr-buffered-error.test.ts
+++ b/packages/react/src/dispatcher-ssr-buffered-error.test.ts
@@ -137,4 +137,74 @@ describe('React SSR buffered error handling', () => {
       await app.close();
     }
   });
+
+  it('reports post-shell recoverable errors through the module diagnostic callback', async () => {
+    const diagnostics: Array<{ readonly code: string; readonly phase: string }> = [];
+    const recoverableError = new Error('Recoverable suspense boundary.');
+    const renderToReadableStream: ReactReadableStreamRenderer = async (_node, options) => {
+      options.onError?.(recoverableError);
+      return new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('<main>Fallback</main>'));
+          controller.close();
+        },
+      });
+    };
+    const entry: ReactServerEntry = {
+      assetMap: {},
+      bootstrapModules: [],
+      bootstrapScripts: [],
+      headers: {},
+      node: createElement('main', null, 'Fallback'),
+    };
+
+    Object.defineProperty(entry, Symbol.for('fluo.react.serverEntry'), { value: true });
+    Object.defineProperty(entry, Symbol.for('fluo.http.responseWriter'), {
+      enumerable: false,
+      value: async (context: ReactResponseWriterContext): Promise<void> => {
+        await renderReactResponse(entry, context.requestContext, {
+          applySuccessResponseMetadata: context.applySuccessResponseMetadata,
+          renderToReadableStream,
+        });
+      },
+    });
+
+    @Router('/recoverable')
+    class RecoverableRouter {
+      @Path('/')
+      show() {
+        return entry;
+      }
+    }
+
+    @Module({
+      imports: [ReactModule.forRoot({
+        controllers: [RecoverableRouter],
+        onDiagnostic(diagnostic) {
+          diagnostics.push({ code: diagnostic.code, phase: diagnostic.phase });
+        },
+      })],
+    })
+    class AppModule {}
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+
+    try {
+      // Given: a React entry reports a recoverable render error while producing a valid shell.
+      const response = createBufferedResponse();
+
+      // When: the @Path result is finalized through the existing buffered response writer.
+      await app.dispatch(createRequest('/recoverable'), response);
+
+      // Then: the response succeeds and diagnostics identify the post-shell recoverable phase.
+      expect(response.statusCode).toBe(200);
+      expect(response.chunks.join('')).toBe('<main>Fallback</main>');
+      expect(diagnostics).toEqual([{
+        code: 'react-ssr-post-shell-recoverable-error',
+        phase: 'post-shell-recoverable',
+      }]);
+    } finally {
+      await app.close();
+    }
+  });
 });

--- a/packages/react/src/dispatcher-ssr-diagnostic-isolation.test.ts
+++ b/packages/react/src/dispatcher-ssr-diagnostic-isolation.test.ts
@@ -1,0 +1,195 @@
+import { Module } from '@fluojs/core';
+import type { FrameworkRequest, FrameworkResponse } from '@fluojs/http';
+import { bootstrapApplication } from '@fluojs/runtime';
+import { createElement } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { Path, Router } from './decorators.js';
+import type { ReactSsrDiagnosticHandler } from './diagnostics.js';
+import { ReactModule } from './module.js';
+import { type ReactReadableStreamRenderer, type ReactRenderContext, renderReactResponse } from './render.js';
+import type { ReactServerEntry } from './server-entry.js';
+
+type ReactResponseWriterContext = {
+  readonly applySuccessResponseMetadata: () => void;
+  readonly requestContext: ReactRenderContext;
+};
+
+function createRequest(path: string): FrameworkRequest {
+  return {
+    body: undefined,
+    cookies: {},
+    headers: {},
+    method: 'GET',
+    params: {},
+    path,
+    query: {},
+    raw: {},
+    url: path,
+  };
+}
+
+function createResponse(): FrameworkResponse {
+  return {
+    committed: false,
+    headers: {},
+    redirect(status: number, location: string) {
+      this.setStatus(status);
+      this.setHeader('Location', location);
+      this.committed = true;
+    },
+    send() {
+      this.committed = true;
+    },
+    setHeader(name: string, value: string | string[]) {
+      this.headers[name] = value;
+    },
+    setStatus(code: number) {
+      this.statusCode = code;
+      this.statusSet = true;
+    },
+  };
+}
+
+function createSharedEntry(renderToReadableStream: ReactReadableStreamRenderer): ReactServerEntry {
+  const entry: ReactServerEntry = {
+    assetMap: {},
+    bootstrapModules: [],
+    bootstrapScripts: [],
+    headers: {},
+    node: createElement('main', null, 'Shared entry'),
+  };
+
+  Object.defineProperty(entry, Symbol.for('fluo.react.serverEntry'), { value: true });
+  Object.defineProperty(entry, Symbol.for('fluo.http.responseWriter'), {
+    enumerable: false,
+    value: async (context: ReactResponseWriterContext): Promise<void> => {
+      await renderReactResponse(entry, context.requestContext, {
+        applySuccessResponseMetadata: context.applySuccessResponseMetadata,
+        renderToReadableStream,
+      });
+    },
+  });
+
+  return entry;
+}
+
+function createAppModule(
+  path: string,
+  entry: ReactServerEntry,
+  onDiagnostic?: ReactSsrDiagnosticHandler,
+) {
+  @Router(path)
+  class SharedEntryRouter {
+    @Path('/')
+    show() {
+      return entry;
+    }
+  }
+
+  @Module({
+    imports: [ReactModule.forRoot({
+      controllers: [SharedEntryRouter],
+      ...(onDiagnostic === undefined ? {} : { onDiagnostic }),
+    })],
+  })
+  class AppModule {}
+
+  return AppModule;
+}
+
+describe('React SSR diagnostic request isolation', () => {
+  it('does not retain a diagnostic handler when a shared entry is reused sequentially', async () => {
+    const firstDiagnostics: string[] = [];
+    const recoverableError = new Error('Sequential recoverable render error.');
+    const renderToReadableStream: ReactReadableStreamRenderer = async (_node, options) => {
+      options.onError?.(recoverableError);
+      return new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.close();
+        },
+      });
+    };
+    const entry = createSharedEntry(renderToReadableStream);
+    const firstApp = await bootstrapApplication({
+      rootModule: createAppModule('/first', entry, (diagnostic) => {
+        firstDiagnostics.push(diagnostic.request.url);
+      }),
+    });
+    const secondApp = await bootstrapApplication({
+      rootModule: createAppModule('/second', entry),
+    });
+
+    try {
+      // Given: one shared entry is first rendered by a module with diagnostics enabled.
+      await firstApp.dispatch(createRequest('/first'), createResponse());
+
+      // When: another module without a diagnostic handler reuses the same entry.
+      await secondApp.dispatch(createRequest('/second'), createResponse());
+
+      // Then: the first module observes only its own request.
+      expect(firstDiagnostics).toEqual(['/first']);
+    } finally {
+      await Promise.all([firstApp.close(), secondApp.close()]);
+    }
+  });
+
+  it('routes concurrent shared-entry diagnostics to each active request', async () => {
+    const firstDiagnostics: string[] = [];
+    const secondDiagnostics: string[] = [];
+    let firstRenderStarted = (): void => {};
+    const firstRender = new Promise<void>((resolve) => {
+      firstRenderStarted = resolve;
+    });
+    let releaseFirstRender = (): void => {};
+    const secondRender = new Promise<void>((resolve) => {
+      releaseFirstRender = resolve;
+    });
+    let renderCount = 0;
+    const renderToReadableStream: ReactReadableStreamRenderer = async (_node, options) => {
+      renderCount += 1;
+      const activeRender = renderCount;
+
+      if (activeRender === 1) {
+        firstRenderStarted();
+        await secondRender;
+      } else {
+        releaseFirstRender();
+      }
+
+      options.onError?.(new Error(`Concurrent recoverable error ${activeRender}.`));
+      return new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.close();
+        },
+      });
+    };
+    const entry = createSharedEntry(renderToReadableStream);
+    const firstApp = await bootstrapApplication({
+      rootModule: createAppModule('/first', entry, (diagnostic) => {
+        firstDiagnostics.push(diagnostic.request.url);
+      }),
+    });
+    const secondApp = await bootstrapApplication({
+      rootModule: createAppModule('/second', entry, (diagnostic) => {
+        secondDiagnostics.push(diagnostic.request.url);
+      }),
+    });
+
+    try {
+      // Given: the first shared-entry render is paused after its request-local handler is selected.
+      const firstDispatch = firstApp.dispatch(createRequest('/first'), createResponse());
+      await firstRender;
+
+      // When: a second request reuses the entry before either render reports its error.
+      const secondDispatch = secondApp.dispatch(createRequest('/second'), createResponse());
+      await Promise.all([firstDispatch, secondDispatch]);
+
+      // Then: each module observes only the diagnostic from its own request.
+      expect(firstDiagnostics).toEqual(['/first']);
+      expect(secondDiagnostics).toEqual(['/second']);
+    } finally {
+      await Promise.all([firstApp.close(), secondApp.close()]);
+    }
+  });
+});

--- a/packages/react/src/dispatcher-ssr-diagnostic-marker-isolation.test.ts
+++ b/packages/react/src/dispatcher-ssr-diagnostic-marker-isolation.test.ts
@@ -1,0 +1,161 @@
+import { Module } from '@fluojs/core';
+import type { FrameworkRequest, FrameworkResponse } from '@fluojs/http';
+import { bootstrapApplication } from '@fluojs/runtime';
+import { createElement } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { Path, Router } from './decorators.js';
+import type { ReactSsrDiagnostic, ReactSsrDiagnosticHandler } from './diagnostics.js';
+import { ReactModule } from './module.js';
+import { type ReactReadableStreamRenderer, type ReactRenderContext, renderReactResponse } from './render.js';
+import type { ReactServerEntry } from './server-entry.js';
+
+type ReactResponseWriterContext = {
+  readonly applySuccessResponseMetadata: () => void;
+  readonly requestContext: ReactRenderContext;
+};
+
+function createRequest(path: string): FrameworkRequest {
+  return {
+    body: undefined,
+    cookies: {},
+    headers: {},
+    method: 'GET',
+    params: {},
+    path,
+    query: {},
+    raw: {},
+    url: path,
+  };
+}
+
+function createResponse(): FrameworkResponse {
+  return {
+    committed: false,
+    headers: {},
+    redirect(status: number, location: string) {
+      this.setStatus(status);
+      this.setHeader('Location', location);
+      this.committed = true;
+    },
+    send() {
+      this.committed = true;
+    },
+    setHeader(name: string, value: string | string[]) {
+      this.headers[name] = value;
+    },
+    setStatus(code: number) {
+      this.statusCode = code;
+      this.statusSet = true;
+    },
+  };
+}
+
+function createFailingEntry(
+  renderToReadableStream: ReactReadableStreamRenderer,
+  beforeFailureRethrow?: () => Promise<void>,
+): ReactServerEntry {
+  const entry: ReactServerEntry = {
+    assetMap: {},
+    bootstrapModules: [],
+    bootstrapScripts: [],
+    headers: {},
+    node: createElement('main', null, 'Diagnostic marker isolation'),
+  };
+
+  Object.defineProperty(entry, Symbol.for('fluo.react.serverEntry'), { value: true });
+  Object.defineProperty(entry, Symbol.for('fluo.http.responseWriter'), {
+    enumerable: false,
+    value: async (context: ReactResponseWriterContext): Promise<void> => {
+      try {
+        await renderReactResponse(entry, context.requestContext, {
+          applySuccessResponseMetadata: context.applySuccessResponseMetadata,
+          renderToReadableStream,
+        });
+      } catch (error) {
+        await beforeFailureRethrow?.();
+        throw error;
+      }
+    },
+  });
+
+  return entry;
+}
+
+function createAppModule(
+  path: string,
+  entry: ReactServerEntry,
+  onDiagnostic: ReactSsrDiagnosticHandler,
+) {
+  @Router(path)
+  class MarkerRouter {
+    @Path('/')
+    show() {
+      return entry;
+    }
+  }
+
+  @Module({
+    imports: [ReactModule.forRoot({ controllers: [MarkerRouter], onDiagnostic })],
+  })
+  class AppModule {}
+
+  return AppModule;
+}
+
+describe('React SSR diagnostic marker isolation', () => {
+  it('keeps shell markers request-local when concurrent requests throw the same Error', async () => {
+    const sharedError = new Error('Shared concurrent shell failure.');
+    const firstDiagnostics: ReactSsrDiagnostic[] = [];
+    const secondDiagnostics: ReactSsrDiagnostic[] = [];
+    let failedRenderCount = 0;
+    let releaseFailures = (): void => {};
+    const bothRendersFailed = new Promise<void>((resolve) => {
+      releaseFailures = resolve;
+    });
+    const beforeFailureRethrow = async (): Promise<void> => {
+      failedRenderCount += 1;
+      if (failedRenderCount === 2) {
+        releaseFailures();
+      }
+      await bothRendersFailed;
+    };
+    const entry = createFailingEntry(async () => {
+      throw sharedError;
+    }, beforeFailureRethrow);
+    const firstApp = await bootstrapApplication({
+      rootModule: createAppModule('/first', entry, (diagnostic) => firstDiagnostics.push(diagnostic)),
+    });
+    const secondApp = await bootstrapApplication({
+      rootModule: createAppModule('/second', entry, (diagnostic) => secondDiagnostics.push(diagnostic)),
+    });
+
+    try {
+      // Given: two shell renders fail with the same Error before either failure reaches its request boundary.
+      const firstDispatch = firstApp.dispatch(createRequest('/first'), createResponse());
+      const secondDispatch = secondApp.dispatch(createRequest('/second'), createResponse());
+
+      // When: both request boundaries classify their retained shell failure.
+      await Promise.all([firstDispatch, secondDispatch]);
+
+      // Then: each request reports its own shell marker and preserves the shared Error identity.
+      expect(firstDiagnostics).toHaveLength(1);
+      expect(secondDiagnostics).toHaveLength(1);
+      expect(firstDiagnostics[0]).toMatchObject({
+        code: 'react-ssr-pre-commit-shell-failure',
+        phase: 'pre-commit-shell',
+        request: { url: '/first' },
+      });
+      expect(secondDiagnostics[0]).toMatchObject({
+        code: 'react-ssr-pre-commit-shell-failure',
+        phase: 'pre-commit-shell',
+        request: { url: '/second' },
+      });
+      expect(firstDiagnostics[0]?.error).toBe(sharedError);
+      expect(secondDiagnostics[0]?.error).toBe(sharedError);
+    } finally {
+      await Promise.all([firstApp.close(), secondApp.close()]);
+    }
+  });
+
+});

--- a/packages/react/src/dispatcher-ssr-diagnostic-marker-isolation.test.ts
+++ b/packages/react/src/dispatcher-ssr-diagnostic-marker-isolation.test.ts
@@ -158,4 +158,57 @@ describe('React SSR diagnostic marker isolation', () => {
     }
   });
 
+  it('does not reuse an unconsumed direct-render shell marker in a later request', async () => {
+    const sharedError = new Error('Shared direct and HTTP failure.');
+    const diagnostics: ReactSsrDiagnostic[] = [];
+    const renderToReadableStream: ReactReadableStreamRenderer = async () => {
+      throw sharedError;
+    };
+    const directEntry = createFailingEntry(renderToReadableStream);
+    const directContext: ReactRenderContext = {
+      request: createRequest('/direct-render'),
+      response: createResponse(),
+    };
+
+    // Given: a direct render leaves its original shell Error unhandled by React page middleware.
+    await expect(renderReactResponse(directEntry, directContext, {
+      renderToReadableStream,
+    })).rejects.toBe(sharedError);
+
+    @Router('/http-pipeline')
+    class HttpPipelineRouter {
+      @Path('/')
+      show(): never {
+        throw sharedError;
+      }
+    }
+
+    @Module({
+      imports: [ReactModule.forRoot({
+        controllers: [HttpPipelineRouter],
+        onDiagnostic(diagnostic) {
+          diagnostics.push(diagnostic);
+        },
+      })],
+    })
+    class AppModule {}
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+
+    try {
+      // When: a later request throws the same Error identity in its HTTP pipeline.
+      await app.dispatch(createRequest('/http-pipeline'), createResponse());
+
+      // Then: the later request reports its own phase without consuming stale direct-render state.
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]).toMatchObject({
+        code: 'react-ssr-http-pipeline-failure',
+        phase: 'http-pipeline',
+        request: { url: '/http-pipeline' },
+      });
+      expect(diagnostics[0]?.error).toBe(sharedError);
+    } finally {
+      await app.close();
+    }
+  });
 });

--- a/packages/react/src/dispatcher-ssr-send-failure-diagnostic.test.ts
+++ b/packages/react/src/dispatcher-ssr-send-failure-diagnostic.test.ts
@@ -1,0 +1,140 @@
+import { Module } from '@fluojs/core';
+import type { FrameworkRequest, FrameworkResponse } from '@fluojs/http';
+import { bootstrapApplication } from '@fluojs/runtime';
+import { createElement } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { Path, Router } from './decorators.js';
+import { ReactModule } from './module.js';
+import { type ReactReadableStreamRenderer, type ReactRenderContext, renderReactResponse } from './render.js';
+import type { ReactServerEntry } from './server-entry.js';
+
+type ReactResponseWriterContext = {
+  readonly applySuccessResponseMetadata: () => void;
+  readonly requestContext: ReactRenderContext;
+};
+
+type SendFailureResponse = FrameworkResponse & {
+  readonly body?: unknown;
+  readonly sendAttempts: number;
+};
+
+function createRequest(): FrameworkRequest {
+  return {
+    body: undefined,
+    cookies: {},
+    headers: {},
+    method: 'GET',
+    params: {},
+    path: '/send-failure',
+    query: {},
+    raw: {},
+    url: '/send-failure',
+  };
+}
+
+function createSendFailureResponse(sendFailure: Error): SendFailureResponse {
+  let body: unknown;
+  let sendAttempts = 0;
+
+  return {
+    get body() {
+      return body;
+    },
+    committed: false,
+    headers: {},
+    redirect(status: number, location: string) {
+      this.setStatus(status);
+      this.setHeader('Location', location);
+      this.committed = true;
+    },
+    send(nextBody: unknown) {
+      sendAttempts += 1;
+      if (sendAttempts === 1) {
+        throw sendFailure;
+      }
+
+      body = nextBody;
+      this.committed = true;
+    },
+    get sendAttempts() {
+      return sendAttempts;
+    },
+    setHeader(name: string, value: string | string[]) {
+      this.headers[name] = value;
+    },
+    setStatus(code: number) {
+      this.statusCode = code;
+      this.statusSet = true;
+    },
+  };
+}
+
+describe('React SSR response-writer diagnostics', () => {
+  it('classifies an uncommitted response send failure as an HTTP pipeline failure', async () => {
+    const diagnostics: Array<{ readonly code: string; readonly phase: string }> = [];
+    const sendFailure = new Error('Buffered response send failed.');
+    const renderToReadableStream: ReactReadableStreamRenderer = async () => new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('<main>Ready</main>'));
+        controller.close();
+      },
+    });
+    const entry: ReactServerEntry = {
+      assetMap: {},
+      bootstrapModules: [],
+      bootstrapScripts: [],
+      headers: {},
+      node: createElement('main', null, 'Ready'),
+    };
+
+    Object.defineProperty(entry, Symbol.for('fluo.react.serverEntry'), { value: true });
+    Object.defineProperty(entry, Symbol.for('fluo.http.responseWriter'), {
+      enumerable: false,
+      value: async (context: ReactResponseWriterContext): Promise<void> => {
+        await renderReactResponse(entry, context.requestContext, {
+          applySuccessResponseMetadata: context.applySuccessResponseMetadata,
+          renderToReadableStream,
+        });
+      },
+    });
+
+    @Router('/send-failure')
+    class SendFailureRouter {
+      @Path('/')
+      show() {
+        return entry;
+      }
+    }
+
+    @Module({
+      imports: [ReactModule.forRoot({
+        controllers: [SendFailureRouter],
+        onDiagnostic(diagnostic) {
+          diagnostics.push({ code: diagnostic.code, phase: diagnostic.phase });
+        },
+      })],
+    })
+    class AppModule {}
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+
+    try {
+      // Given: React produces a complete buffered shell before the response writer runs.
+      const response = createSendFailureResponse(sendFailure);
+
+      // When: the first uncommitted response send fails and the HTTP error writer recovers.
+      await app.dispatch(createRequest(), response);
+
+      // Then: diagnostics identify the HTTP pipeline rather than the React shell phase.
+      expect(response.committed).toBe(true);
+      expect(response.sendAttempts).toBe(2);
+      expect(diagnostics).toEqual([{
+        code: 'react-ssr-http-pipeline-failure',
+        phase: 'http-pipeline',
+      }]);
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/packages/react/src/dispatcher-ssr.test.ts
+++ b/packages/react/src/dispatcher-ssr.test.ts
@@ -198,6 +198,8 @@ describe('React SSR dispatcher integration', () => {
   });
 
   it('does not leak route success headers when React shell rendering fails before commit', async () => {
+    const diagnostics: Array<{ readonly code: string; readonly phase: string }> = [];
+
     class ReactShellRenderError extends Error {
       readonly name = 'ReactShellRenderError';
 
@@ -224,6 +226,9 @@ describe('React SSR dispatcher integration', () => {
       imports: [
         ReactModule.forRoot({
           controllers: [BrokenRouter],
+          onDiagnostic(diagnostic) {
+            diagnostics.push({ code: diagnostic.code, phase: diagnostic.phase });
+          },
         }),
       ],
     })
@@ -242,6 +247,10 @@ describe('React SSR dispatcher integration', () => {
       expect(response.statusCode).toBe(500);
       expect(response.headers['x-react-route']).toBeUndefined();
       expect(response.chunks.join('')).toContain('INTERNAL_SERVER_ERROR');
+      expect(diagnostics).toEqual([{
+        code: 'react-ssr-pre-commit-shell-failure',
+        phase: 'pre-commit-shell',
+      }]);
     } finally {
       await app.close();
     }

--- a/packages/react/src/index.test.ts
+++ b/packages/react/src/index.test.ts
@@ -17,7 +17,10 @@ describe('@fluojs/react root package scaffold', () => {
     expect(Object.keys(react).sort()).toEqual([
       'Path',
       'REACT_PAGE_RENDERER',
+      'REACT_SSR_DIAGNOSTIC_CODES',
+      'REACT_SSR_DIAGNOSTIC_PHASES',
       'ReactModule',
+      'ReactSsrDiagnosticError',
       'Router',
       'createReactServerEntry',
       'getReactPathMetadata',
@@ -59,6 +62,7 @@ describe('@fluojs/react root package scaffold', () => {
     expect(rootEntrypoint).toContain("from './module.js'");
     expect(rootEntrypoint).toContain("from './page-renderer.js'");
     expect(rootEntrypoint).toContain("from './decorators.js'");
+    expect(rootEntrypoint).toContain("from './diagnostics.js'");
     expect(rootEntrypoint).toContain("from './server-entry.js'");
     expect(rootEntrypoint).toContain("from './render.js'");
     expect(rootEntrypoint).not.toContain('react-dom/server');

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -5,6 +5,18 @@ export {
   getReactRouterMetadata,
 } from './decorators.js';
 export type { ReactPathMetadata, ReactPathOptions, ReactRouterMetadata } from './decorators.js';
+export {
+  REACT_SSR_DIAGNOSTIC_CODES,
+  REACT_SSR_DIAGNOSTIC_PHASES,
+  ReactSsrDiagnosticError,
+} from './diagnostics.js';
+export type {
+  ReactSsrDiagnostic,
+  ReactSsrDiagnosticCode,
+  ReactSsrDiagnosticErrorOptions,
+  ReactSsrDiagnosticHandler,
+  ReactSsrDiagnosticPhase,
+} from './diagnostics.js';
 export { ReactModule } from './module.js';
 export type { ReactModuleOptions } from './module.js';
 export { REACT_PAGE_RENDERER } from './page-renderer.js';

--- a/packages/react/src/lifecycle-pre-render-failure.test.ts
+++ b/packages/react/src/lifecycle-pre-render-failure.test.ts
@@ -59,6 +59,7 @@ function createResponse(): TestResponse {
 describe('React page pre-render HTTP failures', () => {
   it('preserves the ordinary HTTP 403 error response when a guard denies before React rendering', async () => {
     const events: string[] = [];
+    const diagnostics: Array<{ readonly code: string; readonly phase: string }> = [];
     let renderAttempts = 0;
 
     class DenyGuard implements Guard {
@@ -86,7 +87,13 @@ describe('React page pre-render HTTP failures', () => {
     }
 
     @Module({
-      imports: [ReactModule.forRoot({ controllers: [GuardedRouter], providers: [DenyGuard] })],
+      imports: [ReactModule.forRoot({
+        controllers: [GuardedRouter],
+        onDiagnostic(diagnostic) {
+          diagnostics.push({ code: diagnostic.code, phase: diagnostic.phase });
+        },
+        providers: [DenyGuard],
+      })],
     })
     class AppModule {}
 
@@ -115,6 +122,10 @@ describe('React page pre-render HTTP failures', () => {
       });
       expect(events).toEqual(['guard']);
       expect(renderAttempts).toBe(0);
+      expect(diagnostics).toEqual([{
+        code: 'react-ssr-http-pipeline-failure',
+        phase: 'http-pipeline',
+      }]);
     } finally {
       await app.close();
     }

--- a/packages/react/src/module.ts
+++ b/packages/react/src/module.ts
@@ -4,6 +4,8 @@ import type { MiddlewareLike } from '@fluojs/http';
 import { defineModule, type ModuleDefinition, type ModuleType } from '@fluojs/runtime';
 
 import { REACT_PAGE_RENDERER, type ReactPageRenderer } from './page-renderer.js';
+import { createReactPageResultMiddleware } from './page-result.js';
+import type { ReactSsrDiagnosticHandler } from './diagnostics.js';
 
 /**
  * Options for registering React routers through the fluo module graph.
@@ -17,6 +19,8 @@ export type ReactModuleOptions = {
   readonly imports?: readonly ModuleType[];
   /** Module-level middleware applied by the existing HTTP dispatcher to this module's routes. */
   readonly middleware?: readonly MiddlewareLike[];
+  /** Application callback for stable phase-aware React SSR diagnostics. */
+  readonly onDiagnostic?: ReactSsrDiagnosticHandler;
   /** Providers local to this dynamic React module and visible to registered routers. */
   readonly providers?: readonly Provider[];
   /** Application callback that composes page elements into existing React server entries. */
@@ -56,11 +60,18 @@ export class ReactModule {
       ...(options.providers ?? []),
       ...(pageRendererProvider === undefined ? [] : [pageRendererProvider]),
     ];
+    const middleware = [
+      createReactPageResultMiddleware({
+        ...(options.onDiagnostic === undefined ? {} : { onDiagnostic: options.onDiagnostic }),
+        ...(options.renderPage === undefined ? {} : { renderPage: options.renderPage }),
+      }),
+      ...(options.middleware ?? []),
+    ];
     const definition = {
       controllers: [...options.controllers],
       ...(exports.length > 0 ? { exports } : {}),
       ...(options.imports ? { imports: [...options.imports] } : {}),
-      ...(options.middleware ? { middleware: [...options.middleware] } : {}),
+      middleware,
       ...(providers.length > 0 ? { providers } : {}),
     } satisfies ModuleDefinition;
 

--- a/packages/react/src/page-result.ts
+++ b/packages/react/src/page-result.ts
@@ -13,13 +13,14 @@ import {
   REACT_SSR_DIAGNOSTIC_CODES,
   REACT_SSR_DIAGNOSTIC_PHASES,
   ReactSsrDiagnosticError,
+  bindReactSsrDiagnosticHandler,
   createReactSsrDiagnostic,
   readReactSsrDiagnosticMarker,
   reportReactSsrDiagnostic,
   type ReactSsrDiagnosticHandler,
 } from './diagnostics.js';
 import type { ReactPageRenderer } from './page-renderer.js';
-import { bindReactSsrDiagnosticHandler, isReactServerEntry } from './server-entry.js';
+import { isReactServerEntry } from './server-entry.js';
 
 const responseValueFinalizerKey = Symbol.for('fluo.http.responseValueFinalizer');
 
@@ -109,7 +110,6 @@ function finalizeReactPageResult(
   }
 
   if (isReactServerEntry(context.value)) {
-    bindReactSsrDiagnosticHandler(context.value, runtime.onDiagnostic);
     return context.value;
   }
 
@@ -129,13 +129,19 @@ function finalizeReactPageResult(
   }
 
   const entry = runtime.renderPage(context.value, context.requestContext);
-  bindReactSsrDiagnosticHandler(entry, runtime.onDiagnostic);
   return entry;
 }
 
+/**
+ * Creates module middleware that finalizes React page values through the HTTP response lifecycle.
+ *
+ * @param runtime Module-level renderer and diagnostic configuration.
+ * @returns Middleware that installs request-local React response state.
+ */
 export function createReactPageResultMiddleware(runtime: ReactPageResultRuntime): Middleware {
   return {
     async handle(context: MiddlewareContext, next: Next): Promise<void> {
+      bindReactSsrDiagnosticHandler(context.requestContext, runtime.onDiagnostic);
       context.requestContext.metadata[responseValueFinalizerKey] = (
         finalizerContext: ReactPageResultFinalizerContext,
       ): unknown => finalizeReactPageResult(runtime, finalizerContext);

--- a/packages/react/src/page-result.ts
+++ b/packages/react/src/page-result.ts
@@ -1,0 +1,150 @@
+import {
+  RequestAbortedError,
+  type HandlerDescriptor,
+  type Middleware,
+  type MiddlewareContext,
+  type Next,
+  type RequestContext,
+} from '@fluojs/http';
+import { isValidElement } from 'react';
+
+import { getReactPathMetadata } from './decorators.js';
+import {
+  REACT_SSR_DIAGNOSTIC_CODES,
+  REACT_SSR_DIAGNOSTIC_PHASES,
+  ReactSsrDiagnosticError,
+  createReactSsrDiagnostic,
+  readReactSsrDiagnosticMarker,
+  reportReactSsrDiagnostic,
+  type ReactSsrDiagnosticHandler,
+} from './diagnostics.js';
+import type { ReactPageRenderer } from './page-renderer.js';
+import { bindReactSsrDiagnosticHandler, isReactServerEntry } from './server-entry.js';
+
+const responseValueFinalizerKey = Symbol.for('fluo.http.responseValueFinalizer');
+
+type ReactPageResultRuntime = {
+  readonly onDiagnostic?: ReactSsrDiagnosticHandler;
+  readonly renderPage?: ReactPageRenderer;
+};
+
+type ReactPageResultFinalizerContext = {
+  readonly handler: HandlerDescriptor;
+  readonly requestContext: RequestContext;
+  readonly value: unknown;
+};
+
+function isRequestAborted(context: RequestContext): boolean {
+  return context.request.signal?.aborted === true || context.request.isAborted?.() === true;
+}
+
+function reportReactPageFailure(
+  runtime: ReactPageResultRuntime,
+  error: unknown,
+  context: RequestContext,
+): void {
+  const marker = readReactSsrDiagnosticMarker(error);
+  if (marker !== undefined) {
+    reportReactSsrDiagnostic(
+      runtime.onDiagnostic,
+      createReactSsrDiagnostic({
+        code: marker.code,
+        error,
+        phase: marker.phase,
+        request: context.request,
+        ...(context.requestId === undefined ? {} : { requestId: context.requestId }),
+      }),
+    );
+    return;
+  }
+
+  if (error instanceof ReactSsrDiagnosticError) {
+    reportReactSsrDiagnostic(
+      runtime.onDiagnostic,
+      createReactSsrDiagnostic({
+        code: error.code,
+        error,
+        phase: error.phase,
+        request: context.request,
+        ...(context.requestId === undefined ? {} : { requestId: context.requestId }),
+      }),
+    );
+    return;
+  }
+
+  if (error instanceof RequestAbortedError || isRequestAborted(context)) {
+    reportReactSsrDiagnostic(
+      runtime.onDiagnostic,
+      createReactSsrDiagnostic({
+        code: REACT_SSR_DIAGNOSTIC_CODES.requestAbort,
+        error,
+        phase: REACT_SSR_DIAGNOSTIC_PHASES.requestAbort,
+        request: context.request,
+        ...(context.requestId === undefined ? {} : { requestId: context.requestId }),
+      }),
+    );
+    return;
+  }
+
+  if (!context.response.committed) {
+    reportReactSsrDiagnostic(
+      runtime.onDiagnostic,
+      createReactSsrDiagnostic({
+        code: REACT_SSR_DIAGNOSTIC_CODES.httpPipelineFailure,
+        error,
+        phase: REACT_SSR_DIAGNOSTIC_PHASES.httpPipeline,
+        request: context.request,
+        ...(context.requestId === undefined ? {} : { requestId: context.requestId }),
+      }),
+    );
+  }
+}
+
+function finalizeReactPageResult(
+  runtime: ReactPageResultRuntime,
+  context: ReactPageResultFinalizerContext,
+): unknown {
+  if (getReactPathMetadata(context.handler.controllerToken, context.handler.methodName) === undefined) {
+    return context.value;
+  }
+
+  if (isReactServerEntry(context.value)) {
+    bindReactSsrDiagnosticHandler(context.value, runtime.onDiagnostic);
+    return context.value;
+  }
+
+  if (!isValidElement(context.value)) {
+    return context.value;
+  }
+
+  if (runtime.renderPage === undefined) {
+    throw new ReactSsrDiagnosticError(
+      'A @Path handler returned a ReactElement, but ReactModule.forRoot(...) has no renderPage callback. '
+      + 'Configure renderPage or return createReactServerEntry(...) explicitly.',
+      {
+        code: REACT_SSR_DIAGNOSTIC_CODES.missingPageRenderer,
+        phase: REACT_SSR_DIAGNOSTIC_PHASES.httpPipeline,
+      },
+    );
+  }
+
+  const entry = runtime.renderPage(context.value, context.requestContext);
+  bindReactSsrDiagnosticHandler(entry, runtime.onDiagnostic);
+  return entry;
+}
+
+export function createReactPageResultMiddleware(runtime: ReactPageResultRuntime): Middleware {
+  return {
+    async handle(context: MiddlewareContext, next: Next): Promise<void> {
+      context.requestContext.metadata[responseValueFinalizerKey] = (
+        finalizerContext: ReactPageResultFinalizerContext,
+      ): unknown => finalizeReactPageResult(runtime, finalizerContext);
+      try {
+        await next();
+      } catch (error) {
+        reportReactPageFailure(runtime, error, context.requestContext);
+        throw error;
+      }
+    },
+  };
+}

--- a/packages/react/src/page-result.ts
+++ b/packages/react/src/page-result.ts
@@ -1,23 +1,23 @@
 import {
-  RequestAbortedError,
   type HandlerDescriptor,
   type Middleware,
   type MiddlewareContext,
   type Next,
+  RequestAbortedError,
   type RequestContext,
 } from '@fluojs/http';
 import { isValidElement } from 'react';
 
 import { getReactPathMetadata } from './decorators.js';
 import {
+  bindReactSsrDiagnosticHandler,
+  createReactSsrDiagnostic,
   REACT_SSR_DIAGNOSTIC_CODES,
   REACT_SSR_DIAGNOSTIC_PHASES,
   ReactSsrDiagnosticError,
-  bindReactSsrDiagnosticHandler,
-  createReactSsrDiagnostic,
+  type ReactSsrDiagnosticHandler,
   readReactSsrDiagnosticMarker,
   reportReactSsrDiagnostic,
-  type ReactSsrDiagnosticHandler,
 } from './diagnostics.js';
 import type { ReactPageRenderer } from './page-renderer.js';
 import { isReactServerEntry } from './server-entry.js';
@@ -44,7 +44,7 @@ function reportReactPageFailure(
   error: unknown,
   context: RequestContext,
 ): void {
-  const marker = readReactSsrDiagnosticMarker(error);
+  const marker = readReactSsrDiagnosticMarker(context, error);
   if (marker !== undefined) {
     reportReactSsrDiagnostic(
       runtime.onDiagnostic,

--- a/packages/react/src/render-diagnostics.ts
+++ b/packages/react/src/render-diagnostics.ts
@@ -6,14 +6,11 @@ import {
   ReactSsrDiagnosticError,
   createReactSsrDiagnostic,
   markReactSsrDiagnostic,
+  readReactSsrDiagnosticHandler,
   reportReactSsrDiagnostic,
 } from './diagnostics.js';
 import type { ReactRenderContext } from './render.js';
-import {
-  readReactSsrDiagnosticHandler,
-  type ReactRecoverableErrorContext,
-  type ReactServerEntry,
-} from './server-entry.js';
+import type { ReactRecoverableErrorContext, ReactServerEntry } from './server-entry.js';
 
 /** Recoverable React render error retained until the response shell can commit. */
 export type PendingReactRecoverableError = {
@@ -25,6 +22,7 @@ export type PendingReactRecoverableError = {
 
 type ReactRenderDiagnostics = {
   readonly preservePreCommitShellError: (error: unknown) => unknown;
+  readonly reportRequestAbort: () => void;
   readonly reportRecoverableError: (event: PendingReactRecoverableError) => void;
   readonly reportRecoverableErrors: (events: readonly PendingReactRecoverableError[]) => void;
 };
@@ -60,7 +58,7 @@ export function createReactRenderDiagnostics(
   const reportRecoverableError = (event: PendingReactRecoverableError): void => {
     const recoverableContext = createRecoverableErrorContext(event.errorInfo, requestContext);
     reportReactSsrDiagnostic(
-      readReactSsrDiagnosticHandler(entry),
+      readReactSsrDiagnosticHandler(requestContext),
       createReactSsrDiagnostic({
         code: recoverableContext.code,
         error: event.error,
@@ -111,6 +109,25 @@ export function createReactRenderDiagnostics(
         phase: REACT_SSR_DIAGNOSTIC_PHASES.preCommitShell,
       });
       return error;
+    },
+    reportRequestAbort() {
+      if (
+        requestContext.request.signal?.aborted !== true
+        && requestContext.request.isAborted?.() !== true
+      ) {
+        return;
+      }
+
+      reportReactSsrDiagnostic(
+        readReactSsrDiagnosticHandler(requestContext),
+        createReactSsrDiagnostic({
+          code: REACT_SSR_DIAGNOSTIC_CODES.requestAbort,
+          error: new RequestAbortedError(),
+          phase: REACT_SSR_DIAGNOSTIC_PHASES.requestAbort,
+          request: requestContext.request,
+          ...(requestContext.requestId === undefined ? {} : { requestId: requestContext.requestId }),
+        }),
+      );
     },
     reportRecoverableError,
     reportRecoverableErrors(events) {

--- a/packages/react/src/render-diagnostics.ts
+++ b/packages/react/src/render-diagnostics.ts
@@ -1,11 +1,11 @@
 import { RequestAbortedError } from '@fluojs/http';
 
 import {
+  createReactSsrDiagnostic,
+  markReactSsrDiagnostic,
   REACT_SSR_DIAGNOSTIC_CODES,
   REACT_SSR_DIAGNOSTIC_PHASES,
   ReactSsrDiagnosticError,
-  createReactSsrDiagnostic,
-  markReactSsrDiagnostic,
   readReactSsrDiagnosticHandler,
   reportReactSsrDiagnostic,
 } from './diagnostics.js';
@@ -103,7 +103,7 @@ export function createReactRenderDiagnostics(
         );
       }
 
-      markReactSsrDiagnostic(error, {
+      markReactSsrDiagnostic(requestContext, error, {
         code: REACT_SSR_DIAGNOSTIC_CODES.preCommitShellFailure,
         error,
         phase: REACT_SSR_DIAGNOSTIC_PHASES.preCommitShell,

--- a/packages/react/src/render-diagnostics.ts
+++ b/packages/react/src/render-diagnostics.ts
@@ -1,0 +1,122 @@
+import { RequestAbortedError } from '@fluojs/http';
+
+import {
+  REACT_SSR_DIAGNOSTIC_CODES,
+  REACT_SSR_DIAGNOSTIC_PHASES,
+  ReactSsrDiagnosticError,
+  createReactSsrDiagnostic,
+  markReactSsrDiagnostic,
+  reportReactSsrDiagnostic,
+} from './diagnostics.js';
+import type { ReactRenderContext } from './render.js';
+import {
+  readReactSsrDiagnosticHandler,
+  type ReactRecoverableErrorContext,
+  type ReactServerEntry,
+} from './server-entry.js';
+
+/** Recoverable React render error retained until the response shell can commit. */
+export type PendingReactRecoverableError = {
+  /** Original recoverable render failure. */
+  readonly error: unknown;
+  /** React-provided metadata, when available. */
+  readonly errorInfo?: unknown;
+};
+
+type ReactRenderDiagnostics = {
+  readonly preservePreCommitShellError: (error: unknown) => unknown;
+  readonly reportRecoverableError: (event: PendingReactRecoverableError) => void;
+  readonly reportRecoverableErrors: (events: readonly PendingReactRecoverableError[]) => void;
+};
+
+function createRecoverableErrorContext(
+  errorInfo: unknown,
+  requestContext: ReactRenderContext,
+): ReactRecoverableErrorContext {
+  return {
+    code: REACT_SSR_DIAGNOSTIC_CODES.postShellRecoverableError,
+    ...(errorInfo !== undefined ? { errorInfo } : {}),
+    phase: REACT_SSR_DIAGNOSTIC_PHASES.postShellRecoverable,
+    request: requestContext.request,
+    ...(requestContext.requestId !== undefined ? { requestId: requestContext.requestId } : {}),
+  };
+}
+
+function isDiagnosticMarkerKey(value: unknown): value is object {
+  return (typeof value === 'object' && value !== null) || typeof value === 'function';
+}
+
+/**
+ * Creates request-local reporting helpers for one React server entry render.
+ *
+ * @param entry React server entry whose callbacks receive recoverable errors.
+ * @param requestContext Active request and response lifecycle context.
+ * @returns Helpers that classify pre-commit failures and report recoverable errors.
+ */
+export function createReactRenderDiagnostics(
+  entry: ReactServerEntry,
+  requestContext: ReactRenderContext,
+): ReactRenderDiagnostics {
+  const reportRecoverableError = (event: PendingReactRecoverableError): void => {
+    const recoverableContext = createRecoverableErrorContext(event.errorInfo, requestContext);
+    reportReactSsrDiagnostic(
+      readReactSsrDiagnosticHandler(entry),
+      createReactSsrDiagnostic({
+        code: recoverableContext.code,
+        error: event.error,
+        phase: recoverableContext.phase,
+        request: requestContext.request,
+        ...(requestContext.requestId === undefined ? {} : { requestId: requestContext.requestId }),
+      }),
+    );
+    const hook = entry.onRecoverableError;
+
+    if (!hook) {
+      return;
+    }
+
+    try {
+      hook(event.error, recoverableContext);
+    } catch (error) {
+      if (error instanceof Error) {
+        return;
+      }
+    }
+  };
+
+  return {
+    preservePreCommitShellError(error) {
+      if (
+        error instanceof RequestAbortedError
+        || error instanceof ReactSsrDiagnosticError
+        || requestContext.response.committed
+      ) {
+        return error;
+      }
+
+      if (!isDiagnosticMarkerKey(error)) {
+        return new ReactSsrDiagnosticError(
+          'React SSR failed before the response shell committed.',
+          {
+            cause: error,
+            code: REACT_SSR_DIAGNOSTIC_CODES.preCommitShellFailure,
+            phase: REACT_SSR_DIAGNOSTIC_PHASES.preCommitShell,
+          },
+        );
+      }
+
+      markReactSsrDiagnostic(error, {
+        code: REACT_SSR_DIAGNOSTIC_CODES.preCommitShellFailure,
+        error,
+        phase: REACT_SSR_DIAGNOSTIC_PHASES.preCommitShell,
+      });
+      return error;
+    },
+    reportRecoverableError,
+    reportRecoverableErrors(events) {
+      for (const event of events) {
+        reportRecoverableError(event);
+      }
+    },
+  };
+}

--- a/packages/react/src/render.test.ts
+++ b/packages/react/src/render.test.ts
@@ -212,7 +212,9 @@ describe('renderReactResponse', () => {
     );
 
     expect(onRecoverableError).toHaveBeenCalledWith(recoverableError, expect.objectContaining({
+      code: 'react-ssr-post-shell-recoverable-error',
       errorInfo: { componentStack: '\n    at SlowPanel' },
+      phase: 'post-shell-recoverable',
       request: context.request,
     }));
     expect(response.statusCode).toBe(200);

--- a/packages/react/src/render.ts
+++ b/packages/react/src/render.ts
@@ -1,12 +1,12 @@
 import type { RequestContext } from '@fluojs/http';
 import type { ReactNode } from 'react';
 
-import type {
-  ReactAssetMap,
-  ReactBootstrapAsset,
-  ReactBootstrapScriptDescriptor,
-  ReactRecoverableErrorContext,
-  ReactServerEntry,
+import { createReactRenderDiagnostics, type PendingReactRecoverableError } from './render-diagnostics.js';
+import {
+  type ReactAssetMap,
+  type ReactBootstrapAsset,
+  type ReactBootstrapScriptDescriptor,
+  type ReactServerEntry,
 } from './server-entry.js';
 import { collectReadableStream, pipeReadableStream, throwIfReactRequestAborted } from './render-stream.js';
 
@@ -73,15 +73,10 @@ export type RenderReactResponseOptions = {
 /** Minimal fluo request context needed to render one React HTML response. */
 export type ReactRenderContext = Pick<RequestContext, 'request' | 'requestId' | 'response'>;
 
-type PendingRecoverableError = {
-  readonly error: unknown;
-  readonly errorInfo?: unknown;
-};
-
 type ReactStreamWritePlan = {
   readonly applySuccessMetadata: () => void;
-  readonly entry: ReactServerEntry;
-  readonly pendingRecoverableErrors: readonly PendingRecoverableError[];
+  readonly pendingRecoverableErrors: readonly PendingReactRecoverableError[];
+  readonly reportRecoverableErrors: (events: readonly PendingReactRecoverableError[]) => void;
   readonly requestContext: ReactRenderContext;
   readonly stream: ReactReadableStream;
 };
@@ -154,56 +149,15 @@ function createReactDomRenderOptions(options: ReactReadableStreamRenderOptions):
   };
 }
 
-function createRecoverableErrorContext(
-  errorInfo: unknown,
-  requestContext: ReactRenderContext,
-): ReactRecoverableErrorContext {
-  return {
-    ...(errorInfo !== undefined ? { errorInfo } : {}),
-    request: requestContext.request,
-    ...(requestContext.requestId !== undefined ? { requestId: requestContext.requestId } : {}),
-  };
-}
-
-function reportRecoverableError(
-  entry: ReactServerEntry,
-  requestContext: ReactRenderContext,
-  event: PendingRecoverableError,
-): void {
-  const hook = entry.onRecoverableError;
-
-  if (!hook) {
-    return;
-  }
-
-  try {
-    hook(event.error, createRecoverableErrorContext(event.errorInfo, requestContext));
-  } catch (error) {
-    if (error instanceof Error) {
-      return;
-    }
-  }
-}
-
-function reportRecoverableErrors(
-  entry: ReactServerEntry,
-  requestContext: ReactRenderContext,
-  events: readonly PendingRecoverableError[],
-): void {
-  for (const event of events) {
-    reportRecoverableError(entry, requestContext, event);
-  }
-}
-
 async function writeReactStream(plan: ReactStreamWritePlan): Promise<void> {
-  const { applySuccessMetadata, entry, pendingRecoverableErrors, requestContext, stream } = plan;
+  const { applySuccessMetadata, pendingRecoverableErrors, reportRecoverableErrors, requestContext, stream } = plan;
   const responseStream = requestContext.response.stream;
 
   if (!responseStream) {
     const body = await collectReadableStream(stream, requestContext.request);
     throwIfReactRequestAborted(requestContext.request);
     applySuccessMetadata();
-    reportRecoverableErrors(entry, requestContext, pendingRecoverableErrors);
+    reportRecoverableErrors(pendingRecoverableErrors);
     await requestContext.response.send(body);
     return;
   }
@@ -211,7 +165,7 @@ async function writeReactStream(plan: ReactStreamWritePlan): Promise<void> {
   applySuccessMetadata();
   requestContext.response.committed = true;
   responseStream.flush?.();
-  reportRecoverableErrors(entry, requestContext, pendingRecoverableErrors);
+  reportRecoverableErrors(pendingRecoverableErrors);
   await pipeReadableStream(stream, responseStream, requestContext.request);
 }
 
@@ -239,33 +193,45 @@ export async function renderReactResponse(
   requestContext: ReactRenderContext,
   options: RenderReactResponseOptions = {},
 ): Promise<void> {
-  throwIfReactRequestAborted(requestContext.request);
+  const diagnostics = createReactRenderDiagnostics(entry, requestContext);
 
-  const renderToReadableStream = options.renderToReadableStream ?? defaultRenderToReadableStream;
-  const pendingRecoverableErrors: PendingRecoverableError[] = [];
-  let shellReady = false;
-  const stream = await renderToReadableStream(
-    entry.node,
-    createReactReadableStreamRenderOptions(entry, requestContext, (error, errorInfo) => {
-      const event = errorInfo !== undefined ? { error, errorInfo } : { error };
+  try {
+    throwIfReactRequestAborted(requestContext.request);
 
-      if (shellReady) {
-        reportRecoverableError(entry, requestContext, event);
-        return;
-      }
+    const renderToReadableStream = options.renderToReadableStream ?? defaultRenderToReadableStream;
+    const pendingRecoverableErrors: PendingReactRecoverableError[] = [];
+    let shellReady = false;
+    const stream = await renderToReadableStream(
+      entry.node,
+      createReactReadableStreamRenderOptions(entry, requestContext, (error, errorInfo) => {
+        const event = errorInfo !== undefined ? { error, errorInfo } : { error };
 
-      pendingRecoverableErrors.push(event);
-    }),
-  );
+        if (shellReady) {
+          diagnostics.reportRecoverableError(event);
+          return;
+        }
 
-  shellReady = true;
-  throwIfReactRequestAborted(requestContext.request);
+        pendingRecoverableErrors.push(event);
+      }),
+    );
 
-  const applySuccessMetadata = () => {
-    options.applySuccessResponseMetadata?.();
-    applyEntryStatus(entry, requestContext);
-    applyEntryHeaders(entry, requestContext);
-  };
+    shellReady = true;
+    throwIfReactRequestAborted(requestContext.request);
 
-  await writeReactStream({ applySuccessMetadata, entry, pendingRecoverableErrors, requestContext, stream });
+    const applySuccessMetadata = () => {
+      options.applySuccessResponseMetadata?.();
+      applyEntryStatus(entry, requestContext);
+      applyEntryHeaders(entry, requestContext);
+    };
+
+    await writeReactStream({
+      applySuccessMetadata,
+      pendingRecoverableErrors,
+      reportRecoverableErrors: diagnostics.reportRecoverableErrors,
+      requestContext,
+      stream,
+    });
+  } catch (error) {
+    throw diagnostics.preservePreCommitShellError(error);
+  }
 }

--- a/packages/react/src/render.ts
+++ b/packages/react/src/render.ts
@@ -73,14 +73,6 @@ export type RenderReactResponseOptions = {
 /** Minimal fluo request context needed to render one React HTML response. */
 export type ReactRenderContext = Pick<RequestContext, 'request' | 'requestId' | 'response'>;
 
-type ReactStreamWritePlan = {
-  readonly applySuccessMetadata: () => void;
-  readonly pendingRecoverableErrors: readonly PendingReactRecoverableError[];
-  readonly reportRecoverableErrors: (events: readonly PendingReactRecoverableError[]) => void;
-  readonly requestContext: ReactRenderContext;
-  readonly stream: ReactReadableStream;
-};
-
 function applyEntryHeaders(entry: ReactServerEntry, requestContext: ReactRenderContext): void {
   for (const [name, value] of Object.entries(entry.headers)) {
     requestContext.response.setHeader(name, typeof value === 'string' ? value : [...value]);
@@ -149,26 +141,6 @@ function createReactDomRenderOptions(options: ReactReadableStreamRenderOptions):
   };
 }
 
-async function writeReactStream(plan: ReactStreamWritePlan): Promise<void> {
-  const { applySuccessMetadata, pendingRecoverableErrors, reportRecoverableErrors, requestContext, stream } = plan;
-  const responseStream = requestContext.response.stream;
-
-  if (!responseStream) {
-    const body = await collectReadableStream(stream, requestContext.request);
-    throwIfReactRequestAborted(requestContext.request);
-    applySuccessMetadata();
-    reportRecoverableErrors(pendingRecoverableErrors);
-    await requestContext.response.send(body);
-    return;
-  }
-
-  applySuccessMetadata();
-  requestContext.response.committed = true;
-  responseStream.flush?.();
-  reportRecoverableErrors(pendingRecoverableErrors);
-  await pipeReadableStream(stream, responseStream, requestContext.request);
-}
-
 async function defaultRenderToReadableStream(
   node: ReactNode,
   options: ReactReadableStreamRenderOptions,
@@ -194,14 +166,14 @@ export async function renderReactResponse(
   options: RenderReactResponseOptions = {},
 ): Promise<void> {
   const diagnostics = createReactRenderDiagnostics(entry, requestContext);
+  const renderToReadableStream = options.renderToReadableStream ?? defaultRenderToReadableStream;
+  const pendingRecoverableErrors: PendingReactRecoverableError[] = [];
+  let shellReady = false;
+  let stream: ReactReadableStream;
 
   try {
     throwIfReactRequestAborted(requestContext.request);
-
-    const renderToReadableStream = options.renderToReadableStream ?? defaultRenderToReadableStream;
-    const pendingRecoverableErrors: PendingReactRecoverableError[] = [];
-    let shellReady = false;
-    const stream = await renderToReadableStream(
+    stream = await renderToReadableStream(
       entry.node,
       createReactReadableStreamRenderOptions(entry, requestContext, (error, errorInfo) => {
         const event = errorInfo !== undefined ? { error, errorInfo } : { error };
@@ -217,21 +189,37 @@ export async function renderReactResponse(
 
     shellReady = true;
     throwIfReactRequestAborted(requestContext.request);
-
-    const applySuccessMetadata = () => {
-      options.applySuccessResponseMetadata?.();
-      applyEntryStatus(entry, requestContext);
-      applyEntryHeaders(entry, requestContext);
-    };
-
-    await writeReactStream({
-      applySuccessMetadata,
-      pendingRecoverableErrors,
-      reportRecoverableErrors: diagnostics.reportRecoverableErrors,
-      requestContext,
-      stream,
-    });
   } catch (error) {
     throw diagnostics.preservePreCommitShellError(error);
   }
+
+  const applySuccessMetadata = () => {
+    options.applySuccessResponseMetadata?.();
+    applyEntryStatus(entry, requestContext);
+    applyEntryHeaders(entry, requestContext);
+  };
+  const responseStream = requestContext.response.stream;
+
+  if (!responseStream) {
+    let body: Uint8Array;
+
+    try {
+      body = await collectReadableStream(stream, requestContext.request);
+      throwIfReactRequestAborted(requestContext.request);
+    } catch (error) {
+      throw diagnostics.preservePreCommitShellError(error);
+    }
+
+    applySuccessMetadata();
+    diagnostics.reportRecoverableErrors(pendingRecoverableErrors);
+    await requestContext.response.send(body);
+    return;
+  }
+
+  applySuccessMetadata();
+  requestContext.response.committed = true;
+  responseStream.flush?.();
+  diagnostics.reportRecoverableErrors(pendingRecoverableErrors);
+  await pipeReadableStream(stream, responseStream, requestContext.request);
+  diagnostics.reportRequestAbort();
 }

--- a/packages/react/src/server-entry.ts
+++ b/packages/react/src/server-entry.ts
@@ -1,9 +1,16 @@
 import type { FrameworkRequest } from '@fluojs/http';
 import { cloneElement, isValidElement, type ReactNode } from 'react';
 
+import type {
+  ReactSsrDiagnosticCode,
+  ReactSsrDiagnosticHandler,
+  ReactSsrDiagnosticPhase,
+} from './diagnostics.js';
 import type { ReactRenderContext } from './render.js';
 
 const responseWriterKey = Symbol.for('fluo.http.responseWriter');
+const serverEntryKey = Symbol.for('fluo.react.serverEntry');
+const diagnosticHandlerKey = Symbol.for('fluo.react.ssrDiagnosticHandler');
 
 type ReactResponseWriterContext = {
   readonly applySuccessResponseMetadata: () => void;
@@ -35,8 +42,12 @@ export type ReactBootstrapAsset = string | ReactBootstrapScriptDescriptor;
 
 /** Recoverable React render error details reported after the shell can stream. */
 export type ReactRecoverableErrorContext = {
+  /** Stable machine-readable diagnostic code for recoverable rendering failures. */
+  readonly code: ReactSsrDiagnosticCode;
   /** React-provided error metadata, such as a component stack, when available. */
   readonly errorInfo?: unknown;
+  /** Stable SSR lifecycle phase for recoverable rendering failures. */
+  readonly phase: ReactSsrDiagnosticPhase;
   /** Framework request being rendered. */
   readonly request: FrameworkRequest;
   /** Adapter-provided request id, when available. */
@@ -94,6 +105,57 @@ export type ReactServerEntry = {
   /** HTTP status to apply before streaming starts. Defaults to the current response status or `200`. */
   readonly status?: number;
 };
+
+/**
+ * Returns whether a value is a React server entry created or branded by the stable SSR seam.
+ *
+ * @param value Candidate response value.
+ * @returns Whether the value carries the React server entry brand.
+ */
+export function isReactServerEntry(value: unknown): value is ReactServerEntry {
+  return typeof value === 'object'
+    && value !== null
+    && Reflect.get(value, serverEntryKey) === true;
+}
+
+/**
+ * Binds a module-level diagnostic handler to one React server entry without changing its public shape.
+ *
+ * @param entry React server entry receiving the request-local handler.
+ * @param handler Module-level diagnostic handler, when configured.
+ */
+export function bindReactSsrDiagnosticHandler(
+  entry: ReactServerEntry,
+  handler: ReactSsrDiagnosticHandler | undefined,
+): void {
+  if (handler === undefined) {
+    return;
+  }
+
+  Object.defineProperty(entry, diagnosticHandlerKey, {
+    configurable: true,
+    enumerable: false,
+    value: handler,
+  });
+}
+
+/**
+ * Reads the module-level diagnostic handler bound to a React server entry.
+ *
+ * @param entry React server entry carrying request-local diagnostic state.
+ * @returns The bound handler, when one exists.
+ */
+export function readReactSsrDiagnosticHandler(
+  entry: ReactServerEntry,
+): ReactSsrDiagnosticHandler | undefined {
+  const handler = Reflect.get(entry, diagnosticHandlerKey);
+
+  if (typeof handler !== 'function') {
+    return undefined;
+  }
+
+  return (diagnostic) => Reflect.apply(handler, undefined, [diagnostic]);
+}
 
 function cloneAssetMap(assetMap: ReactAssetMap | undefined): ReactAssetMap {
   const cloned: Record<string, string> = {};
@@ -196,6 +258,11 @@ export function createReactServerEntry(
     ...(options.onRecoverableError !== undefined ? { onRecoverableError: options.onRecoverableError } : {}),
     ...(options.status !== undefined ? { status: options.status } : {}),
   };
+
+  Object.defineProperty(entry, serverEntryKey, {
+    enumerable: false,
+    value: true,
+  });
 
   Object.defineProperty(entry, responseWriterKey, {
     enumerable: false,

--- a/packages/react/src/server-entry.ts
+++ b/packages/react/src/server-entry.ts
@@ -3,14 +3,12 @@ import { cloneElement, isValidElement, type ReactNode } from 'react';
 
 import type {
   ReactSsrDiagnosticCode,
-  ReactSsrDiagnosticHandler,
   ReactSsrDiagnosticPhase,
 } from './diagnostics.js';
 import type { ReactRenderContext } from './render.js';
 
 const responseWriterKey = Symbol.for('fluo.http.responseWriter');
 const serverEntryKey = Symbol.for('fluo.react.serverEntry');
-const diagnosticHandlerKey = Symbol.for('fluo.react.ssrDiagnosticHandler');
 
 type ReactResponseWriterContext = {
   readonly applySuccessResponseMetadata: () => void;
@@ -116,45 +114,6 @@ export function isReactServerEntry(value: unknown): value is ReactServerEntry {
   return typeof value === 'object'
     && value !== null
     && Reflect.get(value, serverEntryKey) === true;
-}
-
-/**
- * Binds a module-level diagnostic handler to one React server entry without changing its public shape.
- *
- * @param entry React server entry receiving the request-local handler.
- * @param handler Module-level diagnostic handler, when configured.
- */
-export function bindReactSsrDiagnosticHandler(
-  entry: ReactServerEntry,
-  handler: ReactSsrDiagnosticHandler | undefined,
-): void {
-  if (handler === undefined) {
-    return;
-  }
-
-  Object.defineProperty(entry, diagnosticHandlerKey, {
-    configurable: true,
-    enumerable: false,
-    value: handler,
-  });
-}
-
-/**
- * Reads the module-level diagnostic handler bound to a React server entry.
- *
- * @param entry React server entry carrying request-local diagnostic state.
- * @returns The bound handler, when one exists.
- */
-export function readReactSsrDiagnosticHandler(
-  entry: ReactServerEntry,
-): ReactSsrDiagnosticHandler | undefined {
-  const handler = Reflect.get(entry, diagnosticHandlerKey);
-
-  if (typeof handler !== 'function') {
-    return undefined;
-  }
-
-  return (diagnostic) => Reflect.apply(handler, undefined, [diagnostic]);
 }
 
 function cloneAssetMap(assetMap: ReactAssetMap | undefined): ReactAssetMap {


### PR DESCRIPTION
## Summary

Allow `@Path(...)` handlers to return one valid `ReactElement` through the configured application page renderer while preserving the existing HTTP response lifecycle. Add stable phase-aware SSR diagnostics for HTTP pipeline failures, pre-commit shell failures, request aborts, and post-shell recoverable errors.

Linked context: Closes #2829

## Changes

- add a request-local HTTP response-value finalizer used by `ReactModule.forRoot(...)`
- finalize only valid `ReactElement` results while preserving explicit `ReactServerEntry` and ordinary values
- expose stable diagnostic phases, codes, callback contracts, and typed errors
- preserve original shell error identity and existing status/header/abort/streaming semantics
- update stable SSR and Vite SSR examples plus EN/KO package documentation
- add a minor `@fluojs/react` Changeset

## Testing

- `pnpm build`
- `pnpm --dir packages/react typecheck`
- `pnpm --dir packages/http typecheck`
- `pnpm --dir packages/react test` — 27 files, 89 tests passed
- `pnpm --dir packages/http test` — 18 files, 230 tests passed
- `pnpm vitest run examples/react-stable-ssr examples/react-vite-ssr` — 3 files, 4 tests passed
- `pnpm lint`
- `pnpm docs:sync-check`
- `pnpm verify:platform-consistency-governance`
- `pnpm verify:changeset-release-lane`
- `pnpm verify:release-readiness` — passed with a dedicated `FLUO_CLI_SANDBOX_ROOT`

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed docs.
- [x] No platform contract docs changed; companion platform-governance updates are not applicable.
- [x] No new platform alignment claim was added; applicable HTTP and React lifecycle regressions pass.