### PR TITLE
Resolve #2875: align core docs and book contracts

### DIFF
--- a/book/advanced/ch16-custom-package.ko.md
+++ b/book/advanced/ch16-custom-package.ko.md
@@ -91,7 +91,7 @@ export interface DynamicModule extends ModuleMetadata {
    }
    ```
 4. **팩토리 기반 `forRootAsync`**:
-   사용자가 `useFactory`, `useClass`, 또는 `useExisting` 전략을 제공할 수 있게 하려면 `AsyncModuleOptions`가 필요합니다. `inject` 배열은 팩토리가 실행되기 전에 `ConfigService` 같은 의존성을 해석하는 데 중요합니다.
+   사용자가 필수 `useFactory`를 제공하는 경우 `AsyncModuleOptions`를 사용합니다. 선택적 `inject` 배열에는 팩토리가 실행되기 전에 DI 컨테이너가 해석할 `ConfigService` 같은 의존성을 나열합니다.
 
 ## The exports Field and Visibility Contract
 
@@ -170,12 +170,11 @@ export class FeatureFlagsModule {
   static forRootAsync(options: AsyncModuleOptions<FeatureFlagsOptions>): DynamicModule {
     return {
       module: FeatureFlagsModule,
-      imports: options.imports || [],
       providers: [
         {
           provide: FEATURE_FLAGS_OPTIONS,
           useFactory: options.useFactory,
-          inject: options.inject || [],
+          inject: options.inject,
         },
         FeatureFlagsService,
       ],

--- a/book/advanced/ch16-custom-package.md
+++ b/book/advanced/ch16-custom-package.md
@@ -91,7 +91,7 @@ Following the community standard, fluo libraries use `forRoot` for static config
    }
    ```
 4. **Factory-based `forRootAsync`**:
-   To let users provide a `useFactory`, `useClass`, or `useExisting` strategy, you need `AsyncModuleOptions`. The `inject` array is important because it resolves dependencies such as `ConfigService` before the factory runs.
+   Use `AsyncModuleOptions` when users provide the required `useFactory`. Its optional `inject` array lists dependencies such as `ConfigService` for the DI container to resolve before the factory runs.
 
 ## The exports Field and Visibility Contract
 
@@ -170,12 +170,11 @@ export class FeatureFlagsModule {
   static forRootAsync(options: AsyncModuleOptions<FeatureFlagsOptions>): DynamicModule {
     return {
       module: FeatureFlagsModule,
-      imports: options.imports || [],
       providers: [
         {
           provide: FEATURE_FLAGS_OPTIONS,
           useFactory: options.useFactory,
-          inject: options.inject || [],
+          inject: options.inject,
         },
         FeatureFlagsService,
       ],

--- a/docs/architecture/decorators-and-metadata.ko.md
+++ b/docs/architecture/decorators-and-metadata.ko.md
@@ -35,8 +35,8 @@
 
 - fluo가 메타데이터 계약을 소유합니다. 런타임 소비자는 컴파일러가 방출한 설계 메타데이터가 아니라 fluo가 정의한 메타데이터 레코드를 읽습니다.
 - 표준 데코레이터 메타데이터는 `Symbol.metadata` 또는 fluo 메타데이터 심벌 폴리필을 통해 TC39 메타데이터 bag에 연결됩니다.
-- `@fluojs/core`는 module, class DI, controller, route, injection, DTO binding, validation 레코드용 메타데이터 헬퍼를 노출합니다.
-- 메타데이터 헬퍼는 공유 가능한 가변 상태 누수를 막기 위해 읽기와 쓰기 경계에서 가변 payload를 복제합니다.
+- `@fluojs/core` 루트는 공개 데코레이터와 에러, `ensureMetadataSymbol()`, read-only `getModuleMetadata()`, 공유 타입을 노출합니다. Request-pipeline 패키지는 DTO validation, binding 및 표준 데코레이터 metadata bag 접근에 문서화된 `@fluojs/core/request-pipeline` seam을 사용하며, 더 넓은 metadata reader/writer, controller/route helper, injection/validation helper, clone utility는 first-party `@fluojs/core/internal` seam에 남습니다.
+- 메타데이터 헬퍼는 문서화된 범위에서 defensive write/read 경계를 유지합니다. `getModuleMetadata()`, `getOwnClassDiMetadata()`, `getInheritedClassDiMetadata()`, `getClassDiMetadata()`는 clone-on-read 동작의 명시적 예외로, frozen immutable snapshot을 반환하고 write 사이에 같은 stable reference를 재사용할 수 있습니다. 다른 metadata reader는 각 reader의 테스트가 stable-reference 재사용을 문서화하지 않는 한 defensive-read 동작을 유지합니다.
 - controller 및 route 메타데이터는 표준 메타데이터 bag 내부에서 `fluo.standard.controller`, `fluo.standard.route` 같은 fluo 소유 심벌로 키잉됩니다.
 - module 및 class DI 메타데이터도 프레임워크 소유 저장소를 통해 함께 유지되므로, 런타임 패키지는 리플렉션 라이브러리에 의존하지 않고 안정적인 계약을 읽을 수 있습니다.
 - 메타데이터 등록은 장식된 클래스, 메서드, 필드가 평가될 때만 발생합니다. import되지 않은 선언은 런타임 그래프에 참여하지 않습니다.

--- a/docs/architecture/decorators-and-metadata.md
+++ b/docs/architecture/decorators-and-metadata.md
@@ -35,8 +35,8 @@ This document defines the current fluo decorator and metadata contract. fluo use
 
 - fluo owns the metadata contract. Runtime consumers read fluo-defined metadata records, not compiler-emitted design metadata.
 - Standard decorator metadata is anchored to the TC39 metadata bag through `Symbol.metadata` or the fluo metadata symbol polyfill.
-- `@fluojs/core` exposes metadata helpers for module, class DI, controller, route, injection, DTO binding, and validation records.
-- Metadata helpers clone mutable payloads on read and write boundaries to avoid shared mutable state leaks.
+- The `@fluojs/core` root exposes public decorators and errors, `ensureMetadataSymbol()`, read-only `getModuleMetadata()`, and shared types. Request-pipeline packages use the documented `@fluojs/core/request-pipeline` seam for DTO validation, binding, and standard decorator metadata-bag access; broader metadata readers and writers, controller and route helpers, injection and validation helpers, and clone utilities remain on the first-party `@fluojs/core/internal` seam.
+- Metadata helpers preserve defensive write and read boundaries where documented. `getModuleMetadata()`, `getOwnClassDiMetadata()`, `getInheritedClassDiMetadata()`, and `getClassDiMetadata()` are explicit exceptions to clone-on-read behavior: they return frozen immutable snapshots and may reuse the same stable reference between writes. Other metadata readers retain defensive-read behavior unless their own tests document stable-reference reuse.
 - Controller and route metadata are keyed by fluo-owned symbols such as `fluo.standard.controller` and `fluo.standard.route` inside the standard metadata bag.
 - Module and class DI metadata are also mirrored through framework-owned stores so runtime packages can read a stable contract without relying on reflection libraries.
 - Metadata registration happens only when the decorated class, method, or field is evaluated. Unimported declarations do not participate in the runtime graph.


### PR DESCRIPTION
## Summary

Align the governed core metadata documentation and advanced custom-package book guidance with the existing `@fluojs/core` contract.

Linked context: Closes #2875

## Changes

- Distinguish the root, `request-pipeline`, and `internal` metadata entrypoint responsibilities in the EN/KO architecture pair.
- Document frozen stable-reference snapshot exceptions without overgeneralizing clone-on-read behavior.
- Remove unsupported `useClass`, `useExisting`, and `imports` guidance from the EN/KO `AsyncModuleOptions` book example.

## Testing

- `git diff --check`
- `pnpm docs:sync-check`
- `pnpm verify:platform-consistency-governance`
- EN/KO heading parity confirmed for both changed pairs.

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

This is a docs-only correction to match existing package behavior and API; no changeset is required.

## Public export documentation

- [x] No public exports changed.
- [x] The documentation now reflects the existing root and subpath export boundaries.
- [x] Source examples and package README contracts remain unchanged.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] No new behavioral contract was introduced.
- [x] Existing metadata immutability and `AsyncModuleOptions` contracts are described accurately.
- [x] Runtime source and tests remain unchanged.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] Platform contract docs were not changed.
- [x] `pnpm verify:platform-consistency-governance` passes.