### PR TITLE
Resolve #2877: add metadata precedence regression coverage

### DIFF
--- a/packages/core/src/metadata-precedence.test.ts
+++ b/packages/core/src/metadata-precedence.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getOwnStandardConstructorMetadataBag,
+  getStandardMetadataBag,
+  type StandardMetadataBag,
+  standardMetadataKeys,
+} from './metadata/shared.js';
+import {
+  appendDtoFieldValidationRule,
+  ensureMetadataSymbol,
+  getDtoFieldValidationRules,
+  getDtoValidationSchema,
+} from './metadata.js';
+
+describe('metadata precedence', () => {
+  it('places standard DTO validation rules before stored rules in field reader output', () => {
+    // Given
+    class ExampleDto {
+      declare readonly name: string;
+    }
+
+    Object.defineProperty(ExampleDto, ensureMetadataSymbol(), {
+      configurable: true,
+      value: {
+        [standardMetadataKeys.dtoFieldValidation]: new Map([
+          ['name', [{ kind: 'minLength', value: 3 }]],
+        ]),
+      },
+    });
+    appendDtoFieldValidationRule(ExampleDto.prototype, 'name', {
+      kind: 'minLength',
+      value: 11,
+    });
+
+    // When
+    const rules = getDtoFieldValidationRules(ExampleDto.prototype, 'name');
+
+    // Then
+    expect(rules).toEqual([
+      { kind: 'minLength', value: 3 },
+      { kind: 'minLength', value: 11 },
+    ]);
+  });
+
+  it('places standard DTO validation rules before stored rules in schema reader output', () => {
+    // Given
+    class ExampleDto {
+      declare readonly name: string;
+    }
+
+    Object.defineProperty(ExampleDto, ensureMetadataSymbol(), {
+      configurable: true,
+      value: {
+        [standardMetadataKeys.dtoFieldValidation]: new Map([
+          ['name', [{ kind: 'maxLength', value: 17 }]],
+        ]),
+      },
+    });
+    appendDtoFieldValidationRule(ExampleDto.prototype, 'name', {
+      kind: 'maxLength',
+      value: 5,
+    });
+
+    // When
+    const schema = getDtoValidationSchema(ExampleDto);
+
+    // Then
+    expect(schema).toEqual([
+      {
+        propertyKey: 'name',
+        rules: [
+          { kind: 'maxLength', value: 17 },
+          { kind: 'maxLength', value: 5 },
+        ],
+      },
+    ]);
+  });
+
+  it('prefers native metadata over same-constructor fallback metadata while supplementing inherited keys', () => {
+    // Given
+    const originalDescriptor = Object.getOwnPropertyDescriptor(Symbol, 'metadata');
+    const fallbackSymbol = ensureMetadataSymbol();
+    const nativeSymbol = Symbol('native.metadata');
+    const inheritedFallbackInjectionMetadata = new Map([['service', { optional: true, token: 'INHERITED_FALLBACK_LOGGER' }]]);
+    const ownFallbackBag: StandardMetadataBag = {
+      [standardMetadataKeys.controller]: { basePath: '/child-fallback' },
+    };
+    const ownNativeBag: StandardMetadataBag = {
+      [standardMetadataKeys.controller]: { basePath: '/child-native' },
+    };
+
+    class BaseController {}
+    class ChildController extends BaseController {}
+
+    Object.defineProperty(BaseController, fallbackSymbol, {
+      configurable: true,
+      value: {
+        [standardMetadataKeys.injection]: inheritedFallbackInjectionMetadata,
+      },
+    });
+    Object.defineProperty(ChildController, fallbackSymbol, {
+      configurable: true,
+      value: ownFallbackBag,
+    });
+    Object.defineProperty(Symbol, 'metadata', {
+      configurable: true,
+      value: nativeSymbol,
+    });
+    Object.defineProperty(ChildController, nativeSymbol, {
+      configurable: true,
+      value: ownNativeBag,
+    });
+
+    try {
+      // When
+      const metadataBag = getStandardMetadataBag(ChildController);
+
+      // Then
+      expect(metadataBag?.[standardMetadataKeys.controller]).toEqual({ basePath: '/child-native' });
+      expect(metadataBag?.[standardMetadataKeys.injection]).toBe(inheritedFallbackInjectionMetadata);
+      expect(getOwnStandardConstructorMetadataBag(ChildController)).toBe(ownNativeBag);
+    } finally {
+      if (originalDescriptor) {
+        Object.defineProperty(Symbol, 'metadata', originalDescriptor);
+      } else {
+        Reflect.deleteProperty(Symbol, 'metadata');
+      }
+      ensureMetadataSymbol();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Add focused regression coverage for the existing DTO validation and mixed-era metadata precedence contracts.

Linked context: Closes #2877

## Changes

- Verify standard DTO validation rules precede explicitly stored rules in both field-reader and schema-reader outputs.
- Verify native same-constructor metadata wins over fallback metadata while missing keys are supplemented from inherited fallback metadata.
- Use distinct fixture values so each precedence choice is observable.

## Testing

- TypeScript diagnostics: 0 errors across `packages/core`
- Targeted metadata precedence tests: 3 passed after rebasing onto current `origin/main`
- Targeted metadata suite: 43 passed
- `pnpm --filter @fluojs/core test`: 72 passed
- `pnpm --filter @fluojs/core typecheck`
- Biome and `git diff --check`

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

This is test-only coverage for existing behavior; no changeset is required.

## Public export documentation

- [x] No public exports changed.
- [x] No source-level TSDoc or README changes are required.
- [x] Existing package documentation remains the test oracle.

## Behavioral contract

- [x] No documented behavioral contracts were removed or changed.
- [x] Existing standard/stored and native/fallback precedence is locked by regression tests.
- [x] Production source remains unchanged.
- [x] Each precedence fixture differs from its fallback value.

## Platform consistency governance (SSOT)

- [x] No platform contract docs changed.
- [x] No EN/KO companion update is required.
- [x] The change is isolated to `packages/core` test coverage.