### PR TITLE
Resolve #2854: Document fluo React concepts for framework users

### DIFF
--- a/docs/guides/react-user-concepts.ko.md
+++ b/docs/guides/react-user-concepts.ko.md
@@ -1,0 +1,112 @@
+# fluo의 React 개념
+
+<p><a href="./react-user-concepts.md"><kbd>English</kbd></a> <strong><kbd>한국어</kbd></strong></p>
+
+이 가이드는 React, Remix/React Router, Next.js 사용자에게 익숙한 용어를 현재 fluo 모델로
+번역합니다. 기능 동등성을 주장하는 문서가 아니라 탐색을 돕는 문서입니다. 안정 모델은 HTTP-first
+React SSR입니다. `@fluojs/http`가 route와 request lifecycle을 소유하고, 애플리케이션이 page
+composition을 소유하며, `@fluojs/react`를 사용해 React document를 stream하고 hydrate합니다.
+
+## 소유권부터 이해하기
+
+안정 request path는 다음과 같습니다.
+
+1. `@fluojs/http`가 명시적 route를 match하고 DTO binding, validation, middleware, guard,
+   interceptor, versioning, request-scope 생성을 실행합니다.
+2. `@Path(...)` handler가 `ReactElement` 하나를 반환하거나, route별 entry option이 필요하면
+   `createReactServerEntry(...)`를 명시적으로 반환합니다.
+3. 애플리케이션 `ReactPageRenderer`가 page를 document shell에 compose하고 `ReactServerEntry`를
+   반환합니다.
+4. 기존 HTTP response writer가 React 결과를 stream하며 status, header, error, abort, not-found
+   response의 소유권을 유지합니다.
+5. 애플리케이션이 로드한 build asset과 browser code가 document를 hydrate하고 progressive
+   navigation이나 local interaction을 추가할 수 있습니다.
+
+React는 두 번째 matcher나 route lifecycle을 만들지 않습니다. URL matching, DTO binding,
+validation, guard, interceptor, middleware, versioning, request scope, not-found ownership은
+`@fluojs/http`에 남습니다.
+
+## 개념 번역
+
+| 익숙한 개념 | 현재 fluo 동등 개념 | 경계 |
+| --- | --- | --- |
+| **Page** | `@Router(...)`와 `@Path(...)`로 표시한 `GET` handler입니다. Configured application renderer가 처리할 `ReactElement` 하나를 반환하거나 `createReactServerEntry(...)`를 명시적으로 반환합니다. | **Shipped.** Page는 file 또는 route-module convention이 아니라 여전히 HTTP handler입니다. |
+| **Route** | 일반 fluo module/controller metadata에서 compile된 effective route입니다. `@Path(...)`는 `@fluojs/http`와 같은 `GET` metadata를 기록하고, `@fluojs/react/typegen`은 compiled page catalog를 path-only href builder로 project할 수 있습니다. | **Shipped, intentionally different.** HTTP가 matching, grammar, conflict, param, versioning, dispatch를 소유합니다. Typegen은 route tree를 만들지 않고 versioned route를 표현하지 않습니다. |
+| **Layout** | 애플리케이션 `ReactPageRenderer`가 document shell과 shared provider를 소유합니다. `@PageLayout(...)`은 같은 renderer가 compose하는 optional class/method component-reference metadata를 추가합니다. | **Shipped.** File ancestry나 framework-owned layout router는 없습니다. |
+| **Loading UI** | Application tree의 일반 React `Suspense`를 사용하고, 필요하면 `@SuspenseFallback(...)`으로 page fallback을 선택합니다. | **Shipped with a narrow boundary.** Fallback은 SSR 중 suspend하는 descendant를 다루며 handler `await`, form, effect, navigation은 관찰하지 않습니다. |
+| **Data read / loader** | HTTP DTO binding과 validation 이후 `@Path(...)` handler에서 명시적인 application provider를 통해 data를 읽고 React element에 전달합니다. | **Shipped, intentionally different.** Loader runtime, loader cache, client revalidation contract는 없습니다. |
+| **Mutation / action** | Native form을 일반 `@Post(...)` handler로 제출하고, `@RequestDto(...)`로 bind/validate하며, 일반 guard/interceptor를 적용하고, application state를 변경한 뒤 필요하면 `303 See Other`로 redirect합니다. | **Shipped, intentionally different.** Stable surface에는 compiled action, fetcher, optimistic-state, cache-invalidation runtime이 없습니다. |
+| **Navigation** | 실제 `<a>` 또는 `@fluojs/react/client`의 `Link`를 사용합니다. Control에는 `router.push(...)`, `router.replace(...)`, `router.back()`, `router.refresh()`를 사용합니다. | **Shipped, intentionally different.** Path/search 변경은 full-document navigation을 사용하므로 destination이 HTTP lifecycle을 다시 통과합니다. Fragment-only 변경은 same-document browser navigation으로 남습니다. |
+| **Pending state** | `useNavigation()`이 client navigation lifecycle을 보고합니다. React `Suspense`는 component tree를 통해 rendering fallback을 보고합니다. 애플리케이션은 native form action을 제거하지 않는 범위에서 local form pending UI를 추가할 수 있습니다. | **Shipped with separate phases.** Stable submit-state helper나 공유 loader/action pending model은 없습니다. |
+| **Error UI** | HTTP pipeline failure는 기존 HTTP error path를 유지합니다. Stable React SSR diagnostic은 HTTP-pipeline, pre-commit shell, request-abort, post-shell recoverable phase를 구분합니다. Application React error boundary는 일반 React code로 남습니다. | **Shipped, intentionally different.** Segment `error` file이나 React-owned HTTP error router는 없습니다. |
+| **Not found** | 명시적 route가 없으면 일반 `@fluojs/http` not-found response가 되고, application lookup이 실패하면 handler가 shipped HTTP not-found exception을 throw할 수 있습니다. | **Shipped, intentionally different.** React `notFound()` helper나 catch-all requirement는 없습니다. |
+| **Metadata / head** | Application document에 `<title>`, `<meta>`, `<link>`를 렌더링합니다. Status와 header에는 기존 HTTP decorator와 response API를 사용합니다. | **Shipped as application-owned composition.** Automatic metadata function이나 route-segment merge contract는 없습니다. |
+| **Hydration** | `createReactServerEntry(...)`를 통해 명시적 hydration asset을 전달하고, 같은 request URL과 HTTP-matched param을 `ReactClientRouterProvider` snapshot에 렌더링한 뒤 browser entry에서 React DOM `hydrateRoot(...)`를 호출합니다. | **Shipped.** Server/client data transfer와 safe serialization은 application 책임입니다. |
+| **Build assets** | 애플리케이션이 Vite manifest를 로드해 `@fluojs/react/vite`의 `createReactViteAssetManifest(...)`에 전달하고, application document가 반환된 CSS와 hydration option을 emit합니다. | **Shipped.** fluo는 manifest discovery, Vite 실행, bundle generation, static-file/CDN hosting 선택을 수행하지 않습니다. |
+
+## 패키지 경계
+
+| Import | 책임 | 상태 |
+| --- | --- | --- |
+| `@fluojs/react` | `ReactModule.forRoot(...)`, `@Router(...)`, `@Path(...)`, page rendering policy, Web Streams SSR, diagnostic, page catalog, 명시적 hydration option. | 안정적인 runtime-neutral root입니다. Browser, Vite, typegen, RSC code를 import하지 않습니다. |
+| `@fluojs/react/client` | 실제 anchor, full-document navigation control, request-scoped route snapshot, URL/navigation hook. | 안정적인 browser-only subpath입니다. Matcher, route table, document cache, prefetch layer는 없습니다. |
+| `@fluojs/react/vite` | 이미 로드한 Vite manifest를 deterministic React CSS, JavaScript, asset-map, hydration option으로 파싱합니다. | 안정적인 build-integration subpath입니다. File을 읽거나 Vite를 실행하지 않습니다. |
+| `@fluojs/react/typegen` | Compiled React page catalog에서 deterministic path-only declaration과 absolute href builder를 생성합니다. | 안정적인 tooling subpath입니다. Versioned route를 거부하고 query, fragment, relative-route, route-tree contract를 생성하지 않습니다. |
+| `@fluojs/react/experimental/rsc` | Compatibility diagnostic, application-supplied RSC manifest seam, Flight response, 명시적 HTTP endpoint에 mount하는 signed Server Function transport. | **Experimental.** 모든 stable entrypoint와 격리되며 stable RSC 또는 action promise가 아닙니다. |
+
+## 최소 end-to-end path
+
+실행 가능한 `react-vite-ssr` 예제가 canonical complete path입니다. 다음 순서로 읽으세요.
+
+1. [`src/main.ts`](../../examples/react-vite-ssr/src/main.ts)는 application boundary에서 생성된 Vite
+   manifest를 로드하고 일반 fluo HTTP application을 bootstrap합니다.
+2. [`src/app.ts`](../../examples/react-vite-ssr/src/app.ts)는 그 값을
+   `createReactViteAssetManifest(...)`에 전달하고, `createReactServerEntry(...)`로
+   `ReactPageRenderer`를 만들며, `@Router('/products')`와 `@Path('/:sku')`를 선언하고,
+   `ReactModule.forRoot(...)`를 통해 router를 등록합니다.
+3. 같은 router의 `@Post('/:sku')` handler는 native form을 받고 일반 HTTP DTO, guard,
+   interceptor, middleware, request-scope path를 사용한 뒤 `303`으로 명시적 `GET` route에
+   redirect합니다.
+4. [`src/page.ts`](../../examples/react-vite-ssr/src/page.ts)는 document metadata와 Vite CSS를
+   렌더링하고, `createReactRouteSnapshot(...)`으로 request-scoped snapshot을 만들며, document를
+   `ReactClientRouterProvider`로 감싸고, 실제 `Link`와 `useNavigation()`을 사용하며, mutation
+   baseline으로 실제 `<form method="post">`를 유지합니다.
+5. [`src/entry-client.ts`](../../examples/react-vite-ssr/src/entry-client.ts)는 server rendering과
+   같은 URL, param, page data, stylesheet, identifier prefix로 React DOM `hydrateRoot(...)`를
+   호출합니다.
+
+더 작은 SSR-only 시작점은
+[`examples/react-stable-ssr`](../../examples/react-stable-ssr/README.ko.md)를 사용하세요. 생성된 build
+asset, hydration, client navigation, native form slice가 필요할 때만 Vite 예제를 추가하세요.
+
+## Experimental surface
+
+`@fluojs/react/experimental/rsc`가 현재 유일한 RSC 및 Server Function surface입니다. 문서화된 exact
+React/renderer compatibility와 application-owned build/encoding input이 필요합니다. Flight response와
+Server Function call도 명시적인 일반 fluo HTTP route에 mount합니다. 이 subpath를 stable Server
+Component, server action, router, loader, cache contract로 해석하지 마세요. Stable subpath가 존재하기
+전에 필요한 evidence는 [RSC graduation policy](../contracts/react-rsc-graduation.ko.md)를 확인하세요.
+
+## 지원하지 않는 개념
+
+현재 패키지는 다음을 제공하지 않습니다.
+
+- file routing, React-owned matcher, nested route tree, catch-all route grammar
+- route-module loader/action runtime, fetcher, automatic data revalidation
+- SPA document swapping, client document/data cache, navigation prefetch, optimistic mutation policy
+- automatic metadata merging 또는 segment-level `loading`, `error`, `not-found` convention
+- automatic Vite manifest discovery, bundle generation, static-file hosting, arbitrary inline data
+  serialization
+- stable RSC subpath, built-in Flight renderer, automatic `"use server"` transform/export discovery
+
+애플리케이션은 shipped seam 위에 자체 policy를 만들 수 있지만, 그 policy는 `@fluojs/react` contract가
+아니며 route 또는 request-lifecycle ownership을 `@fluojs/http` 밖으로 옮겨서는 안 됩니다.
+
+## 관련 문서
+
+- [`@fluojs/react` package contract](../../packages/react/README.ko.md)
+- [Stable SSR 실행 가능 예제](../../examples/react-stable-ssr/README.ko.md)
+- [Vite SSR, hydration, navigation, native form 실행 가능 예제](../../examples/react-vite-ssr/README.ko.md)
+- [`@fluojs/http` package contract](../../packages/http/README.ko.md)
+- [React render policy 결정](../architecture/react-render-policy-decorators.ko.md)
+- [React RSC graduation policy](../contracts/react-rsc-graduation.ko.md)

--- a/docs/guides/react-user-concepts.ko.md
+++ b/docs/guides/react-user-concepts.ko.md
@@ -13,12 +13,13 @@ composition을 소유하며, `@fluojs/react`를 사용해 React document를 stre
 
 1. `@fluojs/http`가 명시적 route를 match하고 DTO binding, validation, middleware, guard,
    interceptor, versioning, request-scope 생성을 실행합니다.
-2. `@Path(...)` handler가 `ReactElement` 하나를 반환하거나, route별 entry option이 필요하면
-   `createReactServerEntry(...)`를 명시적으로 반환합니다.
-3. 애플리케이션 `ReactPageRenderer`가 page를 document shell에 compose하고 `ReactServerEntry`를
-   반환합니다.
-4. 기존 HTTP response writer가 React 결과를 stream하며 status, header, error, abort, not-found
-   response의 소유권을 유지합니다.
+2. `@Path(...)` handler는 일반 HTTP 값을 반환할 수 있으며, 이 값은 React rendering을 우회하고
+   기존 HTTP response path를 유지합니다. React로 렌더링할 page라면 `ReactElement` 하나를 반환하거나,
+   route별 entry option이 필요할 때 `createReactServerEntry(...)`를 명시적으로 반환합니다.
+3. 반환된 값이 `ReactElement`이면 애플리케이션 `ReactPageRenderer`가 page를 document shell에
+   compose하고 `ReactServerEntry`를 반환합니다.
+4. 기존 HTTP response writer가 일반 값을 쓰거나 React entry를 stream하며 status, header, error,
+   abort, not-found response의 소유권을 유지합니다.
 5. 애플리케이션이 로드한 build asset과 browser code가 document를 hydrate하고 progressive
    navigation이나 local interaction을 추가할 수 있습니다.
 
@@ -30,7 +31,7 @@ validation, guard, interceptor, middleware, versioning, request scope, not-found
 
 | 익숙한 개념 | 현재 fluo 동등 개념 | 경계 |
 | --- | --- | --- |
-| **Page** | `@Router(...)`와 `@Path(...)`로 표시한 `GET` handler입니다. Configured application renderer가 처리할 `ReactElement` 하나를 반환하거나 `createReactServerEntry(...)`를 명시적으로 반환합니다. | **Shipped.** Page는 file 또는 route-module convention이 아니라 여전히 HTTP handler입니다. |
+| **Page** | `@Router(...)`와 `@Path(...)`로 표시한 `GET` handler입니다. React rendering을 우회하는 일반 HTTP 값, configured application renderer가 처리할 `ReactElement` 하나, 또는 명시적인 `createReactServerEntry(...)`를 반환할 수 있습니다. | **Shipped.** Page는 file 또는 route-module convention이 아니라 여전히 HTTP handler입니다. |
 | **Route** | 일반 fluo module/controller metadata에서 compile된 effective route입니다. `@Path(...)`는 `@fluojs/http`와 같은 `GET` metadata를 기록하고, `@fluojs/react/typegen`은 compiled page catalog를 path-only href builder로 project할 수 있습니다. | **Shipped, intentionally different.** HTTP가 matching, grammar, conflict, param, versioning, dispatch를 소유합니다. Typegen은 route tree를 만들지 않고 versioned route를 표현하지 않습니다. |
 | **Layout** | 애플리케이션 `ReactPageRenderer`가 document shell과 shared provider를 소유합니다. `@PageLayout(...)`은 같은 renderer가 compose하는 optional class/method component-reference metadata를 추가합니다. | **Shipped.** File ancestry나 framework-owned layout router는 없습니다. |
 | **Loading UI** | Application tree의 일반 React `Suspense`를 사용하고, 필요하면 `@SuspenseFallback(...)`으로 page fallback을 선택합니다. | **Shipped with a narrow boundary.** Fallback은 SSR 중 suspend하는 descendant를 다루며 handler `await`, form, effect, navigation은 관찰하지 않습니다. |
@@ -49,7 +50,7 @@ validation, guard, interceptor, middleware, versioning, request scope, not-found
 | Import | 책임 | 상태 |
 | --- | --- | --- |
 | `@fluojs/react` | `ReactModule.forRoot(...)`, `@Router(...)`, `@Path(...)`, page rendering policy, Web Streams SSR, diagnostic, page catalog, 명시적 hydration option. | 안정적인 runtime-neutral root입니다. Browser, Vite, typegen, RSC code를 import하지 않습니다. |
-| `@fluojs/react/client` | 실제 anchor, full-document navigation control, request-scoped route snapshot, URL/navigation hook. | 안정적인 browser-only subpath입니다. Matcher, route table, document cache, prefetch layer는 없습니다. |
+| `@fluojs/react/client` | SSR-safe request-scoped route snapshot과 provider composition, 실제 anchor, hydration 이후 full-document navigation control, URL/navigation hook. | 안정적인 SSR-and-browser subpath입니다. `createReactRouteSnapshot(...)`과 `ReactClientRouterProvider`는 SSR 및 hydration을 지원하고 browser navigation effect는 hydration 이후에만 연결됩니다. Matcher, route table, document cache, prefetch layer는 없습니다. |
 | `@fluojs/react/vite` | 이미 로드한 Vite manifest를 deterministic React CSS, JavaScript, asset-map, hydration option으로 파싱합니다. | 안정적인 build-integration subpath입니다. File을 읽거나 Vite를 실행하지 않습니다. |
 | `@fluojs/react/typegen` | Compiled React page catalog에서 deterministic path-only declaration과 absolute href builder를 생성합니다. | 안정적인 tooling subpath입니다. Versioned route를 거부하고 query, fragment, relative-route, route-tree contract를 생성하지 않습니다. |
 | `@fluojs/react/experimental/rsc` | Compatibility diagnostic, application-supplied RSC manifest seam, Flight response, 명시적 HTTP endpoint에 mount하는 signed Server Function transport. | **Experimental.** 모든 stable entrypoint와 격리되며 stable RSC 또는 action promise가 아닙니다. |

--- a/docs/guides/react-user-concepts.md
+++ b/docs/guides/react-user-concepts.md
@@ -1,0 +1,117 @@
+# React Concepts in fluo
+
+<p><strong><kbd>English</kbd></strong> <a href="./react-user-concepts.ko.md"><kbd>한국어</kbd></a></p>
+
+This guide translates familiar React, Remix/React Router, and Next.js vocabulary into the current
+fluo model. It is a navigation aid, not a feature-parity claim. The stable model is HTTP-first React
+SSR: `@fluojs/http` owns routes and the request lifecycle, while the application owns page
+composition and uses `@fluojs/react` to stream and hydrate React documents.
+
+## Start with ownership
+
+The stable request path is:
+
+1. `@fluojs/http` matches an explicit route and runs DTO binding, validation, middleware, guards,
+   interceptors, versioning, and request-scope creation.
+2. An `@Path(...)` handler returns one `ReactElement`, or returns `createReactServerEntry(...)`
+   explicitly when that route needs entry-specific options.
+3. The application `ReactPageRenderer` composes the page into its document shell and returns a
+   `ReactServerEntry`.
+4. The existing HTTP response writer streams the React result and keeps ownership of status,
+   headers, errors, aborts, and not-found responses.
+5. Application-loaded build assets and browser code hydrate the document and may add progressive
+   navigation or local interaction.
+
+React does not introduce a second matcher or route lifecycle. URL matching, DTO binding,
+validation, guards, interceptors, middleware, versioning, request scopes, and not-found ownership
+remain in `@fluojs/http`.
+
+## Concept translation
+
+| Familiar concept | Current fluo equivalent | Boundary |
+| --- | --- | --- |
+| **Page** | A `GET` handler marked with `@Router(...)` and `@Path(...)`. Return one `ReactElement` for the configured application renderer, or return `createReactServerEntry(...)` explicitly. | **Shipped.** A page is still an HTTP handler, not a file or route-module convention. |
+| **Route** | The effective route compiled from ordinary fluo module/controller metadata. `@Path(...)` writes the same `GET` metadata as `@fluojs/http`; `@fluojs/react/typegen` can project the compiled page catalog into path-only href builders. | **Shipped, intentionally different.** HTTP owns matching, grammar, conflicts, params, versioning, and dispatch. Typegen does not create a route tree or represent versioned routes. |
+| **Layout** | The application `ReactPageRenderer` owns the document shell and shared providers. `@PageLayout(...)` adds optional class/method component-reference metadata that the same renderer composes. | **Shipped.** There is no file ancestry or framework-owned layout router. |
+| **Loading UI** | Ordinary React `Suspense` in the application tree, optionally selected for a page with `@SuspenseFallback(...)`. | **Shipped with a narrow boundary.** The fallback covers descendants that suspend during SSR; it does not observe handler `await`, forms, effects, or navigation. |
+| **Data read / loader** | Read data in the `@Path(...)` handler through explicit application providers after HTTP DTO binding and validation, then pass the result to the React element. | **Shipped, intentionally different.** There is no loader runtime, loader cache, or client revalidation contract. |
+| **Mutation / action** | Submit a native form to an ordinary `@Post(...)` handler, bind and validate it with `@RequestDto(...)`, apply normal guards/interceptors, mutate application state, and redirect with `303 See Other` when appropriate. | **Shipped, intentionally different.** The stable surface has no compiled action, fetcher, optimistic-state, or cache-invalidation runtime. |
+| **Navigation** | Use a real `<a>` or `Link` from `@fluojs/react/client`; use `router.push(...)`, `router.replace(...)`, `router.back()`, or `router.refresh()` for controls. | **Shipped, intentionally different.** Path/search changes use full-document navigation, so the destination returns through the HTTP lifecycle. Fragment-only changes remain same-document browser navigation. |
+| **Pending state** | `useNavigation()` reports the client navigation lifecycle. React `Suspense` reports rendering fallback through the component tree. Applications may add local form pending UI without removing the native form action. | **Shipped with separate phases.** There is no stable submit-state helper or shared loader/action pending model. |
+| **Error UI** | HTTP pipeline failures keep the existing HTTP error path. Stable React SSR diagnostics distinguish HTTP-pipeline, pre-commit shell, request-abort, and post-shell recoverable phases. Application React error boundaries remain ordinary React code. | **Shipped, intentionally different.** There is no segment `error` file or React-owned HTTP error router. |
+| **Not found** | A missing explicit route is the normal `@fluojs/http` not-found response; handlers may throw the shipped HTTP not-found exception when application lookup fails. | **Shipped, intentionally different.** There is no React `notFound()` helper or catch-all requirement. |
+| **Metadata / head** | Render `<title>`, `<meta>`, and `<link>` in the application document. Use existing HTTP decorators and response APIs for status and headers. | **Shipped as application-owned composition.** There is no automatic metadata function or route-segment merge contract. |
+| **Hydration** | Pass explicit hydration assets through `createReactServerEntry(...)`, render the same request URL and HTTP-matched params into a `ReactClientRouterProvider` snapshot, then call React DOM `hydrateRoot(...)` in the browser entry. | **Shipped.** Server/client data transfer and safe serialization remain application responsibilities. |
+| **Build assets** | The application loads its Vite manifest and gives that value to `createReactViteAssetManifest(...)` from `@fluojs/react/vite`; the application document emits returned CSS and hydration options. | **Shipped.** fluo does not discover manifests, run Vite, generate bundles, or choose static-file/CDN hosting. |
+
+## Package boundaries
+
+| Import | Responsibility | Status |
+| --- | --- | --- |
+| `@fluojs/react` | `ReactModule.forRoot(...)`, `@Router(...)`, `@Path(...)`, page rendering policies, Web Streams SSR, diagnostics, page catalog, and explicit hydration options. | Stable runtime-neutral root. It does not import browser, Vite, typegen, or RSC code. |
+| `@fluojs/react/client` | Real anchors, full-document navigation controls, request-scoped route snapshots, and URL/navigation hooks. | Stable browser-only subpath. It has no matcher, route table, document cache, or prefetch layer. |
+| `@fluojs/react/vite` | Parse an already-loaded Vite manifest into deterministic React CSS, JavaScript, asset-map, and hydration options. | Stable build-integration subpath. It does not read files or run Vite. |
+| `@fluojs/react/typegen` | Generate deterministic path-only declarations and absolute href builders from a compiled React page catalog. | Stable tooling subpath. It rejects versioned routes and does not generate query, fragment, relative-route, or route-tree contracts. |
+| `@fluojs/react/experimental/rsc` | Compatibility diagnostics, application-supplied RSC manifest seams, Flight responses, and signed Server Function transport mounted on explicit HTTP endpoints. | **Experimental.** It is isolated from every stable entrypoint and is not a stable RSC or action promise. |
+
+## Minimal end-to-end path
+
+The runnable `react-vite-ssr` example is the canonical complete path. Read it in this order:
+
+1. [`src/main.ts`](../../examples/react-vite-ssr/src/main.ts) loads the generated Vite manifest at
+   the application boundary and bootstraps the normal fluo HTTP application.
+2. [`src/app.ts`](../../examples/react-vite-ssr/src/app.ts) passes that value to
+   `createReactViteAssetManifest(...)`, builds a `ReactPageRenderer` with
+   `createReactServerEntry(...)`, declares `@Router('/products')` plus `@Path('/:sku')`, and registers
+   the router through `ReactModule.forRoot(...)`.
+3. The same router's `@Post('/:sku')` handler receives the native form, uses the ordinary HTTP DTO,
+   guard, interceptor, middleware, and request-scope path, and redirects back to an explicit `GET`
+   route with `303`.
+4. [`src/page.ts`](../../examples/react-vite-ssr/src/page.ts) renders document metadata and Vite CSS,
+   creates the request-scoped snapshot with `createReactRouteSnapshot(...)`, wraps the document in
+   `ReactClientRouterProvider`, renders a real `Link`, exposes `useNavigation()`, and keeps a real
+   `<form method="post">` as the mutation baseline.
+5. [`src/entry-client.ts`](../../examples/react-vite-ssr/src/entry-client.ts) calls React DOM
+   `hydrateRoot(...)` with the same URL, params, page data, stylesheets, and identifier prefix used
+   for server rendering.
+
+For a smaller SSR-only starting point, use
+[`examples/react-stable-ssr`](../../examples/react-stable-ssr/README.md). Add the Vite example only
+when the application needs generated build assets, hydration, client navigation, or the native form
+slice.
+
+## Experimental surfaces
+
+`@fluojs/react/experimental/rsc` is the only current RSC and Server Function surface. It requires
+the documented exact React/renderer compatibility and application-owned build/encoding inputs.
+Flight responses and Server Function calls still mount on explicit ordinary fluo HTTP routes. Do not
+translate this subpath into a stable Server Component, server action, router, loader, or cache
+contract. See the [RSC graduation policy](../contracts/react-rsc-graduation.md) for the evidence
+required before any stable subpath can exist.
+
+## Unsupported concepts
+
+The current package does not provide:
+
+- file routing, a React-owned matcher, a nested route tree, or a catch-all route grammar
+- a route-module loader/action runtime, fetchers, or automatic data revalidation
+- SPA document swapping, a client document/data cache, navigation prefetch, or optimistic mutation
+  policy
+- automatic metadata merging or segment-level `loading`, `error`, and `not-found` conventions
+- automatic Vite manifest discovery, bundle generation, static-file hosting, or arbitrary inline data
+  serialization
+- a stable RSC subpath, built-in Flight renderer, or automatic `"use server"` transform/export
+  discovery
+
+Applications may build policies above the shipped seams, but those policies are not
+`@fluojs/react` contracts and must not move route or request-lifecycle ownership out of
+`@fluojs/http`.
+
+## Related documentation
+
+- [`@fluojs/react` package contract](../../packages/react/README.md)
+- [Stable SSR runnable example](../../examples/react-stable-ssr/README.md)
+- [Vite SSR, hydration, navigation, and native form runnable example](../../examples/react-vite-ssr/README.md)
+- [`@fluojs/http` package contract](../../packages/http/README.md)
+- [React render policy decision](../architecture/react-render-policy-decorators.md)
+- [React RSC graduation policy](../contracts/react-rsc-graduation.md)

--- a/docs/guides/react-user-concepts.md
+++ b/docs/guides/react-user-concepts.md
@@ -13,12 +13,13 @@ The stable request path is:
 
 1. `@fluojs/http` matches an explicit route and runs DTO binding, validation, middleware, guards,
    interceptors, versioning, and request-scope creation.
-2. An `@Path(...)` handler returns one `ReactElement`, or returns `createReactServerEntry(...)`
-   explicitly when that route needs entry-specific options.
-3. The application `ReactPageRenderer` composes the page into its document shell and returns a
-   `ReactServerEntry`.
-4. The existing HTTP response writer streams the React result and keeps ownership of status,
-   headers, errors, aborts, and not-found responses.
+2. An `@Path(...)` handler may return an ordinary HTTP value, which bypasses React rendering and
+   keeps the normal HTTP response path. For a React-rendered page, it returns one `ReactElement` or
+   returns `createReactServerEntry(...)` explicitly when that route needs entry-specific options.
+3. For a returned `ReactElement`, the application `ReactPageRenderer` composes the page into its
+   document shell and returns a `ReactServerEntry`.
+4. The existing HTTP response writer writes the ordinary value or streams the React entry and keeps
+   ownership of status, headers, errors, aborts, and not-found responses.
 5. Application-loaded build assets and browser code hydrate the document and may add progressive
    navigation or local interaction.
 
@@ -30,7 +31,7 @@ remain in `@fluojs/http`.
 
 | Familiar concept | Current fluo equivalent | Boundary |
 | --- | --- | --- |
-| **Page** | A `GET` handler marked with `@Router(...)` and `@Path(...)`. Return one `ReactElement` for the configured application renderer, or return `createReactServerEntry(...)` explicitly. | **Shipped.** A page is still an HTTP handler, not a file or route-module convention. |
+| **Page** | A `GET` handler marked with `@Router(...)` and `@Path(...)`. It may return an ordinary HTTP value that bypasses React rendering, one `ReactElement` for the configured application renderer, or `createReactServerEntry(...)` explicitly. | **Shipped.** A page is still an HTTP handler, not a file or route-module convention. |
 | **Route** | The effective route compiled from ordinary fluo module/controller metadata. `@Path(...)` writes the same `GET` metadata as `@fluojs/http`; `@fluojs/react/typegen` can project the compiled page catalog into path-only href builders. | **Shipped, intentionally different.** HTTP owns matching, grammar, conflicts, params, versioning, and dispatch. Typegen does not create a route tree or represent versioned routes. |
 | **Layout** | The application `ReactPageRenderer` owns the document shell and shared providers. `@PageLayout(...)` adds optional class/method component-reference metadata that the same renderer composes. | **Shipped.** There is no file ancestry or framework-owned layout router. |
 | **Loading UI** | Ordinary React `Suspense` in the application tree, optionally selected for a page with `@SuspenseFallback(...)`. | **Shipped with a narrow boundary.** The fallback covers descendants that suspend during SSR; it does not observe handler `await`, forms, effects, or navigation. |
@@ -49,7 +50,7 @@ remain in `@fluojs/http`.
 | Import | Responsibility | Status |
 | --- | --- | --- |
 | `@fluojs/react` | `ReactModule.forRoot(...)`, `@Router(...)`, `@Path(...)`, page rendering policies, Web Streams SSR, diagnostics, page catalog, and explicit hydration options. | Stable runtime-neutral root. It does not import browser, Vite, typegen, or RSC code. |
-| `@fluojs/react/client` | Real anchors, full-document navigation controls, request-scoped route snapshots, and URL/navigation hooks. | Stable browser-only subpath. It has no matcher, route table, document cache, or prefetch layer. |
+| `@fluojs/react/client` | SSR-safe request-scoped route snapshots and provider composition, plus real anchors, hydrated full-document navigation controls, and URL/navigation hooks. | Stable SSR-and-browser subpath. `createReactRouteSnapshot(...)` and `ReactClientRouterProvider` support SSR and hydration; browser navigation effects bind only after hydration. It has no matcher, route table, document cache, or prefetch layer. |
 | `@fluojs/react/vite` | Parse an already-loaded Vite manifest into deterministic React CSS, JavaScript, asset-map, and hydration options. | Stable build-integration subpath. It does not read files or run Vite. |
 | `@fluojs/react/typegen` | Generate deterministic path-only declarations and absolute href builders from a compiled React page catalog. | Stable tooling subpath. It rejects versioned routes and does not generate query, fragment, relative-route, or route-tree contracts. |
 | `@fluojs/react/experimental/rsc` | Compatibility diagnostics, application-supplied RSC manifest seams, Flight responses, and signed Server Function transport mounted on explicit HTTP endpoints. | **Experimental.** It is isolated from every stable entrypoint and is not a stable RSC or action promise. |

--- a/packages/react/README.ko.md
+++ b/packages/react/README.ko.md
@@ -9,6 +9,7 @@ fluo 애플리케이션을 위한 런타임 중립 React 통합입니다.
 - [설치](#설치)
 - [사용 시점](#사용-시점)
 - [Stable SSR Mental Model](#stable-ssr-mental-model)
+- [React 사용자 개념 번역](#react-사용자-개념-번역)
 - [런타임 및 피어 계약](#런타임-및-피어-계약)
 - [Phase Boundaries](#phase-boundaries)
 - [ReactModule Registration](#reactmodule-registration)
@@ -65,6 +66,14 @@ Angular `Routes[]` table, file-route scanner, primary React-owned `routes: []` c
 기존 fluo module/controller pipeline에 남아 있습니다. Page handler는 일반 HTTP 값을 반환하거나,
 configured application page renderer가 처리할 유효한 `ReactElement` 하나를 반환하거나, route별 SSR option이
 필요할 때 `createReactServerEntry(...)`를 명시적으로 반환할 수 있습니다.
+
+## React 사용자 개념 번역
+
+Page, layout, loader, action, navigation, pending UI, metadata, hydration, build asset 용어에서
+출발한다면 간결한 [fluo의 React 개념 가이드](../../docs/guides/react-user-concepts.ko.md)를 사용하세요.
+이 가이드는 shipped equivalent, intentionally different behavior, experimental surface, unsupported
+concept를 구분하고, `@Router(...)`/`@Path(...)`에서 application renderer, Vite asset, hydration,
+client navigation, native form mutation으로 이어지는 실행 가능한 path 하나를 따라갑니다.
 
 ## 런타임 및 피어 계약
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -9,6 +9,7 @@ Runtime-neutral React integration for fluo applications.
 - [Installation](#installation)
 - [When to Use](#when-to-use)
 - [Stable SSR Mental Model](#stable-ssr-mental-model)
+- [React User Concept Translation](#react-user-concept-translation)
 - [Runtime and Peer Contract](#runtime-and-peer-contract)
 - [Phase Boundaries](#phase-boundaries)
 - [ReactModule Registration](#reactmodule-registration)
@@ -67,6 +68,15 @@ TanStack route tree, Angular `Routes[]` table, file-route scanner, or primary Re
 and dispatch stay in the existing fluo module/controller pipeline. Page handlers may return ordinary
 HTTP values, return one valid `ReactElement` for the configured application page renderer, or return
 `createReactServerEntry(...)` explicitly when they need per-route SSR options.
+
+## React User Concept Translation
+
+If your starting vocabulary is pages, layouts, loaders, actions, navigation, pending UI, metadata,
+hydration, or build assets, use the concise
+[React concepts in fluo guide](../../docs/guides/react-user-concepts.md). It separates shipped
+equivalents, intentionally different behavior, experimental surfaces, and unsupported concepts,
+then follows one runnable path from `@Router(...)`/`@Path(...)` through the application renderer,
+Vite assets, hydration, client navigation, and a native form mutation.
 
 ## Runtime and Peer Contract
 


### PR DESCRIPTION
## Summary

Adds a concise bilingual concept-translation guide for React, Remix/React Router, and Next.js users while preserving the existing HTTP-first ownership model. The guide distinguishes shipped equivalents, intentional differences, experimental surfaces, and unsupported concepts without claiming framework parity.

Linked context: Closes #2854

## Changes

- Added matching English and Korean guides for page, route, layout, loading, data-read, mutation, navigation, pending, error, not-found, metadata, hydration, and asset concepts.
- Documented the stable responsibilities of `@fluojs/react`, `@fluojs/react/client`, `@fluojs/react/vite`, and `@fluojs/react/typegen`, while keeping `@fluojs/react/experimental/rsc` explicitly unstable.
- Traced the shipped end-to-end path through `@Router(...)` / `@Path(...)`, `ReactModule.forRoot(...)`, the application page renderer, Vite assets, hydration, HTTP-first navigation, and a native form mutation.
- Linked both package README languages to their localized guide and runnable React examples.
- Preserved `@fluojs/http` ownership of URL matching, DTO binding, validation, guards, interceptors, middleware, versioning, request scopes, errors, and not-found responses.

## Testing

- `pnpm docs:sync-check` — passed; 42 EN/KO page pairs and 10 navigation metadata pairs.
- `pnpm verify:docs` — passed after `pnpm install --frozen-lockfile`; docs locale check, typecheck, and production build completed.
- `pnpm verify:platform-consistency-governance` — passed.
- `git diff --check` — passed.
- Changed-file LSP diagnostics were unavailable because no Markdown LSP is configured; canonical repository docs checks were used instead.
- Verified every named React API and subpath against `packages/react/package.json`, current source entrypoints, and the runnable `react-stable-ssr` / `react-vite-ssr` examples.

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

No Changeset is included because this is documentation-only clarification of already shipped APIs and limitations. It does not change package source, exports, runtime behavior, entrypoints, route ownership, package metadata, or release metadata.

## Public export documentation

- [x] No public exports changed.
- [x] The guide names only exports present in the stable root or documented subpaths.
- [x] Runnable example links provide the scenario treatment; no source TSDoc change is required.

## Behavioral contract

- [x] No documented behavioral contract was removed or widened.
- [x] Existing HTTP route and request-lifecycle ownership is stated explicitly.
- [x] Intentional limitations and unsupported concepts remain explicit.
- [x] No runtime invariant changed, so new regression tests are not applicable.

## Platform consistency governance (SSOT)

- [x] English/Korean companion guide structure and package README navigation remain synchronized.
- [x] Stable root and subpath boundaries remain unchanged.
- [x] No platform contract or conformance claim changed; platform harness updates are not applicable.
- [x] `pnpm verify:platform-consistency-governance` passed.