### PR TITLE
Resolve #2866: Correct public fast-path symbol TSDoc classification

### DIFF
--- a/.changeset/correct-fast-path-tsdoc.md
+++ b/.changeset/correct-fast-path-tsdoc.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/http": patch
+---
+
+Correct the public TSDoc classification for the fast-path observability symbols.

--- a/packages/http/src/dispatch/fast-path/eligibility.ts
+++ b/packages/http/src/dispatch/fast-path/eligibility.ts
@@ -67,13 +67,19 @@ export interface FastPathStats {
 }
 
 /**
- * Symbol used to attach fast path eligibility metadata to handler descriptors.
- * @internal
+ * Public symbol key for fast path eligibility metadata attached to handler descriptors.
+ *
+ * @remarks
+ * Adapter and diagnostics integrations can use this key to inspect the route's
+ * {@link FastPathEligibility} metadata.
  */
 export const FAST_PATH_ELIGIBILITY_SYMBOL = Symbol('fastPathEligibility');
 
 /**
- * Symbol used to attach fast path execution stats to dispatcher.
- * @internal
+ * Public symbol key for fast path execution statistics attached to a dispatcher.
+ *
+ * @remarks
+ * Adapter and diagnostics integrations can use this key to read the same
+ * {@link FastPathStats} value exposed by `getDispatcherFastPathStats(...)`.
  */
 export const FAST_PATH_STATS_SYMBOL = Symbol('fastPathStats');


### PR DESCRIPTION
## Summary

Correct the source TSDoc classification for the two fast-path observability symbols that are already exported and documented through the public `@fluojs/http` root surface.

Linked context: Closes #2866

## Changes

- Remove the incorrect `@internal` tags from `FAST_PATH_ELIGIBILITY_SYMBOL` and `FAST_PATH_STATS_SYMBOL`.
- Document their public adapter and diagnostics observability contracts without changing symbol identity, export names, or runtime behavior.
- Add a patch changeset for `@fluojs/http` because the corrected TSDoc is emitted into the published declaration artifact.

## Testing

- `lsp_diagnostics packages/http/src/dispatch/fast-path/eligibility.ts` — passed with no diagnostics.
- `pnpm exec biome lint packages/http/src/dispatch/fast-path/eligibility.ts` — passed.
- `pnpm verify:public-export-tsdoc` — passed in changed mode.
- `pnpm --filter @fluojs/http... build` — passed for `@fluojs/core`, `@fluojs/di`, `@fluojs/validation`, and `@fluojs/http`.
- `pnpm --dir packages/http typecheck` — passed after dependency builds.
- `pnpm --dir packages/http test` — 18 files and 230 tests passed.
- `pnpm lint` — completed successfully; repository-wide pre-existing informational diagnostics remain outside this diff.
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main` — passed.
- Repository-wide Vitest runs exposed unrelated fixed-timeout contention: the default run had 10 timeout failures and `--maxWorkers=1` had 2 timeout failures. Every timed-out file passed in quiet targeted reruns, including 265 tests across the initial five files and the `packages/platform-bun` declaration test.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

The runtime and public API shape are unchanged, but TypeScript emits these TSDoc comments into the published declaration artifact. The patch changeset records that package-documentation correction.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable. No functions changed; both declarations are symbols.
- [x] Source `@example` blocks and README scenario examples still play complementary roles. No example was required; the README already documents the observability surface.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README. No new behavior was introduced; the existing README already identifies both symbols as public.
- [x] Intentional limitations are explicitly stated. No limitation changed.
- [x] Runtime invariants are covered by regression tests. Runtime behavior is unchanged, and the existing public API test keeps both root exports covered.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. No governance docs changed.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. Not applicable; no platform contract docs changed.
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests. Not applicable; the package README was already aligned and no platform claim changed.