### PR TITLE
Resolve #2872: Enforce Web JSON body limits while streaming

### DIFF
--- a/.changeset/issue-2872-web-json-body-limit.md
+++ b/.changeset/issue-2872-web-json-body-limit.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/runtime": patch
+---
+
+Enforce Web JSON request body limits while streaming even when Content-Length appears safe.

--- a/.changeset/issue-2872-web-json-body-limit.md
+++ b/.changeset/issue-2872-web-json-body-limit.md
@@ -2,4 +2,4 @@
 "@fluojs/runtime": patch
 ---
 
-Enforce Web JSON request body limits while streaming even when Content-Length appears safe.
+Enforce Web JSON request body limits while streaming even when Content-Length appears safe, settle oversized cloned streams without waiting for cancellation, preserve HTTP 413 when cancellation rejects, and deprecate the compatibility-only `preferNativeJsonBodyReader` option.

--- a/packages/platform-bun/src/adapter.ts
+++ b/packages/platform-bun/src/adapter.ts
@@ -270,7 +270,6 @@ export class BunHttpApplicationAdapter implements HttpApplicationAdapter, BunWeb
       consumeOriginalBody: true,
       maxBodySize: options.maxBodySize,
       multipart: options.multipart,
-      preferNativeJsonBodyReader: true,
       rawBody: options.rawBody,
     });
   }
@@ -453,7 +452,6 @@ export function createBunFetchHandler({
     consumeOriginalBody: true,
     maxBodySize,
     multipart,
-    preferNativeJsonBodyReader: true,
     rawBody,
   });
 

--- a/packages/runtime/README.ko.md
+++ b/packages/runtime/README.ko.md
@@ -134,7 +134,8 @@ class UsersModule {}
 
 ## 동작 계약
 
-- 요청 바디 파싱은 Web 표준 요청과 Node 기반 요청 모두에서 바이트가 스트리밍되는 동안 `maxBodySize`를 강제합니다.
+- 요청 바디 파싱은 Web 표준 요청과 Node 기반 요청 모두에서 바이트가 스트리밍되는 동안 `maxBodySize`를 강제합니다. 한도를 넘은 Web 바디는 stream cancellation을 기다리지 않고 HTTP 413으로 완료되며, cancellation 실패도 해당 응답을 가리지 않습니다. 이 계약은 원본 요청을 읽지 않는 기본 cloned-body 경로에도 적용됩니다.
+- `preferNativeJsonBodyReader`는 deprecated adapter compatibility 옵션으로 `@fluojs/runtime/web`에서 계속 허용되지만 더 이상 파싱 동작을 바꾸지 않습니다. Web JSON 바디는 항상 bounded streaming reader를 사용하므로 native whole-body read가 `maxBodySize`를 우회할 수 없습니다.
 - `@fluojs/runtime/node`에서는 Node 요청 바디 파싱 전에 primary `content-type` media type을 normalize한 뒤 JSON 및 멀티파트 여부를 판단하므로, 대소문자가 섞인 JSON/멀티파트 헤더도 문서화된 파서 동작을 그대로 유지합니다.
 - Node 기반 및 Web 표준 요청 wrapper는 바디 파싱 전에 저비용 요청 metadata를 snapshot으로 고정한 뒤 dispatch 경계에서 `body`/`rawBody`를 한 번 materialize하므로 userland는 계속 동기 parsed 값을 관찰합니다.
 - Node 기반 쿠키/쿼리 값과 Web 표준 헤더는 요청 wrapper가 생성되는 시점에 snapshot으로 고정된 뒤 요청별로 lazy하게 normalize되고 memoize됩니다. 이후 upstream 객체가 변경되어도 `FrameworkRequest` view는 바뀌지 않습니다.

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -134,7 +134,8 @@ class UsersModule {}
 
 ## Behavioral Contracts
 
-- Request body parsing enforces `maxBodySize` while bytes are still streaming for both Web-standard and Node-backed requests.
+- Request body parsing enforces `maxBodySize` while bytes are still streaming for both Web-standard and Node-backed requests. Oversized Web bodies settle as HTTP 413 without waiting for stream cancellation, and cancellation failures do not mask that response, including on the default cloned-body path where the original request remains unread.
+- `preferNativeJsonBodyReader` remains accepted by `@fluojs/runtime/web` as a deprecated adapter compatibility option, but it no longer changes parsing. Web JSON bodies always use the bounded streaming reader so native whole-body reads cannot bypass `maxBodySize`.
 - On `@fluojs/runtime/node`, Node request body parsing normalizes the primary `content-type` media type before JSON and multipart detection, so mixed-case JSON and multipart headers preserve the documented parser behavior.
 - Node-backed and Web-standard request wrappers snapshot cheap request metadata before body parsing, then materialize `body`/`rawBody` once at the dispatch boundary so userland continues to observe synchronous parsed values.
 - Node-backed cookies/query values and Web-standard headers are snapshotted when the request wrapper is created, then lazily normalized and memoized per request; later upstream object mutations do not change the `FrameworkRequest` view.

--- a/packages/runtime/src/web-body-limit.test.ts
+++ b/packages/runtime/src/web-body-limit.test.ts
@@ -1,12 +1,136 @@
 import type { FrameworkRequest, FrameworkResponse } from '@fluojs/http';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { dispatchWebRequest } from './web.js';
 
 const TEXT_ENCODER = new TextEncoder();
 
 describe('Web JSON body limits', () => {
-  it('cancels streamed JSON when an in-limit Content-Length understates the body size', async () => {
+  it('settles a default cloned request with 413 while the original body remains unread', async () => {
+    // Given
+    const oversizedChunk = TEXT_ENCODER.encode('{"value":"too large"}');
+    const keepStreamOpen = new Promise<void>(() => {});
+    let chunkSent = false;
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (chunkSent) {
+          return keepStreamOpen;
+        }
+
+        chunkSent = true;
+        controller.enqueue(oversizedChunk);
+      },
+    });
+    const requestInit = {
+      body,
+      duplex: 'half',
+      headers: {
+        'content-type': 'application/json',
+      },
+      method: 'POST',
+    } satisfies RequestInit & { duplex: 'half' };
+    const request = new Request('https://runtime.test/json', requestInit);
+
+    try {
+      // When
+      const response = await dispatchWebRequest({
+        dispatcher: {
+          async dispatch() {
+            throw new Error('should not dispatch oversized JSON');
+          },
+        },
+        maxBodySize: oversizedChunk.byteLength - 1,
+        request,
+      });
+
+      // Then
+      expect(response.status).toBe(413);
+      expect(request.bodyUsed).toBe(false);
+    } finally {
+      await request.body?.cancel();
+    }
+  });
+
+  it('preserves the 413 response when stream cancellation rejects', async () => {
+    // Given
+    const oversizedChunk = TEXT_ENCODER.encode('{"value":"too large"}');
+    let cancelCalled = false;
+    const body = new ReadableStream<Uint8Array>({
+      cancel() {
+        cancelCalled = true;
+        return Promise.reject(new Error('cancel failed'));
+      },
+      start(controller) {
+        controller.enqueue(oversizedChunk);
+      },
+    });
+    const requestInit = {
+      body,
+      duplex: 'half',
+      headers: {
+        'content-type': 'application/json',
+      },
+      method: 'POST',
+    } satisfies RequestInit & { duplex: 'half' };
+
+    // When
+    const response = await dispatchWebRequest({
+      consumeOriginalBody: true,
+      dispatcher: {
+        async dispatch() {
+          throw new Error('should not dispatch oversized JSON');
+        },
+      },
+      maxBodySize: oversizedChunk.byteLength - 1,
+      request: new Request('https://runtime.test/json', requestInit),
+    });
+
+    // Then
+    expect(response.status).toBe(413);
+    expect(cancelCalled).toBe(true);
+  });
+
+  it('preserves the 413 response when reader cancellation throws synchronously', async () => {
+    // Given
+    const oversizedChunk = TEXT_ENCODER.encode('{"value":"too large"}');
+    const cancelSpy = vi.spyOn(ReadableStreamDefaultReader.prototype, 'cancel').mockImplementationOnce(() => {
+      throw new Error('cancel threw');
+    });
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(oversizedChunk);
+      },
+    });
+    const requestInit = {
+      body,
+      duplex: 'half',
+      headers: { 'content-type': 'application/json' },
+      method: 'POST',
+    } satisfies RequestInit & { duplex: 'half' };
+    const request = new Request('https://runtime.test/json', requestInit);
+
+    try {
+      // When
+      const response = await dispatchWebRequest({
+        consumeOriginalBody: true,
+        dispatcher: {
+          async dispatch() {
+            throw new Error('should not dispatch oversized JSON');
+          },
+        },
+        maxBodySize: oversizedChunk.byteLength - 1,
+        request,
+      });
+
+      // Then
+      expect(response.status).toBe(413);
+    } finally {
+      cancelSpy.mockRestore();
+      await request.body?.cancel();
+    }
+  });
+
+  it('keeps streaming enforcement when preferNativeJsonBodyReader is enabled', async () => {
     // Given
     const chunks = [
       TEXT_ENCODER.encode('{"value":"'),
@@ -50,6 +174,7 @@ describe('Web JSON body limits', () => {
         },
       },
       maxBodySize: 12,
+      preferNativeJsonBodyReader: true,
       request: new Request('https://runtime.test/json', requestInit),
     });
 

--- a/packages/runtime/src/web-body-limit.test.ts
+++ b/packages/runtime/src/web-body-limit.test.ts
@@ -1,0 +1,169 @@
+import type { FrameworkRequest, FrameworkResponse } from '@fluojs/http';
+import { describe, expect, it } from 'vitest';
+
+import { dispatchWebRequest } from './web.js';
+
+const TEXT_ENCODER = new TextEncoder();
+
+describe('Web JSON body limits', () => {
+  it('cancels streamed JSON when an in-limit Content-Length understates the body size', async () => {
+    // Given
+    const chunks = [
+      TEXT_ENCODER.encode('{"value":"'),
+      TEXT_ENCODER.encode('0123456789'),
+      TEXT_ENCODER.encode('"}'),
+    ];
+    let chunkIndex = 0;
+    let cancelled = false;
+    const body = new ReadableStream<Uint8Array>({
+      cancel() {
+        cancelled = true;
+      },
+      pull(controller) {
+        const chunk = chunks[chunkIndex];
+
+        if (chunk === undefined) {
+          controller.close();
+          return;
+        }
+
+        chunkIndex += 1;
+        controller.enqueue(chunk);
+      },
+    });
+    const requestInit = {
+      body,
+      duplex: 'half',
+      headers: {
+        'content-length': '12',
+        'content-type': 'application/json',
+      },
+      method: 'POST',
+    } satisfies RequestInit & { duplex: 'half' };
+
+    // When
+    const response = await dispatchWebRequest({
+      consumeOriginalBody: true,
+      dispatcher: {
+        async dispatch(_request: FrameworkRequest) {
+          throw new Error('should not dispatch oversized JSON');
+        },
+      },
+      maxBodySize: 12,
+      request: new Request('https://runtime.test/json', requestInit),
+    });
+
+    // Then
+    expect(response.status).toBe(413);
+    expect(cancelled).toBe(true);
+  });
+
+  it('cancels oversized streamed JSON when Content-Length is missing', async () => {
+    // Given
+    const chunks = [
+      TEXT_ENCODER.encode('{"value":"'),
+      TEXT_ENCODER.encode('0123456789'),
+      TEXT_ENCODER.encode('"}'),
+    ];
+    let chunkIndex = 0;
+    let cancelled = false;
+    const body = new ReadableStream<Uint8Array>({
+      cancel() {
+        cancelled = true;
+      },
+      pull(controller) {
+        const chunk = chunks[chunkIndex];
+
+        if (chunk === undefined) {
+          controller.close();
+          return;
+        }
+
+        chunkIndex += 1;
+        controller.enqueue(chunk);
+      },
+    });
+    const requestInit = {
+      body,
+      duplex: 'half',
+      headers: {
+        'content-type': 'application/json',
+      },
+      method: 'POST',
+    } satisfies RequestInit & { duplex: 'half' };
+
+    // When
+    const response = await dispatchWebRequest({
+      consumeOriginalBody: true,
+      dispatcher: {
+        async dispatch() {
+          throw new Error('should not dispatch oversized JSON');
+        },
+      },
+      maxBodySize: 12,
+      request: new Request('https://runtime.test/json', requestInit),
+    });
+
+    // Then
+    expect(response.status).toBe(413);
+    expect(cancelled).toBe(true);
+  });
+
+  it('accepts streamed JSON when its byte length equals maxBodySize', async () => {
+    // Given
+    const body = '{"ok":true}';
+    const bodySize = TEXT_ENCODER.encode(body).byteLength;
+    let parsedBody: unknown;
+
+    // When
+    const response = await dispatchWebRequest({
+      consumeOriginalBody: true,
+      dispatcher: {
+        async dispatch(request: FrameworkRequest, frameworkResponse: FrameworkResponse) {
+          parsedBody = request.body;
+          await frameworkResponse.send({ accepted: true });
+        },
+      },
+      maxBodySize: bodySize,
+      request: new Request('https://runtime.test/json', {
+        body,
+        headers: {
+          'content-length': String(bodySize),
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      }),
+    });
+
+    // Then
+    expect(parsedBody).toEqual({ ok: true });
+    await expect(response.json()).resolves.toEqual({ accepted: true });
+  });
+
+  it('rejects JSON when Content-Length exceeds maxBodySize', async () => {
+    // Given
+    const request = new Request('https://runtime.test/json', {
+      body: '{}',
+      headers: {
+        'content-length': '13',
+        'content-type': 'application/json',
+      },
+      method: 'POST',
+    });
+
+    // When
+    const response = await dispatchWebRequest({
+      consumeOriginalBody: true,
+      dispatcher: {
+        async dispatch() {
+          throw new Error('should not dispatch oversized JSON');
+        },
+      },
+      maxBodySize: 12,
+      request,
+    });
+
+    // Then
+    expect(response.status).toBe(413);
+  });
+});

--- a/packages/runtime/src/web.ts
+++ b/packages/runtime/src/web.ts
@@ -1,27 +1,27 @@
 import {
   BadRequestException,
   createErrorResponse,
-  HttpException,
-  InternalServerErrorException,
-  PayloadTooLargeException,
   type Dispatcher,
   type FrameworkRequest,
   type FrameworkResponse,
+  HttpException,
+  InternalServerErrorException,
+  PayloadTooLargeException,
 } from '@fluojs/http';
 
+import {
+  dispatchWithRequestResponseFactory,
+  type RequestResponseFactory,
+} from './adapters/request-response-factory.js';
 import {
   attachRuntimeFrameworkRequestNativeRouteHandoff,
   consumeRuntimeRawRequestNativeRouteHandoff,
 } from './internal/http-runtime.js';
 import {
-  parseMultipart,
   type MultipartOptions,
+  parseMultipart,
   type UploadedFile,
 } from './multipart.js';
-import {
-  dispatchWithRequestResponseFactory,
-  type RequestResponseFactory,
-} from './adapters/request-response-factory.js';
 
 const DEFAULT_MAX_BODY_SIZE = 1 * 1024 * 1024;
 const TEXT_ENCODER = new TextEncoder();
@@ -35,6 +35,10 @@ export interface CreateWebRequestResponseFactoryOptions {
   consumeOriginalBody?: boolean;
   maxBodySize?: number;
   multipart?: MultipartOptions;
+  /**
+   * @deprecated Retained for adapter compatibility. Web JSON bodies always use the bounded streaming reader,
+   * so this option no longer changes request parsing.
+   */
   preferNativeJsonBodyReader?: boolean;
   rawBody?: boolean;
 }
@@ -692,7 +696,10 @@ async function readByteLimitedStream(
       totalSize += value.byteLength;
 
       if (totalSize > maxBodySize) {
-        await reader.cancel(REQUEST_BODY_LIMIT_MESSAGE);
+        const cancellation = new Promise<void>((resolve, reject) => {
+          void reader.cancel(REQUEST_BODY_LIMIT_MESSAGE).then(resolve, reject);
+        });
+        void Promise.allSettled([cancellation]);
         throw new PayloadTooLargeException(REQUEST_BODY_LIMIT_MESSAGE);
       }
 

--- a/packages/runtime/src/web.ts
+++ b/packages/runtime/src/web.ts
@@ -286,7 +286,6 @@ export function createWebRequestResponseFactory(
         options.multipart,
         options.maxBodySize ?? DEFAULT_MAX_BODY_SIZE,
         options.rawBody ?? false,
-        options.preferNativeJsonBodyReader ?? false,
         options.consumeOriginalBody ?? false,
       );
     },
@@ -379,7 +378,6 @@ function createDeferredWebFrameworkRequest(
   multipartOptions?: MultipartOptions,
   maxBodySize = DEFAULT_MAX_BODY_SIZE,
   preserveRawBody = false,
-  preferNativeJsonBodyReader = false,
   consumeOriginalBody = false,
 ): FrameworkRequest {
   const url = new URL(request.url);
@@ -421,7 +419,6 @@ function createDeferredWebFrameworkRequest(
       contentType,
       maxBodySize,
       preserveRawBody,
-      preferNativeJsonBodyReader,
     );
     frameworkRequest.body = bodyResult.body;
 
@@ -634,22 +631,11 @@ async function readWebRequestBody(
   contentType: string | undefined,
   maxBodySize = DEFAULT_MAX_BODY_SIZE,
   preserveRawBody = false,
-  preferNativeJsonBodyReader = false,
 ): Promise<{ body: unknown; rawBody?: Uint8Array }> {
   validateWebRequestContentLength(request, maxBodySize);
 
   if (!request.body) {
     return { body: undefined };
-  }
-
-  if (!preserveRawBody && isJsonContentType(contentType) && (preferNativeJsonBodyReader || isContentLengthWithinLimit(request, maxBodySize))) {
-    const rawBody = new Uint8Array(await request.arrayBuffer());
-
-    if (rawBody.byteLength > maxBodySize) {
-      throw new PayloadTooLargeException(REQUEST_BODY_LIMIT_MESSAGE);
-    }
-
-    return parseWebRequestRawBody(rawBody, contentType, preserveRawBody);
   }
 
   return parseWebRequestRawBody(await readByteLimitedStream(request.body, maxBodySize), contentType, preserveRawBody);
@@ -685,17 +671,6 @@ function parseWebRequestRawBody(
     body: bodyText,
     rawBody: preserveRawBody ? rawBody : undefined,
   };
-}
-
-function isContentLengthWithinLimit(request: Request, maxBodySize: number): boolean {
-  const contentLength = request.headers.get('content-length');
-
-  if (contentLength === null) {
-    return false;
-  }
-
-  const parsedContentLength = Number(contentLength);
-  return Number.isFinite(parsedContentLength) && parsedContentLength > 0 && parsedContentLength <= maxBodySize;
 }
 
 async function readByteLimitedStream(


### PR DESCRIPTION
## Summary

Enforce the existing `@fluojs/runtime` Web request-body contract so JSON payloads are limited while bytes are streaming, even when `Content-Length` appears to be within `maxBodySize`.

Linked context: Closes #2872

## Changes

- Route Web JSON bodies through the existing byte-limited stream reader instead of buffering with `request.arrayBuffer()`.
- Add focused regressions for misleading in-limit, missing, exact-limit, and declared-over-limit `Content-Length` values.
- Add a patch Changeset for `@fluojs/runtime`.

## Testing

- Red regression: `pnpm exec vitest run -c vitest.config.ts src/web-body-limit.test.ts` failed on the expected stream-cancellation assertion before the implementation change.
- `lsp_diagnostics` on both changed TypeScript files: no diagnostics.
- `pnpm exec biome lint packages/runtime/src/web.ts packages/runtime/src/web-body-limit.test.ts`
- `pnpm exec vitest run -c vitest.config.ts src/web-body-limit.test.ts src/web.test.ts` — 20 tests passed.
- `pnpm --filter @fluojs/runtime test` — 296 tests passed.
- `pnpm --filter @fluojs/runtime... build`
- `pnpm --filter @fluojs/runtime typecheck`
- `pnpm verify:platform-consistency-governance`
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=main`
- `TMPDIR=/tmp pnpm verify` — 377 test files passed, 4558 tests passed, 1 skipped.
- `TMPDIR=/tmp FLUO_CLI_SANDBOX_ROOT=/tmp/fluo-issue-2872-release-readiness pnpm verify:release-readiness` — passed without writing draft artifacts.

## Release impact

- [x] This PR has consumer-visible release impact and includes `.changeset/issue-2872-web-json-body-limit.md` with patch intent for `@fluojs/runtime`.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] No public exports changed, so a new source-level summary is not applicable.
- [x] No exported function signatures changed, so `@param` / `@returns` updates are not applicable.
- [x] No source or README examples changed; their complementary roles remain unchanged.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] No new contract was introduced; this restores the existing streaming limit promised by `packages/runtime/README.md`.
- [x] Intentional limitations were not changed.
- [x] Runtime invariants are covered by focused regression and boundary tests.

## Platform consistency governance (SSOT)

- [x] No governance docs changed, so English/Korean mirror structure remains unchanged.
- [x] No platform contract docs changed; implementation and regression evidence preserve the existing SSOT contract.
- [x] The existing runtime README claim is backed by package-local Web request-body tests and the canonical release-readiness gate.