### PR TITLE
[React 0.5.0][Phase 5-7] Document a native form HTTP mutation recipe with progressive enhancement

### DIFF
--- a/examples/README.ko.md
+++ b/examples/README.ko.md
@@ -16,7 +16,7 @@
 - `./react-stable-ssr/` — HTTP-owned route, DTO-bound params/search, lifecycle middleware, 명시적인
   hydration asset을 포함한 안정 `@fluojs/react` SSR MVP 예제
 - `./react-vite-ssr/` — manifest-fed asset, streamed Suspense, hydration, HTTP-first client
-  navigation을 포함한 Vite-backed React SSR 예제
+  navigation, JavaScript-optional native form mutation을 포함한 Vite-backed React SSR 예제
 
 ## 권장 읽기 순서
 
@@ -45,8 +45,9 @@
   stable root 밖에 남습니다.
 - `react-vite-ssr`은 Vite hydration과 `@fluojs/react/client` phase를 증명합니다. 같은 HTTP-owned
   route와 DTO contract가 streamed Suspense HTML을 만들고, 이미 로드한 Vite manifest가 hydration
-  asset을 공급하며, full-document client navigation은 SPA document swapping이나 file-based routing을
-  약속하지 않고 server DTO validation을 authoritative하게 유지합니다.
+  asset을 공급하며, full-document client navigation은 server DTO validation을 authoritative하게
+  유지합니다. Native form은 SPA document swapping, file-based routing, compiled action을 약속하지 않고
+  guarded/intercepted `POST`, validation, mutation, `303` redirect boundary를 통과합니다.
 
 예제는 `../docs/contracts/testing-guide.ko.md`의 canonical fluo TDD ladder도 고정합니다. 빠른 unit 테스트는 `src/**` 가까이에 작성하고, DI wiring이나 provider override가 중요할 때는 `createTestingModule({ rootModule })` 기반 slice/module 테스트를 추가하며, app-level e2e 스타일 request-pipeline 점검에는 `createTestApp({ rootModule })`와 `app.request(...).send()`를 사용합니다. `minimal/src/app.test.ts`, `auth-jwt-passport/src/app.test.ts`, `ops-metrics-terminus/src/app.test.ts` 같은 기존 파일은 그 ladder의 app-level 끝단을 보여줍니다.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,7 +16,7 @@ These examples intentionally stay on the HTTP side of the published `fluo new` v
 - `./react-stable-ssr/` — stable `@fluojs/react` SSR MVP example with HTTP-owned routes, DTO-bound
   params/search, lifecycle middleware, and explicit hydration assets
 - `./react-vite-ssr/` — Vite-backed React SSR example with manifest-fed assets, streamed Suspense,
-  hydration, and HTTP-first client navigation
+  hydration, HTTP-first client navigation, and a JavaScript-optional native form mutation
 
 ## recommended reading order
 
@@ -45,8 +45,9 @@ If you are new to the repo, follow this order:
   outside the stable root
 - `react-vite-ssr` proves the Vite hydration and `@fluojs/react/client` phases: the same HTTP-owned
   route and DTO contracts feed streamed Suspense HTML, an already-loaded Vite manifest supplies
-  hydration assets, and full-document client navigation keeps server DTO validation authoritative
-  without claiming SPA document swapping or file-based routing
+  hydration assets, full-document client navigation keeps server DTO validation authoritative, and
+  a native form crosses guarded/intercepted `POST`, validation, mutation, and `303` redirect boundaries
+  without claiming SPA document swapping, file-based routing, or compiled actions
 
 The examples also anchor the canonical fluo TDD ladder from `../docs/contracts/testing-guide.md`: write fast unit tests near `src/**`, add slice/module tests with `createTestingModule({ rootModule })` when DI wiring or provider overrides matter, and use `createTestApp({ rootModule })` with `app.request(...).send()` for app-level e2e-style request-pipeline checks. Existing files such as `minimal/src/app.test.ts`, `auth-jwt-passport/src/app.test.ts`, and `ops-metrics-terminus/src/app.test.ts` show the app-level end of that ladder.
 

--- a/examples/react-vite-ssr/README.ko.md
+++ b/examples/react-vite-ssr/README.ko.md
@@ -4,7 +4,8 @@
 
 Hydration 및 client-navigation phase를 위한 최소 Vite-backed `@fluojs/react` 애플리케이션입니다.
 두 번째 routing model을 만들지 않고 HTTP-owned page route, DTO-bound parameter, streamed React
-SSR, Vite manifest asset, hydrated browser runtime을 연결합니다.
+SSR, Vite manifest asset, hydrated browser runtime, progressively enhanced native mutation form을
+연결합니다.
 
 ## 이 예제가 보여주는 것
 
@@ -18,6 +19,9 @@ SSR, Vite manifest asset, hydrated browser runtime을 연결합니다.
 - React DOM `hydrateRoot(...)`를 통해 interactive 상태가 되는 server-rendered counter.
 - Server-owned DTO validation boundary에 계속 도달하는 `@fluojs/react/client` route snapshot,
   URL-state hook, progressive `Link`, full-document `push` navigation.
+- 일반 guarded/intercepted `@Post(...)` route에 도달해 application state를 mutate하고 HTTP-matched
+  destination으로 `303 See Other`를 반환하는 native `multipart/form-data` form.
+- JavaScript disabled 상태에서 해당 form을 submit하는 production browser coverage.
 - 생성된 Vite client asset까지 Fastify adapter로 제공하는 production build.
 
 ## 레포 루트에서 실행하기
@@ -42,9 +46,41 @@ pnpm --filter @fluojs/example-react-vite-ssr test:browser
 ```
 
 Browser 명령은 workspace package와 예제를 다시 build하고, build된 server를 시작한 뒤 production
-client entry를 Chrome에서 실행합니다. Bootstrap/style asset 누락 또는 non-200 response, hydration
-warning/error, identifier-prefix mismatch, hydrate되지 않는 counter, URL과 server-rendered route
-state가 일치하지 않는 client navigation이 있으면 실패합니다.
+client entry 및 JavaScript-disabled context를 Chrome에서 실행합니다. Bootstrap/style asset 누락 또는
+non-200 response, hydration warning/error, identifier-prefix mismatch, hydrate되지 않는 counter,
+URL과 server-rendered route state가 일치하지 않는 client navigation, `POST` → `303` → `GET` flow를
+완료하지 못하는 native form이 있으면 실패합니다.
+
+## native form mutation workflow
+
+`ProductDocument`는 label, required input, submit button, 일반 route action, 명시적인 multipart encoding을
+가진 실제 form을 렌더링합니다.
+
+```html
+<form action="/products/sku-42" enctype="multipart/form-data" method="post">
+  <label for="product-name">Product name</label>
+  <input id="product-name" minlength="3" name="name" required />
+  <button type="submit">Save product</button>
+</form>
+```
+
+Receiving method는 같은 HTTP-owned router의 일반 `@Post('/:sku')` handler입니다. Path와 body field를
+`@RequestDto(...)`로 bind하고, `CatalogMutationGuard`와 request-scoped
+`CatalogMutationInterceptor`를 실행하며, singleton example catalog를 mutate한 뒤
+`context.response.redirect(303, ...)`를 호출합니다. `CatalogRequestMiddleware`는 module middleware
+chain에 그대로 남습니다. Focused authorization fixture는 `x-example-user: catalog-editor`를 사용합니다.
+실제 애플리케이션에서는 나머지 route와 같은 session/cookie 및 CSRF policy로 교체하세요.
+
+잘못된 input은 안전한 field/source/code/message detail을 가진 canonical `400` validation envelope를
+반환합니다. 성공한 input은 `/products/:sku?updated=true`로 redirect되고, 해당 `GET` destination은 일반
+dispatcher가 다시 match, bind, render합니다. Browser regression은 `javaScriptEnabled: false` Chrome
+context를 만들고 rendered form을 제출한 뒤 `303`을 관찰하며 destination document가 mutate된 값을
+포함하는지 확인합니다.
+
+이 flow는 React Router action/fetcher, Astro Action, Next.js Server Action, experimental fluo Server
+Function이 아닙니다. Action id를 compile하거나 route matching을 소유하거나 client cache를 revalidate하거나
+optimistic state를 약속하지 않습니다. Native form이 이미 완전한 fallback을 제공하고 stable client package가
+mutation route나 cache policy를 소유하지 않으므로 submit-state helper를 추가하지 않습니다.
 
 ## phase 경계와 제한 사항
 
@@ -70,17 +106,17 @@ state가 일치하지 않는 client navigation이 있으면 실패합니다.
 ```txt
 examples/react-vite-ssr/
 ├── src/
-│   ├── app.ts              # @Router/@Path page와 Vite asset serving module
-│   ├── app.test.ts         # DTO, streamed Suspense, manifest asset assertion
+│   ├── app.ts              # @Router page, native POST mutation, Vite asset serving module
+│   ├── app.test.ts         # DTO, protected mutation, redirect, streamed SSR assertion
 │   ├── entry-client.ts     # Browser-only hydrateRoot(...) entry
 │   ├── entry-server.ts     # 명시적 Vite server-entry selector
 │   ├── hydration.ts        # server/client 공유 identifierPrefix
 │   ├── hydration.test.ts   # DOM-equivalent hydration interaction 및 warning 검증
 │   ├── main.ts             # 생성된 manifest를 로드하고 Fastify 시작
-│   ├── page.ts             # server/client 공유 document와 interactive counter
+│   ├── page.ts             # 공유 document, native form, client router, interactive counter
 │   └── recommendations.ts  # Lazy Suspense content
 ├── tests/
-│   └── production-hydration.spec.ts # Built-server 및 production-client browser regression
+│   └── production-hydration.spec.ts # Hydration 및 JavaScript-disabled form regression
 ├── playwright.config.ts
 ├── vite.client.config.ts
 ├── vite.server.config.ts

--- a/examples/react-vite-ssr/README.md
+++ b/examples/react-vite-ssr/README.md
@@ -4,7 +4,8 @@
 
 Minimal Vite-backed `@fluojs/react` application for the hydration and client-navigation phases. It connects
 HTTP-owned page routes, DTO-bound parameters, streamed React SSR, Vite manifest assets, and one
-hydrated browser runtime without introducing a second routing model.
+hydrated browser runtime with a progressively enhanced native mutation form, without introducing a
+second routing model.
 
 ## what this example demonstrates
 
@@ -20,6 +21,9 @@ hydrated browser runtime without introducing a second routing model.
 - A server-rendered counter that becomes interactive through React DOM `hydrateRoot(...)`.
 - `@fluojs/react/client` route snapshots, URL-state hooks, progressive `Link`, and full-document
   `push` navigation that still reaches the server-owned DTO validation boundary.
+- A native `multipart/form-data` form that reaches an ordinary guarded/intercepted `@Post(...)`
+  route, mutates application state, and returns `303 See Other` to an HTTP-matched destination.
+- Production browser coverage that submits that form with JavaScript disabled.
 - A production build served by the Fastify adapter, including the generated Vite client assets.
 
 ## run from the repo root
@@ -44,9 +48,41 @@ pnpm --filter @fluojs/example-react-vite-ssr test:browser
 ```
 
 The browser command rebuilds workspace packages plus the example, starts the built server, and runs
-the production client entry in Chrome. It fails on missing or non-200 bootstrap/style assets,
-hydration warnings or errors, an identifier-prefix mismatch, a counter that does not hydrate, or
-client navigation whose URL and server-rendered route state do not agree.
+Chrome coverage for both the production client entry and a JavaScript-disabled context. It fails on
+missing or non-200 bootstrap/style assets, hydration warnings or errors, an identifier-prefix
+mismatch, a counter that does not hydrate, client navigation whose URL and server-rendered route
+state do not agree, or a native form that cannot complete its `POST` → `303` → `GET` flow.
+
+## native form mutation workflow
+
+`ProductDocument` renders a real form with a label, required input, submit button, ordinary route
+action, and explicit multipart encoding:
+
+```html
+<form action="/products/sku-42" enctype="multipart/form-data" method="post">
+  <label for="product-name">Product name</label>
+  <input id="product-name" minlength="3" name="name" required />
+  <button type="submit">Save product</button>
+</form>
+```
+
+The receiving method is an ordinary `@Post('/:sku')` handler on the same HTTP-owned router. It binds
+path and body fields with `@RequestDto(...)`, runs `CatalogMutationGuard`, runs the request-scoped
+`CatalogMutationInterceptor`, mutates the singleton example catalog, and calls
+`context.response.redirect(303, ...)`. `CatalogRequestMiddleware` remains in the module middleware
+chain. The focused authorization fixture uses `x-example-user: catalog-editor`; replace it with the
+same session/cookie and CSRF policy used by the rest of your application.
+
+Invalid input returns the canonical `400` validation envelope with safe field/source/code/message
+details. Successful input redirects to `/products/:sku?updated=true`; that `GET` destination is
+matched, bound, and rendered again by the ordinary dispatcher. The browser regression creates a
+Chrome context with `javaScriptEnabled: false`, submits the rendered form, observes the `303`, and
+asserts the destination document contains the mutated value.
+
+This flow is not a React Router action/fetcher, Astro Action, Next.js Server Action, or experimental
+fluo Server Function. It does not compile action ids, own route matching, revalidate a client cache,
+or promise optimistic state. No submit-state helper is added because the native form already provides
+the complete fallback and the stable client package owns neither mutation routes nor cache policy.
 
 ## phase boundaries and limitations
 
@@ -73,17 +109,17 @@ client navigation whose URL and server-rendered route state do not agree.
 ```txt
 examples/react-vite-ssr/
 ├── src/
-│   ├── app.ts              # @Router/@Path page and Vite asset serving module
-│   ├── app.test.ts         # DTO, streamed Suspense, and manifest asset assertions
+│   ├── app.ts              # @Router pages, native POST mutation, and Vite asset serving module
+│   ├── app.test.ts         # DTO, protected mutation, redirect, and streamed SSR assertions
 │   ├── entry-client.ts     # Browser-only hydrateRoot(...) entry
 │   ├── entry-server.ts     # Explicit Vite server-entry selector
 │   ├── hydration.ts        # Shared server/client identifierPrefix
 │   ├── hydration.test.ts   # DOM-equivalent hydration interaction and warning check
 │   ├── main.ts             # Loads the generated manifest and starts Fastify
-│   ├── page.ts             # Shared server/client document and interactive counter
+│   ├── page.ts             # Shared document, native form, client router, and interactive counter
 │   └── recommendations.ts  # Lazy Suspense content
 ├── tests/
-│   └── production-hydration.spec.ts # Built-server and production-client browser regression
+│   └── production-hydration.spec.ts # Hydration and JavaScript-disabled form regressions
 ├── playwright.config.ts
 ├── vite.client.config.ts
 ├── vite.server.config.ts

--- a/examples/react-vite-ssr/src/app.test.ts
+++ b/examples/react-vite-ssr/src/app.test.ts
@@ -79,4 +79,90 @@ describe('react-vite-ssr example', () => {
       await app.close();
     }
   });
+
+  it('protects native form mutations with the ordinary HTTP guard pipeline', async () => {
+    // Given: a rendered React product whose mutation route requires application authorization.
+    const AppModule = createReactViteExampleModule({
+      clientDirectory: new URL('../dist/client/', import.meta.url),
+      manifest: VITE_MANIFEST,
+    });
+    const app = await createTestApp({ rootModule: AppModule });
+
+    try {
+      // When: an unauthenticated native-form payload reaches the ordinary POST route.
+      const response = await app.request('POST', '/products/sku-42').body({ name: 'Renamed catalog item' }).send();
+
+      // Then: the route guard rejects the mutation before application state changes.
+      expect(response.status).toBe(403);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('returns a safe 400 representation for invalid native form input', async () => {
+    // Given: an authorized request to the ordinary HTTP mutation route.
+    const AppModule = createReactViteExampleModule({
+      clientDirectory: new URL('../dist/client/', import.meta.url),
+      manifest: VITE_MANIFEST,
+    });
+    const app = await createTestApp({ rootModule: AppModule });
+
+    try {
+      // When: the submitted product name violates the request DTO contract.
+      const response = await app
+        .request('POST', '/products/sku-42')
+        .header('x-example-user', 'catalog-editor')
+        .header('x-request-id', 'native-form-invalid')
+        .body({ name: 'x' })
+        .send();
+
+      // Then: the canonical validation envelope exposes safe field-level details.
+      expect(response.status).toBe(400);
+      expect(response.body).toEqual({
+        error: {
+          code: 'BAD_REQUEST',
+          details: [
+            {
+              code: 'PRODUCT_NAME_TOO_SHORT',
+              field: 'name',
+              message: 'Product name must contain at least 3 characters.',
+              source: 'body',
+            },
+          ],
+          message: 'Validation failed.',
+          meta: undefined,
+          requestId: 'native-form-invalid',
+          status: 400,
+        },
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('redirects a successful native form mutation with 303 See Other', async () => {
+    // Given: an authorized editor submitting a valid product mutation.
+    const AppModule = createReactViteExampleModule({
+      clientDirectory: new URL('../dist/client/', import.meta.url),
+      manifest: VITE_MANIFEST,
+    });
+    const app = await createTestApp({ rootModule: AppModule });
+
+    try {
+      // When: the ordinary POST handler accepts the bound request DTO.
+      const response = await app
+        .request('POST', '/products/sku-42')
+        .header('x-example-user', 'catalog-editor')
+        .body({ name: 'Renamed catalog item' })
+        .send();
+
+      // Then: the handler sends the browser back through the ordinary GET dispatcher.
+      expect(response.status).toBe(303);
+      expect(response.headers.location).toBe('/products/sku-42?updated=true');
+      expect(response.headers['x-example-middleware']).toBe('react-native-form');
+      expect(response.headers['x-example-interceptor']).toBe('request-scoped');
+    } finally {
+      await app.close();
+    }
+  });
 });

--- a/examples/react-vite-ssr/src/app.ts
+++ b/examples/react-vite-ssr/src/app.ts
@@ -1,15 +1,28 @@
 import { readFile } from 'node:fs/promises';
 
-import { Module } from '@fluojs/core';
+import { Inject, Module } from '@fluojs/core';
 import {
+  type CallHandler,
   Controller,
+  ForbiddenException,
+  FromBody,
   FromPath,
   FromQuery,
   Get,
+  type Guard,
+  type GuardContext,
+  type Interceptor,
+  type InterceptorContext,
+  type Middleware,
+  type MiddlewareContext,
+  type Next,
   NotFoundException,
   Optional,
+  Post,
   RequestDto,
   type RequestContext,
+  UseGuards,
+  UseInterceptors,
 } from '@fluojs/http';
 import {
   Path,
@@ -46,11 +59,67 @@ class ProductPageRequest {
   @Optional()
   @FromQuery('preview')
   preview?: string;
+
+  @IsIn(['true'])
+  @Optional()
+  @FromQuery('updated')
+  updated?: string;
+}
+
+class ProductMutationRequest {
+  @MinLength(3, {
+    code: 'PRODUCT_NAME_TOO_SHORT',
+    message: 'Product name must contain at least 3 characters.',
+  })
+  @IsString()
+  @FromBody('name')
+  name = '';
+
+  @MinLength(3)
+  @IsString()
+  @FromPath('sku')
+  sku = '';
 }
 
 class AssetRequest {
   @FromPath('file')
   file = '';
+}
+
+class CatalogMutationGuard implements Guard {
+  canActivate(context: GuardContext): boolean {
+    if (context.requestContext.request.headers['x-example-user'] !== 'catalog-editor') {
+      throw new ForbiddenException('Catalog mutations require an authorized editor.');
+    }
+
+    return true;
+  }
+}
+
+class CatalogMutationInterceptor implements Interceptor {
+  async intercept(context: InterceptorContext, next: CallHandler): Promise<unknown> {
+    context.requestContext.response.setHeader('x-example-interceptor', 'request-scoped');
+    return next.handle();
+  }
+}
+
+class CatalogRequestMiddleware implements Middleware {
+  async handle(context: MiddlewareContext, next: Next): Promise<void> {
+    context.response.setHeader('x-example-middleware', 'react-native-form');
+    await next();
+  }
+}
+
+class ProductCatalog {
+  readonly #names = new Map<string, string>();
+
+  findName(sku: string): string {
+    return this.#names.get(sku) ?? `Catalog item ${sku}`;
+  }
+
+  rename(sku: string, name: string): void {
+    this.#names.set(sku, name);
+  }
 }
 
 export function createReactViteExampleModule(options: ReactViteExampleModuleOptions) {
@@ -71,18 +140,32 @@ export function createReactViteExampleModule(options: ReactViteExampleModuleOpti
   const assets = result.manifest;
   const renderPage: ReactPageRenderer = (page) => createReactServerEntry(page, assets.hydrationOptions);
 
+  @Inject(ProductCatalog)
   @Router('/products')
   class ProductPageRouter {
+    constructor(private readonly catalog: ProductCatalog) {}
+
     @Path('/:sku')
     @RequestDto(ProductPageRequest)
     show(input: ProductPageRequest, context: RequestContext) {
       return createElement(ProductDocument, {
         preview: input.preview === 'true',
+        productName: this.catalog.findName(input.sku),
         routeParams: context.request.params,
         routeUrl: context.request.url,
+        saved: input.updated === 'true',
         sku: input.sku,
         stylesheets: assets.css,
       });
+    }
+
+    @Post('/:sku')
+    @RequestDto(ProductMutationRequest)
+    @UseGuards(CatalogMutationGuard)
+    @UseInterceptors(CatalogMutationInterceptor)
+    update(input: ProductMutationRequest, context: RequestContext) {
+      this.catalog.rename(input.sku, input.name);
+      context.response.redirect(303, `/products/${encodeURIComponent(input.sku)}?updated=true`);
     }
   }
 
@@ -113,7 +196,22 @@ export function createReactViteExampleModule(options: ReactViteExampleModuleOpti
 
   @Module({
     controllers: [ViteAssetController],
-    imports: [ReactModule.forRoot({ controllers: [ProductPageRouter], renderPage })],
+    imports: [
+      ReactModule.forRoot({
+        controllers: [ProductPageRouter],
+        middleware: [CatalogRequestMiddleware],
+        providers: [
+          CatalogMutationGuard,
+          ProductCatalog,
+          {
+            provide: CatalogMutationInterceptor,
+            scope: 'request',
+            useClass: CatalogMutationInterceptor,
+          },
+        ],
+        renderPage,
+      }),
+    ],
   })
   class ReactViteExampleModule {}
 

--- a/examples/react-vite-ssr/src/entry-client.ts
+++ b/examples/react-vite-ssr/src/entry-client.ts
@@ -13,8 +13,10 @@ hydrateRoot(
   document,
   createElement(ProductDocument, {
     preview: document.documentElement.dataset.preview === 'true',
+    productName: document.documentElement.dataset.productName ?? '',
     routeParams: { sku: document.documentElement.dataset.sku ?? '' },
     routeUrl: `${window.location.pathname}${window.location.search}`,
+    saved: document.documentElement.dataset.saved === 'true',
     sku: document.documentElement.dataset.sku ?? '',
     stylesheets,
   }),

--- a/examples/react-vite-ssr/src/page.ts
+++ b/examples/react-vite-ssr/src/page.ts
@@ -21,8 +21,10 @@ const LazyRecommendations = lazy(async () => {
 
 export type ProductDocumentProps = {
   readonly preview: boolean;
+  readonly productName: string;
   readonly routeParams: Readonly<Record<string, string>>;
   readonly routeUrl: string;
+  readonly saved: boolean;
   readonly sku: string;
   readonly stylesheets: readonly string[];
 };
@@ -66,7 +68,15 @@ function ProductNavigation() {
   );
 }
 
-export function ProductDocument({ preview, routeParams, routeUrl, sku, stylesheets }: ProductDocumentProps) {
+export function ProductDocument({
+  preview,
+  productName,
+  routeParams,
+  routeUrl,
+  saved,
+  sku,
+  stylesheets,
+}: ProductDocumentProps) {
   const identifier = useId();
   const initialSnapshot = createReactRouteSnapshot({ params: routeParams, url: routeUrl });
 
@@ -75,7 +85,13 @@ export function ProductDocument({ preview, routeParams, routeUrl, sku, styleshee
     { initialSnapshot },
     createElement(
       'html',
-      { 'data-preview': String(preview), 'data-sku': sku, lang: 'en' },
+      {
+        'data-preview': String(preview),
+        'data-product-name': productName,
+        'data-saved': String(saved),
+        'data-sku': sku,
+        lang: 'en',
+      },
       createElement(
         'head',
         null,
@@ -97,6 +113,30 @@ export function ProductDocument({ preview, routeParams, routeUrl, sku, styleshee
           createElement('h1', null, `Catalog item ${sku}`),
           createElement('p', null, preview ? 'Preview mode' : 'Published mode'),
           createElement('p', null, `DTO-bound sku: ${sku}`),
+          saved ? createElement('p', { role: 'status' }, `Saved product: ${productName}`) : null,
+          createElement(
+            'form',
+            {
+              action: `/products/${encodeURIComponent(sku)}`,
+              encType: 'multipart/form-data',
+              method: 'post',
+            },
+            createElement(
+              'p',
+              null,
+              createElement('label', { htmlFor: 'product-name' }, 'Product name'),
+              createElement('br'),
+              createElement('input', {
+                defaultValue: productName,
+                id: 'product-name',
+                minLength: 3,
+                name: 'name',
+                required: true,
+                type: 'text',
+              }),
+            ),
+            createElement('button', { type: 'submit' }, 'Save product'),
+          ),
           createElement('p', { 'data-react-identifier': true, id: identifier }, 'Shared hydration identifier'),
           createElement(
             Suspense,

--- a/examples/react-vite-ssr/tests/production-hydration.spec.ts
+++ b/examples/react-vite-ssr/tests/production-hydration.spec.ts
@@ -66,3 +66,38 @@ test('hydrates streamed production HTML with generated Vite assets', async ({ pa
   await expect(page.getByText('Current path: /products/sku-126')).toBeVisible();
   expect(browserDiagnostics).toEqual([]);
 });
+
+test('submits the native mutation form without client JavaScript', async ({ baseURL, browser }) => {
+  // Given: an authorized browser context with JavaScript disabled.
+  if (baseURL === undefined) {
+    throw new TypeError('The browser test requires a configured base URL.');
+  }
+
+  const context = await browser.newContext({
+    baseURL,
+    extraHTTPHeaders: { 'x-example-user': 'catalog-editor' },
+    javaScriptEnabled: false,
+  });
+  const page = await context.newPage();
+
+  try {
+    await page.goto('/products/sku-42?preview=true');
+    await page.getByLabel('Product name').fill('No-script catalog item');
+    const mutationResponsePromise = page.waitForResponse(
+      (response) =>
+        response.request().method() === 'POST' && new URL(response.url()).pathname === '/products/sku-42',
+    );
+
+    // When: the browser submits the rendered HTML form.
+    await page.getByRole('button', { name: 'Save product' }).click();
+    const mutationResponse = await mutationResponsePromise;
+
+    // Then: the POST redirects through the normal GET route in the no-JavaScript context.
+    expect(mutationResponse.status()).toBe(303);
+    expect(mutationResponse.headers().location).toBe('/products/sku-42?updated=true');
+    await expect(page).toHaveURL(/\/products\/sku-42\?updated=true$/u);
+    await expect(page.getByText('Saved product: No-script catalog item')).toBeVisible();
+  } finally {
+    await context.close();
+  }
+});

--- a/packages/react/README.ko.md
+++ b/packages/react/README.ko.md
@@ -19,6 +19,7 @@ fluo 애플리케이션을 위한 런타임 중립 React 통합입니다.
 - [Hydration Asset Contract](#hydration-asset-contract)
 - [Vite Asset Manifest Integration](#vite-asset-manifest-integration)
 - [Client Navigation Runtime](#client-navigation-runtime)
+- [Native Form Mutations](#native-form-mutations)
 - [Experimental RSC Prototype](#experimental-rsc-prototype)
 - [Experimental Server Functions](#experimental-server-functions)
 - [RSC Graduation Policy](#rsc-graduation-policy)
@@ -523,6 +524,82 @@ gap이나 JavaScript disabled 환경에서는 일반 full-document browser navig
 server는 명시적인 `@Path(...)`/HTTP route를 match하거나 정상적인 not-found response를 반환합니다.
 의도적인 deployment-level document rewrite를 별도로 설정할 수 있지만, 이는 React route grammar를 만들거나
 server DTO validation을 변경하지 않습니다.
+
+## Native Form Mutations
+
+React page mutation이 hydration 전이나 client JavaScript disabled 환경에서도 동작해야 한다면 native HTML
+form을 사용하세요. React-owned action transport를 만들지 말고 일반 `@Post(...)` route로 제출합니다. 실행 가능한
+`examples/react-vite-ssr/` slice는 `multipart/form-data`를 사용합니다. Browser가 multipart boundary를
+제공하면 기존 adapter와 `@RequestDto(...)` body-binding path가 field를 materialize합니다.
+
+```tsx
+function ProductForm({ name, sku }: { readonly name: string; readonly sku: string }) {
+  return (
+    <form action={`/products/${encodeURIComponent(sku)}`} encType="multipart/form-data" method="post">
+      <label htmlFor="product-name">Product name</label>
+      <input defaultValue={name} id="product-name" minLength={3} name="name" required />
+      <button type="submit">Save product</button>
+    </form>
+  );
+}
+```
+
+Target은 일반 HTTP handler로 남습니다. DTO binding과 validation은 request boundary에서 한 번 실행되고,
+module middleware, guard, interceptor, request-scoped provider, observer, adapter response writing은 일반
+HTTP pipeline의 ordering과 ownership을 그대로 유지합니다.
+
+```ts
+import {
+  FromBody,
+  FromPath,
+  Post,
+  RequestDto,
+  type RequestContext,
+  UseGuards,
+  UseInterceptors,
+} from '@fluojs/http';
+import { Router } from '@fluojs/react';
+import { IsString, MinLength } from '@fluojs/validation';
+
+class RenameProductRequest {
+  @MinLength(3, {
+    code: 'PRODUCT_NAME_TOO_SHORT',
+    message: 'Product name must contain at least 3 characters.',
+  })
+  @IsString()
+  @FromBody('name')
+  name = '';
+
+  @IsString()
+  @FromPath('sku')
+  sku = '';
+}
+
+@Router('/products')
+class ProductRouter {
+  @Post('/:sku')
+  @RequestDto(RenameProductRequest)
+  @UseGuards(EditorGuard)
+  @UseInterceptors(MutationAuditInterceptor)
+  rename(input: RenameProductRequest, context: RequestContext) {
+    productCatalog.rename(input.sku, input.name);
+    context.response.redirect(303, `/products/${encodeURIComponent(input.sku)}?updated=true`);
+  }
+}
+```
+
+잘못된 제출은 canonical HTTP `400` validation envelope를 유지합니다. `details` entry에는 안전한 field,
+source, code, application-authored validation message만 포함하고 제출 값, stack, internal exception은 노출하지
+않습니다. 성공한 mutation은 `303 See Other`를 사용하므로 browser가 `GET`으로 후속 요청을 보내고, destination은
+일반 HTTP dispatcher를 통해 다시 match됩니다. Authorization과 CSRF policy는 애플리케이션 책임입니다.
+Non-React route와 같은 session/cookie, guard, middleware policy를 사용하세요.
+
+이 recipe는 React Router action/fetcher, Astro Actions, Next.js Server Actions와 의도적으로 다릅니다. fluo는
+function reference를 compile하거나, route matching을 소유하거나, loader/client cache를 revalidate하거나,
+document response를 교체하지 않습니다. Experimental fluo Server Functions transport와도 별개입니다. Native
+form이 이미 완전한 fallback을 제공하고 `@fluojs/react/client`가 mutation route나 cache invalidation을 소유하지
+않으므로 이 phase에서는 stable submit-state helper를 추가하지 않습니다. Application은 실제 form action과
+native submission을 유지하는 경우에만 hydration 이후 local pending UI를 추가할 수 있습니다.
 
 ## Experimental RSC Prototype
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -19,6 +19,7 @@ Runtime-neutral React integration for fluo applications.
 - [Hydration Asset Contract](#hydration-asset-contract)
 - [Vite Asset Manifest Integration](#vite-asset-manifest-integration)
 - [Client Navigation Runtime](#client-navigation-runtime)
+- [Native Form Mutations](#native-form-mutations)
 - [Experimental RSC Prototype](#experimental-rsc-prototype)
 - [Experimental Server Functions](#experimental-server-functions)
 - [RSC Graduation Policy](#rsc-graduation-policy)
@@ -528,6 +529,85 @@ gaps and disabled JavaScript fall back to ordinary full-document browser navigat
 matches an explicit `@Path(...)`/HTTP route or returns its normal not-found response. An intentional
 deployment-level document rewrite may be configured separately, but it does not create a React route
 grammar or change server DTO validation.
+
+## Native Form Mutations
+
+Use a native HTML form when a React page needs a mutation that remains functional before hydration or
+with client JavaScript disabled. Submit to an ordinary `@Post(...)` route rather than creating a
+React-owned action transport. The runnable `examples/react-vite-ssr/` slice uses
+`multipart/form-data`, which lets the browser provide the multipart boundary while the existing
+adapter and `@RequestDto(...)` body-binding path materialize the fields.
+
+```tsx
+function ProductForm({ name, sku }: { readonly name: string; readonly sku: string }) {
+  return (
+    <form action={`/products/${encodeURIComponent(sku)}`} encType="multipart/form-data" method="post">
+      <label htmlFor="product-name">Product name</label>
+      <input defaultValue={name} id="product-name" minLength={3} name="name" required />
+      <button type="submit">Save product</button>
+    </form>
+  );
+}
+```
+
+The target remains a normal HTTP handler. DTO binding and validation run once at the request
+boundary; module middleware, guards, interceptors, request-scoped providers, observers, and adapter
+response writing keep their ordinary ordering and ownership.
+
+```ts
+import {
+  FromBody,
+  FromPath,
+  Post,
+  RequestDto,
+  type RequestContext,
+  UseGuards,
+  UseInterceptors,
+} from '@fluojs/http';
+import { Router } from '@fluojs/react';
+import { IsString, MinLength } from '@fluojs/validation';
+
+class RenameProductRequest {
+  @MinLength(3, {
+    code: 'PRODUCT_NAME_TOO_SHORT',
+    message: 'Product name must contain at least 3 characters.',
+  })
+  @IsString()
+  @FromBody('name')
+  name = '';
+
+  @IsString()
+  @FromPath('sku')
+  sku = '';
+}
+
+@Router('/products')
+class ProductRouter {
+  @Post('/:sku')
+  @RequestDto(RenameProductRequest)
+  @UseGuards(EditorGuard)
+  @UseInterceptors(MutationAuditInterceptor)
+  rename(input: RenameProductRequest, context: RequestContext) {
+    productCatalog.rename(input.sku, input.name);
+    context.response.redirect(303, `/products/${encodeURIComponent(input.sku)}?updated=true`);
+  }
+}
+```
+
+An invalid submission keeps the canonical HTTP `400` validation envelope. Its `details` entries
+contain the safe field, source, code, and application-authored validation message; they do not expose
+the submitted value, stack, or internal exception. A successful mutation uses `303 See Other` so the
+browser follows with `GET`, and that destination is matched again by the ordinary HTTP dispatcher.
+Authorization and CSRF policy remain application responsibilities; use the same session/cookie,
+guard, and middleware policies as non-React routes.
+
+This recipe is intentionally different from React Router actions/fetchers, Astro Actions, and
+Next.js Server Actions: fluo does not compile a function reference, own route matching, revalidate a
+loader/client cache, or replace the document response. It is also separate from the experimental
+fluo Server Functions transport. No stable submit-state helper is added in this phase because the
+native form already supplies the complete fallback and `@fluojs/react/client` does not own mutation
+routes or cache invalidation. Applications may add local pending UI after hydration only when the
+real form action and native submission remain intact.
 
 ## Experimental RSC Prototype
 


### PR DESCRIPTION
## Summary

Document and prove the canonical HTTP-first React mutation flow: a native form posts to an ordinary fluo route, passes through the existing request pipeline, returns safe validation evidence, and redirects with `303 See Other` after success.

Linked context: Closes #2833

## Changes

- add a guarded `@Post` mutation route with `@RequestDto`, middleware, a request-scoped interceptor, mutation storage, safe `400` responses, and a `303` redirect
- render the native form and resulting saved state without introducing action ids, fetchers, route-owned caches, or React-specific validation
- prove protected, invalid, successful, redirected, and JavaScript-disabled flows with focused unit and browser tests
- document the canonical workflow and framework boundaries in synchronized English and Korean React/example docs

## Testing

- `pnpm --filter @fluojs/example-react-vite-ssr typecheck`
- `pnpm vitest run examples/react-vite-ssr` — 2 files, 6 tests passed
- `pnpm --filter @fluojs/example-react-vite-ssr test:browser` — 2 tests passed
- `pnpm docs:sync-check`
- `pnpm verify:docs`
- `FLUO_CLI_SANDBOX_ROOT="/var/folders/xj/v8c228rx2ybb4g8pkm1m932r0000gn/T/opencode/fluo-cli-sandbox-issue-2833" pnpm verify:release-readiness`
- `pnpm lint` — passed with unrelated existing informational warnings
- visual QA — two independent passes returned `PASS`

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact. It changes only private example code, tests, and documentation, so no changeset is required.

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] No public exports changed.
- [x] Source examples and README scenario examples remain complementary.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] The new native form workflow is documented in the affected package README.
- [x] Intentional limitations and framework boundaries are explicitly stated.
- [x] Runtime invariants are covered by regression and browser tests.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] Changed English/Korean package and example documentation remains synchronized.
- [x] No platform contract docs changed.
- [x] No package README alignment or conformance claim was introduced.