### PR TITLE
Resolve #2874: Lock Studio trace privacy exclusions in tests

### DIFF
--- a/packages/runtime/src/devtools/studio-runtime.test.ts
+++ b/packages/runtime/src/devtools/studio-runtime.test.ts
@@ -7,7 +7,7 @@ import { defineRuntimeClassDiMetadata, defineRuntimeModuleMetadata } from '../in
 import type { ApplicationLogger } from '../types.js';
 import type { StudioLiveEvent } from './contracts.js';
 import { createStudioLiveSnapshot } from './snapshot.js';
-import { StudioDevtoolsRuntime, createStudioDevtoolsRuntimeFromConfig, createStudioDevtoolsRuntimeFromEnv } from './studio-runtime.js';
+import { createStudioDevtoolsRuntimeFromConfig, createStudioDevtoolsRuntimeFromEnv, StudioDevtoolsRuntime } from './studio-runtime.js';
 
 const logger: ApplicationLogger = {
   debug() {},
@@ -128,7 +128,17 @@ describe('Studio devtools runtime bridge', () => {
     );
   });
 
-  it('emits request lifecycle traces without leaking request bodies', () => {
+  it('emits request lifecycle traces without bodies, cookies, or full headers', () => {
+    // Given
+    const secrets = {
+      cookie: 'studio-cookie-secret',
+      header: 'studio-header-secret',
+      requestBody: 'studio-request-body-secret',
+      responseBody: 'studio-response-body-secret',
+      urlFragment: 'studio-url-fragment-secret',
+      urlQuery: 'studio-url-query-secret',
+    } as const;
+    const forbiddenTraceFields = ['body', 'cookie', 'cookies', 'headers', 'payload', 'rawBody', 'requestBody', 'responseBody'] as const;
     const events: StudioLiveEvent[] = [];
     const runtime = new StudioDevtoolsRuntime({
       appId: 'app-test',
@@ -143,16 +153,20 @@ describe('Studio devtools runtime bridge', () => {
       container: new Container(),
       metadata: {},
       request: {
-        body: { password: 'do-not-send' },
-        cookies: {},
-        headers: { 'x-request-id': 'req-1' },
+        body: { password: secrets.requestBody },
+        cookies: { session: secrets.cookie },
+        headers: {
+          authorization: `Bearer ${secrets.header}`,
+          cookie: `session=${secrets.cookie}`,
+          'x-request-id': 'req-1',
+        },
         method: 'POST',
         params: {},
         path: '/login',
         query: {},
         raw: {},
         requestId: 'req-1',
-        url: '/login?token=do-not-send#fragment',
+        url: `/login?token=${secrets.urlQuery}#${secrets.urlFragment}`,
       },
       response: {
         committed: false,
@@ -165,15 +179,24 @@ describe('Studio devtools runtime bridge', () => {
       },
     } satisfies RequestContext;
 
+    // When
     runtime.requestObserver.onRequestStart?.({ requestContext });
-    runtime.requestObserver.onRequestSuccess?.({ requestContext }, { ok: true });
+    runtime.requestObserver.onRequestSuccess?.({ requestContext }, { accessToken: secrets.responseBody });
     runtime.requestObserver.onRequestFinish?.({ requestContext });
 
+    // Then
     expect(events.map((event) => event.sequence)).toEqual([1, 2]);
     expect(events[0]).toMatchObject({ type: 'request', payload: { requestId: 'req-1', status: 'started' } });
     expect(events[1]).toMatchObject({ type: 'request', payload: { requestId: 'req-1', status: 'succeeded', statusCode: 201 } });
     expect(events[0]?.payload).toMatchObject({ url: '/login' });
-    expect(JSON.stringify(events)).not.toContain('do-not-send');
+    const serializedEvents = JSON.stringify(events);
+    const serializedTracePayloads = JSON.stringify(events.map((event) => event.payload));
+    for (const secret of Object.values(secrets)) {
+      expect(serializedEvents).not.toContain(secret);
+    }
+    for (const field of forbiddenTraceFields) {
+      expect(serializedTracePayloads).not.toContain(`"${field}":`);
+    }
   });
 
   it('auto-instruments bootstrap when fluo dev --studio injects Studio env', async () => {


### PR DESCRIPTION
## Summary

Lock the existing `@fluojs/runtime` Studio trace privacy contract with focused regression coverage.

Linked context: https://github.com/fluojs/fluo/issues/2874

Closes #2874

## Changes

- Add distinct secret cookie, header, request-body, response-body, query, and fragment fixtures to the existing Studio request trace test.
- Assert captured and serialized request events contain neither the sensitive fixture values nor forbidden trace fields.
- Keep production runtime behavior and privacy policy unchanged.

## Testing

- `pnpm exec biome check packages/runtime/src/devtools/studio-runtime.test.ts` — passed
- `pnpm exec vitest run -c vitest.config.ts src/devtools/studio-runtime.test.ts` from `packages/runtime` — 6 tests passed
- `pnpm --filter @fluojs/runtime test` — 26 files / 292 tests passed
- `pnpm --filter @fluojs/runtime typecheck` — passed
- `pnpm --filter "@fluojs/runtime..." build` — passed for the runtime dependency closure
- `pnpm verify:platform-consistency-governance` — passed
- `pnpm test` was also attempted; unrelated workspace-wide build-lock contention and timeout failures remained outside `@fluojs/runtime`, while the targeted and full runtime suites passed.

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

No Changeset is included because only an existing test changes; production code, public API, published package contents, runtime behavior, and release metadata are unchanged.

## Public export documentation

- [x] Not applicable: no public exports or source TSDoc changed.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] No new behavioral contract was introduced; this PR preserves the existing `packages/runtime/README.md` trace privacy contract.
- [x] Intentional limitations remain unchanged.
- [x] The documented Studio trace privacy invariant is covered by focused regression assertions.

## Platform consistency governance (SSOT)

- [x] No governance docs, localized mirrors, platform contracts, or conformance claims changed.
- [x] `pnpm verify:platform-consistency-governance` passed for the unchanged SSOT surface.
- [x] Platform harness evidence is not applicable because this is runtime test-only coverage and no adapter behavior changed.