### PR TITLE
Resolve #2865: Align the advanced book with HTTP cancellation and capability contracts

### DIFF
--- a/book/advanced/ch11-request-pipeline.ko.md
+++ b/book/advanced/ch11-request-pipeline.ko.md
@@ -86,7 +86,7 @@ export function createDispatcher(options: CreateDispatcherOptions): Dispatcher {
 
 fluo는 `runWithRequestContext(...)`와 `getCurrentRequestContext()`를 노출하므로 서비스나 리포지토리처럼 깊은 호출 지점에서도 요청 객체를 모든 함수 인자로 전달하지 않고 현재 요청을 읽을 수 있습니다. 다만 격리 보장은 호스트의 async-context 역량에 따라 달라지며, 모든 런타임에 `AsyncLocalStorage`가 있다는 보편적 약속은 아닙니다.
 
-루트 `@fluojs/http` import는 Node async hooks를 즉시 로드하지 않습니다. Request-context helper는 처음 사용할 때 이미 존재하는 `globalThis.AsyncLocalStorage`를 우선 사용하고, 지원되는 Node.js 호스트에서는 `node:async_hooks`를 lazy하게 해석할 수 있습니다. 어느 storage를 사용하든 context는 awaited continuation을 따라가며 겹치는 요청을 격리합니다.
+루트 `@fluojs/http` import는 런타임별 entrypoint를 선택합니다. Node와 Bun은 module initialization 중 `node:async_hooks`의 host `AsyncLocalStorage` constructor를 등록하고, Deno, worker, browser, default entry는 Node built-in import를 포함하지 않습니다. Request-local store 자체는 첫 helper 사용 시점에 lazy하게 생성됩니다. 호스트가 async-context storage를 제공하면 context는 awaited continuation을 따라가며 겹치는 요청을 격리합니다.
 
 ```typescript
 runWithRequestContext(context, () => {
@@ -130,11 +130,11 @@ async function notifyObservers(
 ```typescript
 // packages/http/src/dispatch/dispatcher.ts (simplified)
 function isRequestAborted(request: FrameworkRequest): boolean {
-  return request.isAborted?.() ?? request.signal?.aborted === true;
+  return request.signal?.aborted === true || request.isAborted?.() === true;
 }
 ```
 
-일반 dispatch pipeline은 진입 시 이 상태를 확인하고, handler가 general path로 실행되면 handler/interceptor 작업 뒤 response를 쓰기 전에 다시 확인합니다. Native fast-path dispatch는 진입 시 확인합니다. 이것은 모든 middleware, database query, 임의의 business operation을 자동으로 취소하는 기능이 아니라 경계 검사입니다. 오래 실행되는 application code는 `RequestContext.request.signal`을 받아 cancellation을 지원하는 API로 직접 전파해야 합니다. Managed SSE는 request signal과 response-stream close notification에도 반응합니다.
+Dispatcher는 `signal`과 `isAborted()`를 독립적인 cancellation surface로 취급합니다. 어느 하나든 cancellation을 보고할 수 있으므로 `false` probe가 aborted signal을 가리지 않습니다. 일반 dispatch pipeline은 진입 시 이 상태를 확인하고, handler가 general path로 실행되면 handler/interceptor 작업 뒤 response를 쓰기 전에 다시 확인합니다. Native fast-path dispatch는 진입 시 확인합니다. 이것은 모든 middleware, database query, 임의의 business operation을 자동으로 취소하는 기능이 아니라 경계 검사입니다. 오래 실행되는 application code는 `RequestContext.request.signal`을 받아 cancellation을 지원하는 API로 직접 전파해야 합니다. Managed SSE는 request signal과 response-stream close notification에도 반응합니다.
 
 ## 11.6 파이프라인 시각화 다이어그램
 

--- a/book/advanced/ch11-request-pipeline.md
+++ b/book/advanced/ch11-request-pipeline.md
@@ -86,7 +86,7 @@ When a single HTTP request arrives, fluo runs the pipeline in the following orde
 
 fluo exposes `runWithRequestContext(...)` and `getCurrentRequestContext()` so deep call sites, such as service or repository layers, can read the current request without passing the request object through every function argument. The isolation guarantee depends on the host's async-context capability; it is not a universal promise that every runtime has `AsyncLocalStorage`.
 
-The root `@fluojs/http` import does not eagerly load Node's async hooks. On first use, the request-context helper prefers an already available `globalThis.AsyncLocalStorage`, and on supported Node.js hosts it can resolve `node:async_hooks` lazily. With either storage implementation, the context follows awaited continuations and overlapping requests stay isolated.
+The root `@fluojs/http` import selects a runtime-specific entrypoint. Node and Bun register the host `AsyncLocalStorage` constructor from `node:async_hooks` during module initialization, while Deno, worker, browser, and default entries remain free of Node built-in imports. The request-local store itself is created lazily on first helper use. When the host provides async-context storage, the context follows awaited continuations and overlapping requests stay isolated.
 
 ```typescript
 runWithRequestContext(context, () => {
@@ -130,11 +130,11 @@ If a client disconnects before receiving the response, such as during a browser 
 ```typescript
 // packages/http/src/dispatch/dispatcher.ts (simplified)
 function isRequestAborted(request: FrameworkRequest): boolean {
-  return request.isAborted?.() ?? request.signal?.aborted === true;
+  return request.signal?.aborted === true || request.isAborted?.() === true;
 }
 ```
 
-The ordinary dispatch pipeline checks this state at entry and, when a handler runs through the general path, again after handler/interceptor work before response writing. Native fast-path dispatch checks at entry. This is a boundary check, not automatic cancellation of every middleware, database query, or arbitrary business operation. Long-running application code must accept and propagate `RequestContext.request.signal` to APIs that support cancellation. Managed SSE additionally reacts to the request signal and response-stream close notifications.
+The dispatcher treats `signal` and `isAborted()` as independent cancellation surfaces: either one can report cancellation, so a `false` probe never masks an aborted signal. The ordinary dispatch pipeline checks this state at entry and, when a handler runs through the general path, again after handler/interceptor work before response writing. Native fast-path dispatch checks at entry. This is a boundary check, not automatic cancellation of every middleware, database query, or arbitrary business operation. Long-running application code must accept and propagate `RequestContext.request.signal` to APIs that support cancellation. Managed SSE additionally reacts to the request signal and response-stream close notifications.
 
 ## 11.6 Pipeline Visualization Diagram
 

--- a/book/advanced/ch13-custom-adapter.ko.md
+++ b/book/advanced/ch13-custom-adapter.ko.md
@@ -178,7 +178,7 @@ export function createFetchStyleHttpAdapterRealtimeCapability(
 }
 ```
 
-프레임워크는 이 정보를 바탕으로 WebSocket 또는 raw-upgrade 기능이 필요한 모듈(예: Socket.IO 통합)의 활성화 여부를 결정하거나 경고를 표시합니다. Managed SSE는 그 대신 adapter가 `FrameworkResponse.stream`을 노출해야 합니다. 이 HTTP contract를 만족하려면 adapter가 request abort를 `FrameworkRequest.signal`에 보존하고, `stream.onClose(...)`로 response-close notification을 노출하며, write backpressure를 보고하고 `waitForDrain()`을 구현해야 합니다. 그래야 dispatcher가 stream을 중단하고 drain한 뒤 닫을 수 있습니다.
+프레임워크는 이 정보를 바탕으로 WebSocket 또는 raw-upgrade 기능이 필요한 모듈(예: Socket.IO 통합)을 검증하고, capability가 지원되지 않거나 호환되지 않으면 error로 fail fast합니다. Managed SSE에 필수인 adapter surface는 `FrameworkResponse.stream`뿐입니다. 호스트가 request cancellation을 노출하면 adapter는 `FrameworkRequest.signal` 또는 `FrameworkRequest.isAborted()` 중 하나로 전달해야 하며, 가능한 경우 `stream.onClose(...)`로 response-close notification도 노출해야 합니다. `stream.write(...)`가 backpressure를 보고하면 dispatcher는 optional `stream.waitForDrain()` hook이 있을 때 이를 사용한 뒤 계속 진행합니다.
 
 ## 13.8 No-op 어댑터: 테스트와 커스텀 런타임
 

--- a/book/advanced/ch13-custom-adapter.ko.md
+++ b/book/advanced/ch13-custom-adapter.ko.md
@@ -161,7 +161,7 @@ AWS Lambda나 Cloudflare Workers 같은 환경에서는 플랫폼이 장기 실�
 
 ## 13.7 실시간 통신 역량(Realtime Capability) 보고
 
-어댑터는 자신이 WebSocket이나 SSE를 지원하는지 프레임워크에 알릴 수 있습니다. 이 보고는 `getRealtimeCapability`를 통해 수행됩니다. 기능이 실제로 지원되는지, 계약만 열려 있는지, 전혀 지원되지 않는지를 명시하면 상위 모듈이 안전하게 활성화 여부를 판단할 수 있습니다.
+어댑터는 WebSocket과 raw request-upgrade boundary를 `getRealtimeCapability()`로 보고합니다. 이 boundary가 실제로 지원되는지, contract-only인지, 지원되지 않는지를 명시하면 상위 WebSocket module이 기능 활성화 여부를 안전하게 판단할 수 있습니다. 이 capability는 SSE 지원을 보고하지 않으며, server-sent event는 HTTP response-stream contract에 속합니다.
 
 ```typescript
 // packages/http/src/adapter.ts:L49-L63
@@ -178,7 +178,7 @@ export function createFetchStyleHttpAdapterRealtimeCapability(
 }
 ```
 
-프레임워크는 이 정보를 바탕으로 실시간 기능이 필요한 모듈(예: Socket.IO 통합)의 활성화 여부를 결정하거나 경고를 표시합니다.
+프레임워크는 이 정보를 바탕으로 WebSocket 또는 raw-upgrade 기능이 필요한 모듈(예: Socket.IO 통합)의 활성화 여부를 결정하거나 경고를 표시합니다. Managed SSE는 그 대신 adapter가 `FrameworkResponse.stream`을 노출해야 합니다. 이 HTTP contract를 만족하려면 adapter가 request abort를 `FrameworkRequest.signal`에 보존하고, `stream.onClose(...)`로 response-close notification을 노출하며, write backpressure를 보고하고 `waitForDrain()`을 구현해야 합니다. 그래야 dispatcher가 stream을 중단하고 drain한 뒤 닫을 수 있습니다.
 
 ## 13.8 No-op 어댑터: 테스트와 커스텀 런타임
 
@@ -334,7 +334,7 @@ export class TinyNodeAdapter implements HttpApplicationAdapter {
 - `FrameworkRequest/Response` 매핑이 어댑터 구현의 핵심입니다.
 - 바인더와의 협력을 통해 데이터가 흐르는 파이프라인이 완성됩니다.
 - 고성능 시스템에서는 AbortSignal 연동을 통한 자원 정리 최적화가 필수적입니다.
-- 실시간 통신 역량 보고는 생태계 모듈 간의 호환성을 보장하는 중요한 계약입니다.
+- WebSocket과 raw-upgrade capability 보고는 realtime 생태계 모듈 간 호환성을 보장하는 중요한 계약이며, managed SSE 지원은 `FrameworkResponse.stream`에 속합니다.
 
 ## 13.14 다음 챕터 예고
 

--- a/book/advanced/ch13-custom-adapter.md
+++ b/book/advanced/ch13-custom-adapter.md
@@ -178,7 +178,7 @@ export function createFetchStyleHttpAdapterRealtimeCapability(
 }
 ```
 
-The framework uses this information to decide whether to enable modules that need WebSocket or raw-upgrade features, such as a Socket.IO integration, or to show warnings. Managed SSE instead requires the adapter to expose `FrameworkResponse.stream`. To satisfy that HTTP contract, the adapter must preserve request abort on `FrameworkRequest.signal`, expose response-close notifications through `stream.onClose(...)`, report write backpressure, and implement `waitForDrain()` so the dispatcher can stop, drain, and close the stream.
+The framework uses this information to validate modules that need WebSocket or raw-upgrade features, such as a Socket.IO integration, and fails fast with an error when the capability is unsupported or incompatible. Managed SSE instead requires only that the adapter expose `FrameworkResponse.stream`. When the host exposes request cancellation, the adapter should forward either `FrameworkRequest.signal` or `FrameworkRequest.isAborted()`; it should also expose response-close notifications through `stream.onClose(...)` when possible. If `stream.write(...)` reports backpressure, the dispatcher uses the optional `stream.waitForDrain()` hook when available before continuing.
 
 ## 13.8 No-op Adapter: Tests and Custom Runtimes
 

--- a/book/advanced/ch13-custom-adapter.md
+++ b/book/advanced/ch13-custom-adapter.md
@@ -161,7 +161,7 @@ In `packages/platform-cloudflare-workers/src/adapter.ts`, `listen()` stores the 
 
 ## 13.7 Reporting Realtime Capability
 
-An adapter can tell the framework whether it supports WebSocket or SSE. This report is made through `getRealtimeCapability`. By stating whether a feature is truly supported, contract-only, or unsupported, the adapter lets higher-level modules decide safely whether they can turn realtime features on.
+An adapter reports its WebSocket and raw request-upgrade boundary through `getRealtimeCapability()`. By stating whether that boundary is truly supported, contract-only, or unsupported, the adapter lets higher-level WebSocket modules decide safely whether they can turn their features on. This capability does not report SSE support; server-sent events remain part of the HTTP response-stream contract.
 
 ```typescript
 // packages/http/src/adapter.ts:L49-L63
@@ -178,7 +178,7 @@ export function createFetchStyleHttpAdapterRealtimeCapability(
 }
 ```
 
-The framework uses this information to decide whether to enable modules that need realtime features, such as a Socket.IO integration, or to show warnings.
+The framework uses this information to decide whether to enable modules that need WebSocket or raw-upgrade features, such as a Socket.IO integration, or to show warnings. Managed SSE instead requires the adapter to expose `FrameworkResponse.stream`. To satisfy that HTTP contract, the adapter must preserve request abort on `FrameworkRequest.signal`, expose response-close notifications through `stream.onClose(...)`, report write backpressure, and implement `waitForDrain()` so the dispatcher can stop, drain, and close the stream.
 
 ## 13.8 No-op Adapter: Tests and Custom Runtimes
 
@@ -334,7 +334,7 @@ This skeleton now satisfies the required request/response shape, but it is still
 - `FrameworkRequest/Response` mapping is the core of adapter implementation.
 - Cooperation with the binder completes the pipeline where data flows.
 - In high-performance systems, resource cleanup optimization through AbortSignal integration is essential.
-- Realtime communication capability reporting is an important contract that guarantees compatibility across ecosystem modules.
+- WebSocket and raw-upgrade capability reporting is an important contract that guarantees compatibility across realtime ecosystem modules; managed SSE support belongs to `FrameworkResponse.stream`.
 
 ## 13.14 Next Chapter Preview
 


### PR DESCRIPTION
## Summary

Align the advanced HTTP book with the canonical cancellation, request-context initialization, realtime capability, and managed SSE contracts.

Linked context: https://github.com/fluojs/fluo/issues/2865

Closes #2865

## Changes

- Update the EN/KO request-pipeline chapters so `FrameworkRequest.signal` and `FrameworkRequest.isAborted()` remain independent cancellation surfaces.
- Distinguish Node/Bun host `AsyncLocalStorage` constructor registration during module initialization from lazy request-local store creation.
- Limit `getRealtimeCapability()` guidance to WebSocket/raw-upgrade boundaries and document managed SSE through `FrameworkResponse.stream`, request abort, response close, and backpressure handling.
- Preserve semantic parity between both changed EN/KO chapter pairs.

## Testing

- `git diff --check` — passed.
- `pnpm docs:sync-check` — passed: 42 EN/KO page pairs and 10 navigation metadata pairs.
- `pnpm verify:platform-consistency-governance` — passed.
- `pnpm vitest run tooling/governance/verify-platform-consistency-governance.test.ts --maxWorkers=1` — passed: 117 tests.
- Targeted `pnpm exec node` EN/KO section and HTTP contract marker assertions — passed for both chapter pairs.
- `pnpm verify` — build, typecheck, and lint passed; the full test phase reported six unrelated timeout failures after 4,548 tests passed.
- `pnpm vitest run packages/cli/src/cli.test.ts packages/platform-bun/src/published-declaration-surface.test.ts packages/cli/src/commands/typegen-navigation.test.ts packages/cli/src/commands/typegen.test.ts packages/cli/src/new/scaffold.test.ts --maxWorkers=1` — passed: 5 files, 262 tests, confirming the timeout-only failures pass when isolated.

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

No changeset is included because this PR corrects book guidance only; it does not change published package behavior, API surface, package contents, or release metadata.

## Public export documentation

- [x] Not applicable: no `packages/*/src` files or public exports changed.
- [x] Package README examples and source TSDoc remain unchanged because the canonical `@fluojs/http` contract was already correct.

## Behavioral contract

- [x] No documented behavioral contracts were removed.
- [x] The book now matches `packages/http/README.md` and `docs/architecture/http-runtime.md`.
- [x] Runtime behavior and public APIs are unchanged.
- [x] Existing governance coverage and targeted EN/KO assertions passed.

## Platform consistency governance (SSOT)

- [x] Both affected English/Korean book pairs were updated together with semantic parity.
- [x] Canonical package and architecture SSOT files were reviewed and required no edits.
- [x] Platform consistency governance checks and their 117-test regression suite passed.
- [x] Adapter capability guidance now keeps WebSocket/raw upgrade reporting separate from managed SSE stream support.