### PR TITLE
Resolve #2867: Lock HTTP lifecycle and portable entrypoint contracts

### DIFF
--- a/packages/http/src/context/request-context-portable.test.ts
+++ b/packages/http/src/context/request-context-portable.test.ts
@@ -1,0 +1,90 @@
+import { Container } from '@fluojs/di';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { RequestContext } from '../types.js';
+
+function createMockContext(): RequestContext {
+  const root = new Container();
+
+  return {
+    container: root.createRequestScope(),
+    metadata: {},
+    request: {
+      body: undefined,
+      cookies: {},
+      headers: {},
+      method: 'GET',
+      params: {},
+      path: '/health',
+      query: {},
+      raw: {},
+      url: '/health',
+    },
+    requestId: 'req_123',
+    response: {
+      committed: false,
+      headers: {},
+      redirect() {},
+      send() {},
+      setHeader(name, value) {
+        this.headers[name] = value;
+      },
+      setStatus(code) {
+        this.statusCode = code;
+      },
+      statusCode: 200,
+    },
+  };
+}
+
+describe('portable request context', () => {
+  it('uses synchronous-only request context after importing the portable entrypoint without a host async store', async () => {
+    // Given
+    vi.resetModules();
+    const getBuiltinModuleDescriptor = Object.getOwnPropertyDescriptor(process, 'getBuiltinModule');
+    const nodeVersionDescriptor = Object.getOwnPropertyDescriptor(process.versions, 'node');
+
+    Object.defineProperty(process, 'getBuiltinModule', {
+      configurable: true,
+      value: undefined,
+    });
+    Object.defineProperty(process.versions, 'node', {
+      configurable: true,
+      value: undefined,
+    });
+
+    try {
+      const portableHttp = await import('../index.portable.js');
+      const context = portableHttp.createRequestContext(createMockContext());
+
+      // When
+      const observations = await portableHttp.runWithRequestContext(context, async () => {
+        const beforeAwait = portableHttp.getCurrentRequestContext()?.requestId;
+        await Promise.resolve();
+
+        return {
+          afterAwait: portableHttp.getCurrentRequestContext()?.requestId,
+          beforeAwait,
+        };
+      });
+
+      // Then
+      expect(observations).toEqual({
+        afterAwait: undefined,
+        beforeAwait: 'req_123',
+      });
+    } finally {
+      if (getBuiltinModuleDescriptor) {
+        Object.defineProperty(process, 'getBuiltinModule', getBuiltinModuleDescriptor);
+      } else {
+        Reflect.deleteProperty(process, 'getBuiltinModule');
+      }
+
+      if (nodeVersionDescriptor) {
+        Object.defineProperty(process.versions, 'node', nodeVersionDescriptor);
+      }
+
+      vi.resetModules();
+    }
+  });
+});

--- a/packages/http/src/dispatch/dispatcher-cancellation.test.ts
+++ b/packages/http/src/dispatch/dispatcher-cancellation.test.ts
@@ -87,6 +87,88 @@ describe('dispatcher cancellation', () => {
     expect(response.committed).toBe(false);
   });
 
+  it('does not commit a full-path success response when the signal aborts during handler execution', async () => {
+    // Given
+    const abortController = new AbortController();
+    const handler = vi.fn(() => {
+      abortController.abort();
+      return { ok: true };
+    });
+
+    @Controller('/full-path-signal-cancellation')
+    class FullPathSignalCancellationController {
+      @Get('/')
+      handle() {
+        return handler();
+      }
+    }
+
+    const middleware: Middleware = {
+      async handle(_context, next) {
+        await next();
+      },
+    };
+    const root = new Container().register(FullPathSignalCancellationController);
+    const dispatcher = createDispatcher({
+      appMiddleware: [middleware],
+      handlerMapping: createHandlerMapping([{ controllerToken: FullPathSignalCancellationController }]),
+      rootContainer: root,
+    });
+    const request = createRequest('/full-path-signal-cancellation');
+    request.signal = abortController.signal;
+    const response = createResponse();
+
+    // When
+    await dispatcher.dispatch(request, response);
+
+    // Then
+    expect(getDispatcherFastPathStats(dispatcher)?.routes[0]?.executionPath).toBe('full');
+    expect(handler).toHaveBeenCalledOnce();
+    expect(response.committed).toBe(false);
+    expect(response.body).toBeUndefined();
+  });
+
+  it('does not commit a full-path success response when the abort probe changes during handler execution', async () => {
+    // Given
+    let aborted = false;
+    const handler = vi.fn(() => {
+      aborted = true;
+      return { ok: true };
+    });
+
+    @Controller('/full-path-probe-cancellation')
+    class FullPathProbeCancellationController {
+      @Get('/')
+      handle() {
+        return handler();
+      }
+    }
+
+    const middleware: Middleware = {
+      async handle(_context, next) {
+        await next();
+      },
+    };
+    const root = new Container().register(FullPathProbeCancellationController);
+    const dispatcher = createDispatcher({
+      appMiddleware: [middleware],
+      handlerMapping: createHandlerMapping([{ controllerToken: FullPathProbeCancellationController }]),
+      rootContainer: root,
+    });
+    const request = createRequest('/full-path-probe-cancellation');
+    request.isAborted = () => aborted;
+    const response = createResponse();
+
+    // When
+    await dispatcher.dispatch(request, response);
+
+    // Then
+    expect(getDispatcherFastPathStats(dispatcher)?.routes[0]?.executionPath).toBe('full');
+    expect(handler).toHaveBeenCalledOnce();
+    expect(response.committed).toBe(false);
+    expect(response.body).toBeUndefined();
+  });
+
   it('short-circuits the fast path when the signal is aborted and the adapter probe returns false', async () => {
     // Given
     const abortController = new AbortController();

--- a/packages/http/src/dispatch/dispatcher-lifecycle-ordering.test.ts
+++ b/packages/http/src/dispatch/dispatcher-lifecycle-ordering.test.ts
@@ -1,0 +1,118 @@
+import { Container } from '@fluojs/di';
+import { describe, expect, it } from 'vitest';
+
+import type { FrameworkRequest, FrameworkResponse } from '../index.js';
+import { Controller, createDispatcher, createHandlerMapping, Get } from '../index.js';
+
+function createRequest(): FrameworkRequest {
+  return {
+    body: undefined,
+    cookies: {},
+    headers: {},
+    method: 'GET',
+    params: {},
+    path: '/finish-disposal-order',
+    query: {},
+    raw: {},
+    url: '/finish-disposal-order',
+  };
+}
+
+function createResponse(): FrameworkResponse {
+  return {
+    committed: false,
+    headers: {},
+    redirect(status, location) {
+      this.setStatus(status);
+      this.setHeader('Location', location);
+      this.committed = true;
+    },
+    send() {
+      this.committed = true;
+    },
+    setHeader(name, value) {
+      this.headers[name] = value;
+    },
+    setStatus(code) {
+      this.statusCode = code;
+      this.statusSet = true;
+    },
+    statusCode: undefined,
+    statusSet: false,
+  };
+}
+
+class LifecycleOrderingContainer extends Container {
+  constructor(private readonly events: string[]) {
+    super();
+  }
+
+  override createRequestScope(): Container {
+    const scope = super.createRequestScope();
+    const dispose = scope.dispose.bind(scope);
+
+    scope.dispose = async () => {
+      this.events.push('dispose');
+      await dispose();
+    };
+
+    return scope;
+  }
+}
+
+function createFinishDisposalDispatcher(events: string[], handler: () => unknown) {
+  @Controller('/finish-disposal-order')
+  class FinishDisposalOrderController {
+    @Get('/')
+    handle() {
+      return handler();
+    }
+  }
+
+  const observer = {
+    async onRequestFinish() {
+      events.push('finish:start');
+      await Promise.resolve();
+      events.push('finish:end');
+    },
+  };
+  const root = new LifecycleOrderingContainer(events).register(FinishDisposalOrderController);
+
+  return createDispatcher({
+    handlerMapping: createHandlerMapping([{ controllerToken: FinishDisposalOrderController }]),
+    observers: [observer],
+    rootContainer: root,
+  });
+}
+
+describe('dispatcher lifecycle ordering', () => {
+  it('completes onRequestFinish before request-scope disposal on the success path', async () => {
+    // Given
+    const events: string[] = [];
+    const dispatcher = createFinishDisposalDispatcher(events, () => ({ ok: true }));
+    const response = createResponse();
+
+    // When
+    await dispatcher.dispatch(createRequest(), response);
+
+    // Then
+    expect(response.statusCode).toBe(200);
+    expect(events).toEqual(['finish:start', 'finish:end', 'dispose']);
+  });
+
+  it('completes onRequestFinish before request-scope disposal on the error path', async () => {
+    // Given
+    const events: string[] = [];
+    const dispatcher = createFinishDisposalDispatcher(events, () => {
+      throw new Error('handler failed');
+    });
+    const response = createResponse();
+
+    // When
+    await dispatcher.dispatch(createRequest(), response);
+
+    // Then
+    expect(response.statusCode).toBe(500);
+    expect(events).toEqual(['finish:start', 'finish:end', 'dispose']);
+  });
+});

--- a/packages/http/src/public-api.test.ts
+++ b/packages/http/src/public-api.test.ts
@@ -14,6 +14,54 @@ type TypeEquals<Left, Right> = (<Value>() => Value extends Left ? 1 : 2) extends
 
 type AssertTrue<Condition extends true> = Condition;
 
+const runtimeStaticModuleSpecifierPattern = /(?:^|\n)\s*(?:import|export)\s+(?!type\b)(?:[^'"]*?\s+from\s+)?['"]([^'"]+)['"]/g;
+const runtimeDynamicModuleSpecifierPattern = /\bimport\(\s*['"]([^'"]+)['"]\s*\)/g;
+
+function readRuntimeModuleSpecifiers(source: string): string[] {
+  return [
+    ...source.matchAll(runtimeStaticModuleSpecifierPattern),
+    ...source.matchAll(runtimeDynamicModuleSpecifierPattern),
+  ].flatMap((match) => {
+    const specifier = match[1];
+    return specifier === undefined ? [] : [specifier];
+  });
+}
+
+function collectRuntimeDependencyGraph(entrypoint: URL) {
+  const pending = [entrypoint];
+  const sourceUrls = new Set<string>();
+  const nodeBuiltinImports: string[] = [];
+
+  while (pending.length > 0) {
+    const sourceUrl = pending.pop();
+
+    if (sourceUrl === undefined || sourceUrls.has(sourceUrl.href)) {
+      continue;
+    }
+
+    sourceUrls.add(sourceUrl.href);
+    const source = readFileSync(sourceUrl, 'utf8');
+
+    for (const specifier of readRuntimeModuleSpecifiers(source)) {
+      if (specifier.startsWith('node:')) {
+        nodeBuiltinImports.push(`${sourceUrl.href}:${specifier}`);
+      }
+
+      if (specifier.startsWith('.')) {
+        const sourceSpecifier = specifier.endsWith('.js')
+          ? `${specifier.slice(0, -3)}.ts`
+          : specifier;
+        pending.push(new URL(sourceSpecifier, sourceUrl));
+      }
+    }
+  }
+
+  return {
+    nodeBuiltinImports,
+    sourceUrls: [...sourceUrls],
+  };
+}
+
 describe('@fluojs/http public API surface', () => {
   it('keeps documented supported root-barrel exports', () => {
     expect(httpPublicApi).toHaveProperty('Controller');
@@ -83,6 +131,18 @@ describe('@fluojs/http public API surface', () => {
 
     expect(correlationSource).not.toContain("from 'node:crypto'");
     expect(requestContextSource).not.toContain("from 'node:async_hooks'");
+  });
+
+  it('keeps every reachable portable entrypoint module free of Node built-in import specifiers', () => {
+    // Given
+    const portableEntrypoint = new URL('./index.portable.ts', import.meta.url);
+
+    // When
+    const graph = collectRuntimeDependencyGraph(portableEntrypoint);
+
+    // Then
+    expect(graph.sourceUrls).toContain(new URL('./context/request-context-node-store.ts', import.meta.url).href);
+    expect(graph.nodeBuiltinImports).toEqual([]);
   });
 
   it('keeps the internal subpath limited to the documented exported helpers', () => {

--- a/packages/http/src/public-api.test.ts
+++ b/packages/http/src/public-api.test.ts
@@ -16,15 +16,70 @@ type AssertTrue<Condition extends true> = Condition;
 
 const runtimeStaticModuleSpecifierPattern = /(?:^|\n)\s*(?:import|export)\s+(?!type\b)(?:[^'"]*?\s+from\s+)?['"]([^'"]+)['"]/g;
 const runtimeDynamicModuleSpecifierPattern = /\bimport\(\s*['"]([^'"]+)['"]\s*\)/g;
+const runtimeDynamicTemplateModuleSpecifierPattern = /\bimport\(\s*`([^`]*)`\s*\)/g;
 
 function readRuntimeModuleSpecifiers(source: string): string[] {
-  return [
+  const quotedSpecifiers = [
     ...source.matchAll(runtimeStaticModuleSpecifierPattern),
     ...source.matchAll(runtimeDynamicModuleSpecifierPattern),
   ].flatMap((match) => {
     const specifier = match[1];
     return specifier === undefined ? [] : [specifier];
   });
+  const templateSpecifiers = [...source.matchAll(runtimeDynamicTemplateModuleSpecifierPattern)].flatMap((match) => {
+    const specifier = match[1];
+    return specifier === undefined || specifier.includes('${') ? [] : [specifier];
+  });
+
+  return [...quotedSpecifiers, ...templateSpecifiers];
+}
+
+function resolveWorkspacePackageSourceUrl(specifier: string): URL | undefined {
+  const match = /^@fluojs\/([^/]+)(?:\/(.+))?$/.exec(specifier);
+  const packageName = match?.[1];
+
+  if (packageName === undefined) {
+    return undefined;
+  }
+
+  const packageRoot = new URL(`../../${packageName}/`, import.meta.url);
+  const manifest: unknown = JSON.parse(readFileSync(new URL('package.json', packageRoot), 'utf8'));
+
+  if (typeof manifest !== 'object' || manifest === null || Reflect.get(manifest, 'name') !== `@fluojs/${packageName}`) {
+    throw new TypeError(`Invalid workspace package manifest for ${specifier}.`);
+  }
+
+  const exports = Reflect.get(manifest, 'exports');
+
+  if (typeof exports !== 'object' || exports === null) {
+    throw new TypeError(`Missing workspace export map for ${specifier}.`);
+  }
+
+  const exportDefinition = Reflect.get(exports, match?.[2] === undefined ? '.' : `./${match[2]}`);
+  const importTarget = typeof exportDefinition === 'string'
+    ? exportDefinition
+    : typeof exportDefinition === 'object' && exportDefinition !== null
+      ? Reflect.get(exportDefinition, 'import')
+      : undefined;
+
+  if (typeof importTarget !== 'string' || !importTarget.startsWith('./dist/') || !importTarget.endsWith('.js')) {
+    throw new TypeError(`Missing ESM source mapping for ${specifier}.`);
+  }
+
+  return new URL(`./src/${importTarget.slice('./dist/'.length, -'.js'.length)}.ts`, packageRoot);
+}
+
+function resolveRuntimeSourceUrl(specifier: string, importer: URL): URL | undefined {
+  if (specifier.startsWith('.')) {
+    const sourceSpecifier = specifier.endsWith('.js')
+      ? `${specifier.slice(0, -3)}.ts`
+      : specifier;
+    return new URL(sourceSpecifier, importer);
+  }
+
+  return specifier.startsWith('@fluojs/')
+    ? resolveWorkspacePackageSourceUrl(specifier)
+    : undefined;
 }
 
 function collectRuntimeDependencyGraph(entrypoint: URL) {
@@ -47,11 +102,10 @@ function collectRuntimeDependencyGraph(entrypoint: URL) {
         nodeBuiltinImports.push(`${sourceUrl.href}:${specifier}`);
       }
 
-      if (specifier.startsWith('.')) {
-        const sourceSpecifier = specifier.endsWith('.js')
-          ? `${specifier.slice(0, -3)}.ts`
-          : specifier;
-        pending.push(new URL(sourceSpecifier, sourceUrl));
+      const dependencySourceUrl = resolveRuntimeSourceUrl(specifier, sourceUrl);
+
+      if (dependencySourceUrl) {
+        pending.push(dependencySourceUrl);
       }
     }
   }
@@ -133,6 +187,20 @@ describe('@fluojs/http public API surface', () => {
     expect(requestContextSource).not.toContain("from 'node:async_hooks'");
   });
 
+  it('reads static dynamic-import templates without treating interpolated templates as dependencies', () => {
+    // Given
+    const source = [
+      "void import(`node:async_hooks`);",
+      `void import(\`@fluojs/\${packageName}\`);`,
+    ].join('\n');
+
+    // When
+    const specifiers = readRuntimeModuleSpecifiers(source);
+
+    // Then
+    expect(specifiers).toEqual(['node:async_hooks']);
+  });
+
   it('keeps every reachable portable entrypoint module free of Node built-in import specifiers', () => {
     // Given
     const portableEntrypoint = new URL('./index.portable.ts', import.meta.url);
@@ -142,6 +210,8 @@ describe('@fluojs/http public API surface', () => {
 
     // Then
     expect(graph.sourceUrls).toContain(new URL('./context/request-context-node-store.ts', import.meta.url).href);
+    expect(graph.sourceUrls).toContain(new URL('../../core/src/index.ts', import.meta.url).href);
+    expect(graph.sourceUrls).toContain(new URL('../../validation/src/index.ts', import.meta.url).href);
     expect(graph.nodeBuiltinImports).toEqual([]);
   });
 


### PR DESCRIPTION
## Summary

Add test-only regression coverage for the documented `@fluojs/http` cancellation, request lifecycle ordering, and portable entrypoint contracts.

Linked context: https://github.com/fluojs/fluo/issues/2867

## Changes

- Prove the full dispatcher path does not commit a success response when `signal` or `isAborted()` changes during handler execution.
- Prove asynchronous `onRequestFinish` completion precedes request-scope disposal on success and error paths.
- Traverse the runtime dependency closure from `index.portable.ts` and reject reachable `node:` import specifiers.
- Import the portable entrypoint without a host async store and prove request context is synchronous-only and cleared after `await`.

## Testing

- `pnpm exec biome lint packages/http/src/dispatch/dispatcher-cancellation.test.ts packages/http/src/dispatch/dispatcher-lifecycle-ordering.test.ts packages/http/src/public-api.test.ts packages/http/src/context/request-context-portable.test.ts` — passed.
- Changed-file LSP diagnostics — no diagnostics.
- `pnpm --dir packages/http exec vitest run -c vitest.config.ts src/dispatch/dispatcher-cancellation.test.ts src/dispatch/dispatcher-lifecycle-ordering.test.ts src/public-api.test.ts src/context/request-context-portable.test.ts` — 4 files, 13 tests passed.
- `pnpm --filter "@fluojs/http..." build` — passed for `@fluojs/core`, `@fluojs/di`, `@fluojs/validation`, and `@fluojs/http`.
- `pnpm --dir packages/http typecheck` — passed.
- `pnpm --dir packages/http test` — 20 files, 236 tests passed.
- `pnpm verify` — passed; 379 files passed, 4566 tests passed, 1 skipped.

Regression sensitivity was demonstrated with temporary, reverted mutations: removing the post-handler abort check failed both new cancellation cases; not awaiting `onRequestFinish` failed both ordering cases; adding a reachable static `node:async_hooks` import failed the portable graph case; and retaining fallback context after the synchronous frame failed the portable context case. No production mutation remains.

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

No changeset is included because this PR changes tests only and does not alter public behavior, API surface, package contents, or release metadata.

## Public export documentation

- [x] No public exports changed; source-level export documentation is not applicable.
- [x] No exported function signatures changed; `@param` / `@returns` updates are not applicable.
- [x] No source or README examples changed.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] No new behavioral contract was introduced; existing README and architecture contracts remain authoritative.
- [x] Intentional limitations remain unchanged.
- [x] Cancellation, finish-before-disposal, and portable fallback invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] No governance docs changed, so English/Korean mirror updates are not required.
- [x] No platform contract docs changed; companion docs/tooling updates are not applicable.
- [x] The existing portability claim is backed by executable portable-entrypoint dependency and fallback tests; adapter harness changes are not applicable.

Closes #2867