### PR TITLE
Resolve #2870: Refresh stale runtime internals in advanced book

### DIFF
--- a/book/advanced/ch08-module-graph.ko.md
+++ b/book/advanced/ch08-module-graph.ko.md
@@ -707,7 +707,7 @@ module graph order는 initialization order의 절반에 불과합니다. registr
 
 둘째, runtime은 `path:packages/runtime/src/bootstrap.ts:1334-1344`의 `resolveBootstrapLifecycleInstances()`를 통해 lifecycle hook을 가질 수 있는 singleton instance를 해석합니다. 이 helper는 effective runtime provider와 module provider를 합친 뒤 `resolveLifecycleInstances()`에 위임합니다.
 
-`path:packages/runtime/src/bootstrap.ts:1019-1072`의 `resolveLifecycleInstances()`가 eager instantiation policy와 concurrency policy를 함께 명시합니다. Provider order대로 token 중복을 제거하고 hook-bearing value provider와 direct singleton class/factory provider만 유지합니다. Alias, multi, request-scoped, transient provider는 top-level lifecycle resolution entry가 되지 않습니다.
+`path:packages/runtime/src/bootstrap.ts:1019-1072`의 `resolveLifecycleInstances()`가 eager instantiation policy와 concurrency policy를 함께 명시합니다. Provider order대로 token 중복을 제거하고 hook-bearing value provider와 direct singleton class/factory provider만 유지합니다. Runtime은 direct-singleton filtering 전에 hook-bearing value provider를 lifecycle entry에 추가하므로, hook-bearing `multi: true` value provider도 lifecycle entry가 될 수 있습니다. Alias, request-scoped, transient, 그리고 value가 아닌 multi class/factory provider는 direct top-level lifecycle entry가 되지 않습니다.
 
 이 helper는 lifecycle 대상이 될 수 있는 provider를 의도적으로 좁힙니다.
 

--- a/book/advanced/ch08-module-graph.ko.md
+++ b/book/advanced/ch08-module-graph.ko.md
@@ -701,55 +701,87 @@ function registerModuleMiddleware(container: Container, modules: CompiledModule[
 ## 8.5 Initialization order continues after registration through lifecycle resolution and hook execution
 module graph order는 initialization order의 절반에 불과합니다. registration 이후 runtime은 어떤 singleton instance를 eager하게 만들지, 어떤 hook을 실행할지, 언제 app이 ready해지는지도 결정해야 합니다.
 
-이 연속 단계는 `path:packages/runtime/src/bootstrap.ts:920-1029`의 `bootstrapApplication()`과, `path:packages/runtime/src/bootstrap.ts:1059-1153`의 `FluoFactory.createApplicationContext()`에 있습니다. 두 흐름은 같은 lifecycle skeleton을 공유합니다.
+이 연속 단계는 `path:packages/runtime/src/bootstrap.ts:1445-1590`의 `bootstrapApplication()`과 `path:packages/runtime/src/bootstrap.ts:1619-1740`의 `FluoFactory.createApplicationContext()`에 있습니다. 두 흐름은 같은 lifecycle skeleton을 공유합니다.
 
-첫째, runtime context token이 등록됩니다. `path:packages/runtime/src/bootstrap.ts:783-795`의 `registerRuntimeBootstrapTokens()`는 full application에 대해 `HTTP_APPLICATION_ADAPTER`와 `PLATFORM_SHELL`을 추가합니다. `path:packages/runtime/src/bootstrap.ts:811-816`의 `registerRuntimeApplicationContextTokens()`는 context-only bootstrap에 대해 `PLATFORM_SHELL`만 추가합니다.
+첫째, runtime context token이 등록됩니다. `path:packages/runtime/src/bootstrap.ts:1280-1300`의 `registerRuntimeBootstrapTokens()`는 full application에 대해 `HTTP_APPLICATION_ADAPTER`와 `PLATFORM_SHELL`을 추가합니다. `path:packages/runtime/src/bootstrap.ts:1316-1332`의 `registerRuntimeApplicationContextTokens()`는 context-only bootstrap에 `PLATFORM_SHELL`을 추가하지만 HTTP adapter는 추가하지 않습니다.
 
-둘째, runtime은 `path:packages/runtime/src/bootstrap.ts:818-828`의 `resolveBootstrapLifecycleInstances()`를 통해 lifecycle-bearing singleton instance를 해석합니다. 이 helper는 runtime provider와 module provider를 합친 뒤, `resolveLifecycleInstances()`에 위임합니다.
+둘째, runtime은 `path:packages/runtime/src/bootstrap.ts:1334-1344`의 `resolveBootstrapLifecycleInstances()`를 통해 lifecycle hook을 가질 수 있는 singleton instance를 해석합니다. 이 helper는 effective runtime provider와 module provider를 합친 뒤 `resolveLifecycleInstances()`에 위임합니다.
 
-`path:packages/runtime/src/bootstrap.ts:666-688`의 `resolveLifecycleInstances()`가 바로 eager instantiation policy를 명시하는 곳입니다. request scope와 transient provider는 건너뜁니다. token 기준으로 중복을 제거합니다. 그리고 singleton provider만 즉시 resolve합니다.
+`path:packages/runtime/src/bootstrap.ts:1019-1072`의 `resolveLifecycleInstances()`가 eager instantiation policy와 concurrency policy를 함께 명시합니다. Provider order대로 token 중복을 제거하고 hook-bearing value provider와 direct singleton class/factory provider만 유지합니다. Alias, multi, request-scoped, transient provider는 top-level lifecycle resolution entry가 되지 않습니다.
 
 이 helper는 lifecycle 대상이 될 수 있는 provider를 의도적으로 좁힙니다.
 
-`path:packages/runtime/src/bootstrap.ts:666-688`
+`path:packages/runtime/src/bootstrap.ts:1019-1072`
 ```typescript
-async function resolveLifecycleInstances(container: Container, providers: Provider[]): Promise<unknown[]> {
-  const instances: unknown[] = [];
+async function resolveLifecycleInstances(
+  container: Container,
+  providers: Provider[],
+  resolvedInstances: unknown[] = [],
+): Promise<unknown[]> {
+  const lifecycleEntries: Array<{ token: Token; useValue?: unknown }> = [];
   const seen = new Set<Token>();
 
   for (const provider of providers) {
-    const scope = providerScope(provider);
-
-    if (scope === 'request' || scope === 'transient') {
-      continue;
-    }
-
     const token = providerToken(provider);
 
     if (seen.has(token)) {
       continue;
     }
 
+    if (isHookBearingValueProvider(provider)) {
+      seen.add(token);
+      lifecycleEntries.push({ token, useValue: provider.useValue });
+      continue;
+    }
+
+    if (!isDirectSingletonContextProvider(provider)) {
+      continue;
+    }
+
     seen.add(token);
-    instances.push(await container.resolve(token));
+    lifecycleEntries.push({ token });
   }
 
-  return instances;
+  const resolutionResults = await Promise.allSettled(
+    lifecycleEntries.map((entry) => entry.useValue ?? container.resolve(entry.token)),
+  );
+
+  let resolutionError: unknown;
+  let hasResolutionError = false;
+
+  for (const result of resolutionResults) {
+    if (result.status === 'fulfilled') {
+      resolvedInstances.push(result.value);
+      continue;
+    }
+
+    if (!hasResolutionError) {
+      resolutionError = result.reason;
+      hasResolutionError = true;
+    }
+  }
+
+  if (hasResolutionError) {
+    throw resolutionError;
+  }
+
+  return resolvedInstances;
 }
 ```
 
-그래프 순서 이후에도 모든 provider가 즉시 생성되는 것은 아닙니다. singleton 후보만 token 중복 제거를 거친 뒤 eager resolve 대상이 됩니다.
+그래프 순서 이후에도 모든 provider가 즉시 생성되는 것은 아닙니다. Direct singleton class/factory 후보와 hook-bearing singleton value만 token 중복 제거를 거쳐 eager lifecycle 대상이 됩니다.
 
+`Promise.allSettled(...)` map은 앞 entry가 끝날 때까지 기다리지 않고 모든 top-level lifecycle entry를 시작하므로 독립 singleton resolution이 겹칩니다. DI는 각 entry가 settle되기 전에 해당 entry 자체의 dependency chain을 계속 해석합니다. `Promise.allSettled(...)`는 input order로 result를 반환하고 이어지는 loop도 fulfilled instance를 같은 provider order로 append합니다. 따라서 resolution completion order가 이후 hook order를 바꿀 수 없습니다.
 
-즉 Fluo의 bootstrap order는 "모든 module의 모든 provider를 instantiate한다"가 아닙니다. "lifecycle hook에 참여할 수 있는 unique singleton provider를 eager하게 instantiate한다"에 가깝습니다. 이 정책이 더 제한적이고, 더 감사 가능하며, 무엇보다 구현 추적이 쉽습니다.
+즉 Fluo의 bootstrap order는 "모든 module의 모든 provider를 순차적으로 instantiate한다"가 아니라 "독립적인 unique singleton lifecycle candidate를 병렬로 resolve한 뒤 hook을 결정적으로 실행한다"에 가깝습니다. `path:packages/runtime/src/bootstrap.test.ts:887-936`은 이 분리를 직접 증명합니다. 첫 번째 factory가 중단된 동안 두 번째 factory가 resolve되지만, `first:init`은 여전히 `second:init`보다 먼저입니다. `path:packages/runtime/src/bootstrap.test.ts:938-980`은 병렬 peer가 실패해도 fulfilled lifecycle instance가 cleanup에 남는다는 점도 검증합니다.
 
-셋째, `path:packages/runtime/src/bootstrap.ts:830-840`의 `runBootstrapLifecycle()`이 실제 start sequence를 조율합니다. readiness marker를 reset하고, bootstrap hook을 실행하고, platform shell을 시작하고, readiness를 표시하고, compiled module 로그를 남깁니다.
+셋째, `path:packages/runtime/src/bootstrap.ts:1346-1358`의 `runBootstrapLifecycle()`이 실제 start sequence를 조율합니다. readiness marker를 reset하고, bootstrap hook을 실행하고, platform shell을 시작하고, readiness를 표시하고, bootstrap-ready signal을 resolve하고, compiled module 로그를 남깁니다.
 
-내부 hook ordering은 `path:packages/runtime/src/bootstrap.ts:693-705`의 `runBootstrapHooks()`에 있습니다. 모든 `onModuleInit()` hook이 먼저 실행됩니다. 그 pass가 끝난 뒤에야 모든 `onApplicationBootstrap()` hook이 실행됩니다. 즉 전역적인 phase barrier가 있습니다. instance별 interleave가 아닙니다.
+내부 hook ordering은 `path:packages/runtime/src/bootstrap.ts:1183-1195`의 `runBootstrapHooks()`에 있습니다. Provider order가 유지된 instance array를 순차적으로 소비합니다. 모든 `onModuleInit()` hook이 provider order대로 먼저 실행되고, 그 pass가 끝난 뒤에야 모든 `onApplicationBootstrap()` hook이 같은 순서로 실행됩니다. 즉 concurrent resolution 다음에 deterministic hook pass와 global phase barrier가 옵니다. Instance별 interleave가 아닙니다.
 
 bootstrap hook runner는 두 번의 pass로 phase barrier를 만듭니다.
 
-`path:packages/runtime/src/bootstrap.ts:693-705`
+`path:packages/runtime/src/bootstrap.ts:1183-1195`
 ```typescript
 async function runBootstrapHooks(instances: unknown[]): Promise<void> {
   for (const instance of instances) {
@@ -766,14 +798,13 @@ async function runBootstrapHooks(instances: unknown[]): Promise<void> {
 }
 ```
 
-한 instance의 두 hook을 붙여 실행하지 않고, 모든 module init을 먼저 끝냅니다. 이 구조가 lifecycle phase를 전역적으로 분리합니다.
+한 instance의 두 hook을 붙여 실행하지 않고 모든 module init을 먼저 끝내며, 각 pass 안에서는 provider order를 유지합니다. 이 구조가 resolution race order를 노출하지 않으면서 lifecycle phase를 전역적으로 분리합니다.
 
-
-shutdown ordering은 거울상입니다. `path:packages/runtime/src/bootstrap.ts:710-722`의 `runShutdownHooks()`는 instance를 역순으로 순회하면서, 먼저 모든 `onModuleDestroy()`를 실행하고, 그 다음 모든 `onApplicationShutdown()`을 실행합니다.
+shutdown ordering은 거울상입니다. `path:packages/runtime/src/bootstrap.ts:1200-1212`의 `runShutdownHooks()`는 provider order가 유지된 instance를 역순으로 순회하면서, 먼저 모든 `onModuleDestroy()`를 실행하고 그 다음 모든 `onApplicationShutdown()`을 실행합니다.
 
 종료 hook은 같은 phase 분리를 유지하되 instance 순서만 뒤집습니다.
 
-`path:packages/runtime/src/bootstrap.ts:710-722`
+`path:packages/runtime/src/bootstrap.ts:1200-1212`
 ```typescript
 async function runShutdownHooks(instances: readonly unknown[], signal?: string): Promise<void> {
   for (const instance of [...instances].reverse()) {
@@ -802,21 +833,23 @@ compile module graph
   -> validate visibility and exports
   -> register providers/controllers/middleware
   -> register runtime tokens
-  -> eagerly resolve singleton lifecycle instances
-  -> run all onModuleInit hooks
-  -> run all onApplicationBootstrap hooks
+  -> collect unique singleton lifecycle entries in provider order
+  -> resolve independent lifecycle entries concurrently
+  -> retain provider order from the settled results
+  -> run all onModuleInit hooks in provider order
+  -> run all onApplicationBootstrap hooks in provider order
   -> start platform shell
   -> create dispatcher/application shell
   -> later: listen() binds adapter
 ```
 
-`path:packages/runtime/src/bootstrap.test.ts:522-629`의 application-context 테스트는 HTTP adapter가 없어도 같은 lifecycle sequence가 유지됨을 보여 줍니다. 즉 initialization order는 transport startup에 속한 것이 아니라, runtime shell 자체에 속합니다. 이 구분이 바로 8장의 진짜 마무리입니다. Fluo에서 "module initialization order"는 단순한 topological sorting이 아닙니다. 더 구체적인 계층화된 모델입니다.
+`path:packages/runtime/src/bootstrap.test.ts:1090-1129`의 application-context 테스트는 HTTP adapter가 없어도 같은 lifecycle sequence가 유지됨을 보여 줍니다. 즉 initialization order는 transport startup에 속한 것이 아니라, runtime shell 자체에 속합니다. 이 구분이 바로 8장의 진짜 마무리입니다. Fluo에서 "module initialization order"는 단순한 topological sorting이 아닙니다. 더 구체적인 계층화된 모델입니다.
 
 첫째, **모듈 그래프의 컴파일 타임 순서**가 있습니다. 여기서 순환 의존성이 거부되고 가시성 경계가 그려집니다. 생성자가 하나도 호출되기 전에 애플리케이션이 여기서 실패한다면, `@Module()` import 구조에 결함이 있을 가능성이 큽니다. `compileModule()` 알고리즘은 모듈의 전체 의존성 하위 트리가 이해되고 검증될 때까지 어떤 모듈도 컨테이너에 들어가지 않도록 보장합니다. 그 결과 일부 모듈만 자신의 export를 알고 다른 모듈은 모르는 "부분적 그래프" 상태를 피하고, 후속 등록 단계에 일관된 세계관을 넘길 수 있습니다. 이 단계에서 `providerTokens`와 `exportedTokens`를 미리 계산하는 일은 전체 컨테이너 설정의 청사진을 만드는 작업입니다.
 
 둘째, **토큰 등록 순서**가 있습니다. 런타임은 컴파일된 모듈 레코드를 순회하면서 프로바이더 정의를 DI 컨테이너에 공급합니다. 이 과정은 평면적인 등록 pass이지만, 컴파일 중에 정해진 위상 순서(topological order)에 의해 제어됩니다. 등록 단계는 중복 프로바이더 정책이 강제되고 컨테이너의 내부 lookup table이 채워지는 지점입니다. 이 작업이 단일하고 순차적인 pass로 일어나기 때문에, Fluo는 일부 프레임워크에서 보이는 "지연 등록(lazy registration)"의 복잡성을 피하고 컨테이너의 최종 상태를 결정론적으로 유지합니다. 진단 도구로 감사하기도 쉬워집니다. 또한 이 단계는 별칭 프로바이더(alias providers)의 정규화를 처리하여 모든 `useExisting` redirect가 컨테이너의 내부 map에 올바르게 등록되도록 보장합니다.
 
-셋째, **싱글톤 라이프사이클 부트스트랩 순서**입니다. 이는 생성자와 `OnModuleInit` 훅의 형태로 사용자 코드가 실제로 실행되는 첫 지점입니다. Fluo는 의존성을 존중하는 순서로 라이프사이클을 가진 싱글톤을 해석합니다. 서비스 A가 서비스 B에 의존한다면, 서비스 B가 초기화되고 그 `onModuleInit` 훅이 완료된 뒤에 서비스 A의 훅이 시작됩니다. 이러한 "깊이 우선 초기화(depth-first initialization)"는 비즈니스 로직이 실행되기 시작할 때 의존 리소스가 알려진 준비 상태에 있음을 보장합니다. `resolveBootstrapLifecycleInstances()`를 통한 인스턴스 해석은 정적 그래프를 실제 운영 가능한 객체로 전환합니다.
+셋째, **싱글톤 라이프사이클 부트스트랩 순서**입니다. 이는 생성자와 lifecycle hook의 형태로 사용자 코드가 실제로 실행되는 첫 지점입니다. Fluo는 독립적인 top-level singleton resolution을 병렬로 시작하며, DI container는 각 provider가 settle되기 전에 해당 provider의 constructor/factory dependency를 계속 resolve합니다. Hook order는 별도 계약입니다. Settled instance는 deterministic provider order를 유지하고, 모든 `onModuleInit()`이 그 순서대로 직렬 실행된 뒤에야 provider-ordered `onApplicationBootstrap()` pass가 시작됩니다. 따라서 factory completion timing에서 hook order를 추론하거나 이를 depth-first lifecycle execution으로 설명하면 안 됩니다. `resolveBootstrapLifecycleInstances()`는 이 concurrency/order 경계를 보존하면서 정적 graph를 실제 운영 가능한 object로 전환합니다.
 
 넷째, 이전 계층이 모두 완료된 후에야 **전송 준비(transport readiness)** 단계가 시작됩니다. 여기서 HTTP 어댑터가 포트에서 리스닝을 시작하거나 메시지 큐 소비자가 태스크를 가져오기 시작할 수 있습니다. 전체 내부 런타임 셸이 건강하고 초기화될 때까지 전송 시작을 늦춤으로써, Fluo는 "절반만 준비된" 애플리케이션이 트래픽을 수락한 뒤 곧바로 실패하는 상황을 막습니다. 또한 부트스트랩 단계에서 등록된 health check endpoint가 애플리케이션 준비 상태를 실제 상태에 맞게 반영하도록 합니다. 이 분리는 애플리케이션의 내부 상태가 외부 가용성보다 먼저 확정되어야 한다는 원칙을 유지합니다.
 

--- a/book/advanced/ch08-module-graph.md
+++ b/book/advanced/ch08-module-graph.md
@@ -689,7 +689,7 @@ First, runtime context Tokens are registered. `registerRuntimeBootstrapTokens()`
 
 Second, the runtime resolves singleton instances that may have lifecycle hooks through `resolveBootstrapLifecycleInstances()` at `path:packages/runtime/src/bootstrap.ts:1334-1344`. This helper combines the effective runtime Providers and Module Providers, then delegates to `resolveLifecycleInstances()`.
 
-`resolveLifecycleInstances()` at `path:packages/runtime/src/bootstrap.ts:1019-1072` states both the eager-instantiation and concurrency policies. In provider order, it deduplicates by Token and keeps hook-bearing value Providers plus direct singleton class/factory Providers. Alias, multi, request-scoped, and transient Providers are not top-level lifecycle resolution entries.
+`resolveLifecycleInstances()` at `path:packages/runtime/src/bootstrap.ts:1019-1072` states both the eager-instantiation and concurrency policies. In provider order, it deduplicates by Token and keeps hook-bearing value Providers plus direct singleton class/factory Providers. Because the runtime adds hook-bearing value Providers before direct-singleton filtering, hook-bearing `multi: true` value Providers can be lifecycle entries. Alias, request-scoped, transient, and non-value multi class/factory Providers are not direct top-level lifecycle entries.
 
 This helper intentionally narrows the Providers that can become lifecycle targets.
 

--- a/book/advanced/ch08-module-graph.md
+++ b/book/advanced/ch08-module-graph.md
@@ -683,54 +683,87 @@ So the middle conclusion of Chapter 8 is this. The graph compiler decides legal 
 ## 8.5 Initialization order continues after registration through lifecycle resolution and hook execution
 Module Graph order is only half of initialization order. After registration, the runtime still has to decide which singleton instances to eagerly create, which hooks to run, and when the app becomes ready.
 
-This continuous phase lives in `bootstrapApplication()` at `path:packages/runtime/src/bootstrap.ts:920-1029` and in `FluoFactory.createApplicationContext()` at `path:packages/runtime/src/bootstrap.ts:1059-1153`. Both flows share the same lifecycle skeleton.
+This continuous phase lives in `bootstrapApplication()` at `path:packages/runtime/src/bootstrap.ts:1445-1590` and in `FluoFactory.createApplicationContext()` at `path:packages/runtime/src/bootstrap.ts:1619-1740`. Both flows share the same lifecycle skeleton.
 
-First, runtime context Tokens are registered. `registerRuntimeBootstrapTokens()` at `path:packages/runtime/src/bootstrap.ts:783-795` adds `HTTP_APPLICATION_ADAPTER` and `PLATFORM_SHELL` for a full application. `registerRuntimeApplicationContextTokens()` at `path:packages/runtime/src/bootstrap.ts:811-816` adds only `PLATFORM_SHELL` for context-only Bootstrap.
+First, runtime context Tokens are registered. `registerRuntimeBootstrapTokens()` at `path:packages/runtime/src/bootstrap.ts:1280-1300` adds `HTTP_APPLICATION_ADAPTER` and `PLATFORM_SHELL` for a full application. `registerRuntimeApplicationContextTokens()` at `path:packages/runtime/src/bootstrap.ts:1316-1332` adds `PLATFORM_SHELL` but not the HTTP adapter for context-only Bootstrap.
 
-Second, the runtime resolves singleton instances that may have lifecycle hooks through `resolveBootstrapLifecycleInstances()` at `path:packages/runtime/src/bootstrap.ts:818-828`. This helper combines runtime Providers and Module Providers, then delegates to `resolveLifecycleInstances()`.
+Second, the runtime resolves singleton instances that may have lifecycle hooks through `resolveBootstrapLifecycleInstances()` at `path:packages/runtime/src/bootstrap.ts:1334-1344`. This helper combines the effective runtime Providers and Module Providers, then delegates to `resolveLifecycleInstances()`.
 
-`resolveLifecycleInstances()` at `path:packages/runtime/src/bootstrap.ts:666-688` is where the eager instantiation policy is stated. It skips request-scoped and transient Providers. It deduplicates by Token. Then it immediately resolves only singleton Providers.
+`resolveLifecycleInstances()` at `path:packages/runtime/src/bootstrap.ts:1019-1072` states both the eager-instantiation and concurrency policies. In provider order, it deduplicates by Token and keeps hook-bearing value Providers plus direct singleton class/factory Providers. Alias, multi, request-scoped, and transient Providers are not top-level lifecycle resolution entries.
 
 This helper intentionally narrows the Providers that can become lifecycle targets.
 
-`path:packages/runtime/src/bootstrap.ts:666-688`
+`path:packages/runtime/src/bootstrap.ts:1019-1072`
 ```typescript
-async function resolveLifecycleInstances(container: Container, providers: Provider[]): Promise<unknown[]> {
-  const instances: unknown[] = [];
+async function resolveLifecycleInstances(
+  container: Container,
+  providers: Provider[],
+  resolvedInstances: unknown[] = [],
+): Promise<unknown[]> {
+  const lifecycleEntries: Array<{ token: Token; useValue?: unknown }> = [];
   const seen = new Set<Token>();
 
   for (const provider of providers) {
-    const scope = providerScope(provider);
-
-    if (scope === 'request' || scope === 'transient') {
-      continue;
-    }
-
     const token = providerToken(provider);
 
     if (seen.has(token)) {
       continue;
     }
 
+    if (isHookBearingValueProvider(provider)) {
+      seen.add(token);
+      lifecycleEntries.push({ token, useValue: provider.useValue });
+      continue;
+    }
+
+    if (!isDirectSingletonContextProvider(provider)) {
+      continue;
+    }
+
     seen.add(token);
-    instances.push(await container.resolve(token));
+    lifecycleEntries.push({ token });
   }
 
-  return instances;
+  const resolutionResults = await Promise.allSettled(
+    lifecycleEntries.map((entry) => entry.useValue ?? container.resolve(entry.token)),
+  );
+
+  let resolutionError: unknown;
+  let hasResolutionError = false;
+
+  for (const result of resolutionResults) {
+    if (result.status === 'fulfilled') {
+      resolvedInstances.push(result.value);
+      continue;
+    }
+
+    if (!hasResolutionError) {
+      resolutionError = result.reason;
+      hasResolutionError = true;
+    }
+  }
+
+  if (hasResolutionError) {
+    throw resolutionError;
+  }
+
+  return resolvedInstances;
 }
 ```
 
-Even after graph order, not every Provider is created immediately. Only singleton candidates become eager resolution targets after Token deduplication.
+Even after graph order, not every Provider is created immediately. Only direct singleton class/factory candidates and hook-bearing singleton values become eager lifecycle targets after Token deduplication.
 
-So Fluo's Bootstrap order is closer to "eagerly instantiate unique singleton Providers that can participate in lifecycle hooks" than to "instantiate every Provider in every Module." This policy is more limited, easier to audit, and above all easier to trace in the implementation.
+The `Promise.allSettled(...)` map starts every top-level lifecycle entry without waiting for the previous entry to finish, so independent singleton resolution overlaps. DI still resolves each entry's own dependency chain before that entry settles. `Promise.allSettled(...)` returns results in input order, and the following loop appends fulfilled instances in that same provider order. Resolution completion order therefore cannot reorder later hooks.
 
-Third, `runBootstrapLifecycle()` at `path:packages/runtime/src/bootstrap.ts:830-840` coordinates the actual start sequence. It resets the readiness marker, runs Bootstrap hooks, starts the platform shell, marks readiness, and logs the compiled Modules.
+So Fluo's Bootstrap order is closer to "resolve independent unique singleton lifecycle candidates concurrently, then run their hooks deterministically" than to "instantiate every Provider in every Module sequentially." `path:packages/runtime/src/bootstrap.test.ts:887-936` proves the split directly: the second factory resolves while the first is suspended, but `first:init` still precedes `second:init`. `path:packages/runtime/src/bootstrap.test.ts:938-980` also verifies that fulfilled lifecycle instances remain available for cleanup when a parallel peer fails.
 
-The internal hook ordering lives in `runBootstrapHooks()` at `path:packages/runtime/src/bootstrap.ts:693-705`. All `onModuleInit()` hooks run first. Only after that pass completes do all `onApplicationBootstrap()` hooks run. In other words, there is a global phase barrier. Hooks are not interleaved instance by instance.
+Third, `runBootstrapLifecycle()` at `path:packages/runtime/src/bootstrap.ts:1346-1358` coordinates the actual start sequence. It resets the readiness marker, runs Bootstrap hooks, starts the platform shell, marks readiness, resolves the bootstrap-ready signal, and logs the compiled Modules.
+
+The internal hook ordering lives in `runBootstrapHooks()` at `path:packages/runtime/src/bootstrap.ts:1183-1195`. It consumes the provider-ordered instance array sequentially. All `onModuleInit()` hooks run first in provider order. Only after that pass completes do all `onApplicationBootstrap()` hooks run in the same order. In other words, concurrent resolution is followed by deterministic hook passes with a global phase barrier. Hooks are not interleaved instance by instance.
 
 The Bootstrap hook runner creates a phase barrier with two passes.
 
-`path:packages/runtime/src/bootstrap.ts:693-705`
+`path:packages/runtime/src/bootstrap.ts:1183-1195`
 ```typescript
 async function runBootstrapHooks(instances: unknown[]): Promise<void> {
   for (const instance of instances) {
@@ -747,13 +780,13 @@ async function runBootstrapHooks(instances: unknown[]): Promise<void> {
 }
 ```
 
-It does not run both hooks for one instance together. It finishes all Module init hooks first. This structure separates lifecycle phases globally.
+It does not run both hooks for one instance together. It finishes all Module init hooks first, preserving provider order within each pass. This structure separates lifecycle phases globally without exposing resolution-race order.
 
-Shutdown ordering is the mirror image. `runShutdownHooks()` at `path:packages/runtime/src/bootstrap.ts:710-722` walks instances in reverse order, first running all `onModuleDestroy()` hooks, then all `onApplicationShutdown()` hooks.
+Shutdown ordering is the mirror image. `runShutdownHooks()` at `path:packages/runtime/src/bootstrap.ts:1200-1212` walks the provider-ordered instances in reverse, first running all `onModuleDestroy()` hooks, then all `onApplicationShutdown()` hooks.
 
 Shutdown hooks keep the same phase separation while reversing only the instance order.
 
-`path:packages/runtime/src/bootstrap.ts:710-722`
+`path:packages/runtime/src/bootstrap.ts:1200-1212`
 ```typescript
 async function runShutdownHooks(instances: readonly unknown[], signal?: string): Promise<void> {
   for (const instance of [...instances].reverse()) {
@@ -781,21 +814,23 @@ compile module graph
   -> validate visibility and exports
   -> register providers/controllers/middleware
   -> register runtime tokens
-  -> eagerly resolve singleton lifecycle instances
-  -> run all onModuleInit hooks
-  -> run all onApplicationBootstrap hooks
+  -> collect unique singleton lifecycle entries in provider order
+  -> resolve independent lifecycle entries concurrently
+  -> retain provider order from the settled results
+  -> run all onModuleInit hooks in provider order
+  -> run all onApplicationBootstrap hooks in provider order
   -> start platform shell
   -> create dispatcher/application shell
   -> later: listen() binds adapter
 ```
 
-The application-context test at `path:packages/runtime/src/bootstrap.test.ts:522-629` shows that the same lifecycle sequence holds even without an HTTP adapter. That means initialization order does not belong to transport startup, it belongs to the runtime shell itself. This distinction is the real conclusion of Chapter 8. In Fluo, "Module initialization order" is not just topological sorting. It is a more specific layered model.
+The application-context test at `path:packages/runtime/src/bootstrap.test.ts:1090-1129` shows that the same lifecycle sequence holds even without an HTTP adapter. That means initialization order does not belong to transport startup, it belongs to the runtime shell itself. This distinction is the real conclusion of Chapter 8. In Fluo, "Module initialization order" is not just topological sorting. It is a more specific layered model.
 
 First, there is the **compile-time order of the Module Graph**. This is where circular dependencies are rejected and visibility boundaries are drawn. If the application fails here before any constructor is called, the likely problem is a flaw in the `@Module()` import structure. The `compileModule()` algorithm ensures that no Module enters the container until the entire dependency subtree of that Module is understood and validated. As a result, it avoids a "partial graph" state where some Modules know their exports and others do not, and it passes a consistent worldview to the later registration phase. Calculating `providerTokens` and `exportedTokens` up front at this phase creates the blueprint for the whole container setup.
 
 Second, there is the **Token registration order**. The runtime walks compiled Module records and feeds Provider definitions into the DI container. This is a flat registration pass, but it is controlled by the topological order decided during compilation. Registration is where duplicate Provider policy is enforced and the container's internal lookup table is filled. Because this work happens as one sequential pass, Fluo avoids the complexity of lazy registration seen in some frameworks and keeps the final container state deterministic. It also becomes easier to audit with diagnostics. This phase also handles normalization of alias Providers so every `useExisting` redirect is correctly registered in the container's internal map.
 
-Third, there is the **singleton lifecycle Bootstrap order**. This is the first point where user code actually runs through constructors and `OnModuleInit` hooks. Fluo resolves lifecycle-bearing singletons in dependency-respecting order. If Service A depends on Service B, Service B is initialized and its `onModuleInit` hook completes before Service A's hook starts. This "depth-first initialization" ensures that dependent resources are in a known ready state when business logic begins to run. Resolving instances through `resolveBootstrapLifecycleInstances()` turns the static graph into actual operational objects.
+Third, there is the **singleton lifecycle Bootstrap order**. This is the first point where user code actually runs through constructors and lifecycle hooks. Fluo starts independent top-level singleton resolutions concurrently; the DI container still resolves each Provider's constructor or factory dependencies before that Provider settles. Hook order is a separate contract: settled instances retain deterministic provider order, every `onModuleInit()` runs sequentially in that order, and only then does the provider-ordered `onApplicationBootstrap()` pass begin. It is therefore incorrect to infer hook order from factory completion timing or to describe it as depth-first lifecycle execution. `resolveBootstrapLifecycleInstances()` turns the static graph into operational objects while preserving this concurrency-versus-order boundary.
 
 Fourth, only after all previous layers finish does the **transport readiness** phase start. This is where an HTTP adapter can start listening on a port, or a message queue consumer can start pulling tasks. By delaying transport startup until the entire internal runtime shell is healthy and initialized, Fluo prevents a half-ready application from accepting traffic and then immediately failing. It also makes health check endpoints registered during Bootstrap reflect the real application readiness state. This separation preserves the principle that an application's internal state must be settled before external availability.
 

--- a/book/advanced/ch09-app-context.ko.md
+++ b/book/advanced/ch09-app-context.ko.md
@@ -100,15 +100,16 @@ bootstrap graph + container + lifecycle baseline
 이 공유 bootstrap spine이 이 장의 기반입니다. runtime contract의 나머지 부분을 이해하려면, 먼저 context, application, microservice shell이 하나의 compiled module/container baseline 위에서 만들어지는 형제라는 사실을 봐야 합니다.
 
 ## 9.2 Application context is the adapterless baseline and still runs full lifecycle bootstrap
-`FluoApplicationContext`는 `path:packages/runtime/src/bootstrap.ts:531-575`에 정의되어 있습니다. 표면은 의도적으로 작습니다. `container`, `modules`, `rootModule`, optional bootstrap timing diagnostics, lifecycle instance, cleanup callback만 저장합니다.
+`FluoApplicationContext`는 `path:packages/runtime/src/bootstrap.ts:808-859`에 정의되어 있습니다. 표면은 의도적으로 작습니다. `container`, `modules`, `rootModule`, optional bootstrap timing diagnostics, lifecycle instance, cleanup callback, 그리고 `get()`이 사용하는 좁은 context-resolution cache를 저장합니다.
 
 context shell 자체도 그 의도를 그대로 드러냅니다. 저장하는 값은 compiled module baseline과 lifecycle cleanup에 필요한 값이고, public 동작은 DI lookup과 close입니다.
 
-`path:packages/runtime/src/bootstrap.ts:531-548`
+`path:packages/runtime/src/bootstrap.ts:808-831`
 ```typescript
 class FluoApplicationContext implements ApplicationContext {
   private closed = false;
   private closingPromise: Promise<void> | undefined;
+  private readonly contextResolutionCache: ContextResolutionCache = new Map();
 
   constructor(
     readonly container: Container,
@@ -117,29 +118,138 @@ class FluoApplicationContext implements ApplicationContext {
     readonly bootstrapTiming: ApplicationContext['bootstrapTiming'],
     private readonly lifecycleInstances: unknown[],
     private readonly runtimeCleanup: Array<() => void>,
-  ) {}
+    private readonly contextCacheableTokens: ContextCacheableTokens,
+  ) {
+    installContextCacheInvalidation(this.container, this.contextResolutionCache, this.contextCacheableTokens);
+  }
 
   async get<T>(token: Token<T>): Promise<T> {
-    return this.container.resolve(token);
+    if (this.closed) {
+      return this.container.resolve(token);
+    }
+
+    return resolveContextToken(this.container, token, this.contextCacheableTokens, this.contextResolutionCache);
   }
 ```
 
-이 발췌에는 dispatcher, adapter, listen state가 없습니다. 그래서 context는 덜 bootstrap된 application이 아니라, DI와 lifecycle만 약속하는 별도 shell입니다.
+이 발췌에도 dispatcher, adapter, listen state는 없습니다. 그래서 context는 덜 bootstrap된 application이 아니라 DI와 lifecycle만 약속하는 별도 shell입니다. 추가된 cache는 두 번째 DI system이 아니라 동일한 container 앞에 놓인 guarded fast path입니다.
 
 public method도 `get()`과 `close()`뿐입니다. 이 미니멀한 표면이 핵심입니다. application context는 CLI task, worker, migration, 혹은 HTTP listener가 필요 없는 모든 DI-driven process를 위한 runtime baseline입니다.
 
-실제 bootstrap path는 `path:packages/runtime/src/bootstrap.ts:1059-1153`의 `FluoFactory.createApplicationContext()`입니다. 이 함수를 `bootstrapApplication()`과 비교하면, 대부분의 순서가 동일합니다. 여전히 logger, platform shell, runtime provider list, compiled module, runtime context token, lifecycle instance, timing diagnostics를 만듭니다.
+애플리케이션이 작성한 provider의 cache eligibility는 effective runtime provider와 root module에 직접 선언된 provider로 제한됩니다. Bare class와 class/factory provider도 singleton이어야 하며, alias, value, `multi: true` provider는 제외됩니다. Internal runtime token은 명시적으로 seed됩니다. Imported module provider는 여전히 container 자체의 singleton cache를 사용하지만 `ApplicationContext.get()`은 별도 context-cache entry를 추가하지 않습니다.
 
-핵심 차이는 token registration입니다. full application에서는 `registerRuntimeBootstrapTokens()`가 `HTTP_APPLICATION_ADAPTER`와 `PLATFORM_SHELL`을 모두 추가합니다. context에서는 `registerRuntimeApplicationContextTokens()`가 `PLATFORM_SHELL`만 추가합니다.
+`path:packages/runtime/src/bootstrap.ts:1074-1113`
+```typescript
+function createContextCacheableTokenSet(
+  effectiveProviders: BootstrapEffectiveProviders,
+  runtimeTokens: readonly Token[],
+): Set<Token> {
+  const cacheableTokens = new Set<Token>(runtimeTokens);
 
-토큰 등록 함수는 이 차이를 가장 작게 보여 줍니다. application branch는 HTTP adapter token을 추가하고, context branch는 platform shell만 더한 뒤 공통 context token 등록 helper로 내려갑니다.
+  for (const provider of effectiveProviders.runtimeProviders) {
+    if (isDirectSingletonContextProvider(provider)) {
+      cacheableTokens.add(providerToken(provider));
+    }
+  }
 
-`path:packages/runtime/src/bootstrap.ts:783-795`
+  for (const provider of effectiveProviders.rootModuleProviders) {
+    if (isDirectSingletonContextProvider(provider)) {
+      cacheableTokens.add(providerToken(provider));
+    }
+  }
+
+  return cacheableTokens;
+}
+
+function isDirectSingletonContextProvider(provider: Provider): boolean {
+  if (isMultiProvider(provider)) {
+    return false;
+  }
+
+  if (typeof provider === 'function') {
+    return providerScope(provider) === 'singleton';
+  }
+
+  if ('useExisting' in provider || 'useValue' in provider) {
+    return false;
+  }
+
+  return providerScope(provider) === 'singleton';
+}
+```
+
+Resolution helper는 적격 token에 대해서만 in-flight promise를 memoize하고 실패한 resolution은 제거합니다. 그 밖의 lookup은 모두 DI에 직접 위임되므로 alias target scope, request-scope error, transient 재생성, 새로운 multi-provider contribution array가 유지됩니다. `container.override()`는 기존 entry를 지우고 override된 각 token의 eligibility를 다시 계산합니다. `close()` 이후에는 `get()`이 context cache를 의도적으로 우회해 disposed container에 도달하므로, 이전에 cache된 singleton이 필수 post-close failure를 숨기지 않습니다.
+
+`path:packages/runtime/src/bootstrap.ts:1129-1178`
+```typescript
+function installContextCacheInvalidation(
+  container: Container,
+  cache: ContextResolutionCache,
+  cacheableTokens: ContextCacheableTokens,
+): void {
+  const cacheInvalidatingContainer = container as CacheInvalidatingContainer;
+  const override = cacheInvalidatingContainer.override.bind(container);
+
+  cacheInvalidatingContainer.override = (...providers: Provider[]): Container => {
+    const result = override(...providers);
+    cache.clear();
+
+    for (const provider of providers) {
+      const token = providerToken(provider);
+
+      if (isDirectSingletonContextProvider(provider)) {
+        cacheableTokens.add(token);
+      } else {
+        cacheableTokens.delete(token);
+      }
+    }
+
+    return result;
+  };
+}
+
+async function resolveContextToken<T>(
+  container: Container,
+  token: Token<T>,
+  cacheableTokens: ReadonlySet<Token>,
+  cache: ContextResolutionCache,
+): Promise<T> {
+  if (!cacheableTokens.has(token)) {
+    return container.resolve(token);
+  }
+
+  const cached = cache.get(token);
+
+  if (cached) {
+    return cached as Promise<T>;
+  }
+
+  const resolution = container.resolve(token).catch((error: unknown) => {
+    cache.delete(token);
+    throw error;
+  });
+  cache.set(token, resolution);
+
+  return resolution;
+}
+```
+
+Regression coverage가 이 경계를 실행 가능한 형태로 고정합니다. `path:packages/runtime/src/bootstrap.test.ts:687-885`는 direct singleton memoization, duplicate winner eligibility, transient override, multi-provider 위임을 다룹니다. `path:packages/runtime/src/application.test.ts:2783-2886`은 transient/request-scoped alias, singleton override invalidation, 그리고 `ApplicationContext.get()`과 `Application.get()` 양쪽의 post-close failure를 다룹니다.
+
+실제 bootstrap path는 `path:packages/runtime/src/bootstrap.ts:1619-1740`의 `FluoFactory.createApplicationContext()`입니다. 이 함수를 `bootstrapApplication()`과 비교하면, 대부분의 순서가 동일합니다. 여전히 logger, platform shell, runtime provider list, compiled module, runtime context token, lifecycle instance, timing diagnostics를 만듭니다.
+
+핵심 차이는 token registration입니다. Full application에서는 `registerRuntimeBootstrapTokens()`가 `HTTP_APPLICATION_ADAPTER`와 `PLATFORM_SHELL`을 모두 추가합니다. Context는 같은 platform, cleanup-registration, bootstrap-ready, container, compiled-module baseline을 등록하지만 `HTTP_APPLICATION_ADAPTER`는 생략합니다.
+
+토큰 등록 함수는 이 차이를 가장 작게 보여 줍니다. Application branch는 공유 lifecycle token과 함께 HTTP adapter token을 추가합니다. Context branch는 lifecycle token을 유지하되 adapter를 생략하고, 두 branch 모두 공통 context token 등록 helper로 내려갑니다.
+
+`path:packages/runtime/src/bootstrap.ts:1280-1300`
 ```typescript
 function registerRuntimeBootstrapTokens(
   bootstrapped: BootstrapResult,
   adapter: HttpApplicationAdapter,
   platformShell: RuntimePlatformShell,
+  runtimeCleanup: Array<() => void>,
+  bootstrapReadySignal: BootstrapReadySignal,
 ): void {
   registerRuntimeContextTokens(bootstrapped, {
     provide: HTTP_APPLICATION_ADAPTER,
@@ -147,13 +257,19 @@ function registerRuntimeBootstrapTokens(
   }, {
     provide: PLATFORM_SHELL,
     useValue: platformShell,
+  }, {
+    provide: RUNTIME_CLEANUP_REGISTRATION,
+    useValue: createRuntimeCleanupRegistration(runtimeCleanup),
+  }, {
+    provide: BOOTSTRAP_READY_SIGNAL,
+    useValue: bootstrapReadySignal,
   });
 }
 ```
 
 이 첫 발췌는 full application branch가 HTTP adapter token을 추가한다는 점만 좁혀 보여 줍니다. 이어지는 공통 helper를 보면 context branch가 같은 baseline token을 공유하면서 adapter token만 제외한다는 차이가 닫힙니다.
 
-`path:packages/runtime/src/bootstrap.ts:797-816`
+`path:packages/runtime/src/bootstrap.ts:1302-1332`
 ```typescript
 function registerRuntimeContextTokens(bootstrapped: BootstrapResult, ...providers: Provider[]): void {
   bootstrapped.container.register(
@@ -169,36 +285,47 @@ function registerRuntimeContextTokens(bootstrapped: BootstrapResult, ...provider
   );
 }
 
-function registerRuntimeApplicationContextTokens(bootstrapped: BootstrapResult, platformShell: RuntimePlatformShell): void {
+function registerRuntimeApplicationContextTokens(
+  bootstrapped: BootstrapResult,
+  platformShell: RuntimePlatformShell,
+  runtimeCleanup: Array<() => void>,
+  bootstrapReadySignal: BootstrapReadySignal,
+): void {
   registerRuntimeContextTokens(bootstrapped, {
     provide: PLATFORM_SHELL,
     useValue: platformShell,
+  }, {
+    provide: RUNTIME_CLEANUP_REGISTRATION,
+    useValue: createRuntimeCleanupRegistration(runtimeCleanup),
+  }, {
+    provide: BOOTSTRAP_READY_SIGNAL,
+    useValue: bootstrapReadySignal,
   });
 }
 ```
 
 두 번째 발췌는 공통 helper와 context 전용 wrapper를 이어서 보여 줍니다. 그래서 `RUNTIME_CONTAINER`와 `COMPILED_MODULES`는 둘 다 갖지만, `HTTP_APPLICATION_ADAPTER`는 full application만 갖는다는 설명이 코드와 맞습니다.
 
-이 차이는 테스트로 명시적으로 고정됩니다. `path:packages/runtime/src/bootstrap.test.ts:523-541`은 application service resolve는 성공하고, `context.get(HTTP_APPLICATION_ADAPTER)`는 `No provider registered`로 실패하며, `context.get(PLATFORM_SHELL)`은 성공해야 한다고 검증합니다.
+이 차이는 테스트로 명시적으로 고정됩니다. `path:packages/runtime/src/bootstrap.test.ts:667-685`는 application service resolve는 성공하고, `context.get(HTTP_APPLICATION_ADAPTER)`는 `No provider registered`로 실패하며, `context.get(PLATFORM_SHELL)`은 성공해야 한다고 검증합니다.
 
 여기서 중요한 점은 미묘합니다. application context는 "절반만 bootstrap된 상태"가 아닙니다. 자신이 약속한 capability에 대해서는 완전히 bootstrap된 상태입니다. 다만 adapter access를 약속하지 않을 뿐입니다.
 
-lifecycle 동작도 완전합니다. 같은 테스트 파일의 `path:packages/runtime/src/bootstrap.test.ts:543-582`는 context bootstrap이 `onModuleInit()`와 `onApplicationBootstrap()`을 실행하고, 이후 `close()`가 `onModuleDestroy()`와 `onApplicationShutdown()`을 실행함을 보여 줍니다.
+lifecycle 동작도 완전합니다. 같은 테스트 파일의 `path:packages/runtime/src/bootstrap.test.ts:1090-1129`는 context bootstrap이 `onModuleInit()`와 `onApplicationBootstrap()`을 실행하고, 이후 `close()`가 `onModuleDestroy()`와 `onApplicationShutdown()`을 실행함을 보여 줍니다.
 
 context와 application이 lifecycle을 공유한다는 점은 공통 helper에서 확인할 수 있습니다. bootstrap은 singleton lifecycle instance를 resolve하고, hook을 실행한 뒤 platform shell을 시작하고 readiness state를 표시합니다.
 
-`path:packages/runtime/src/bootstrap.ts:818-841`
+`path:packages/runtime/src/bootstrap.ts:1334-1358`
 ```typescript
 async function resolveBootstrapLifecycleInstances(
   bootstrapped: BootstrapResult,
-  runtimeProviders: Provider[],
+  resolvedInstances?: unknown[],
 ): Promise<unknown[]> {
   const lifecycleProviders = [
-    ...runtimeProviders,
-    ...bootstrapped.modules.flatMap((compiledModule) => compiledModule.definition.providers ?? []),
+    ...bootstrapped.effectiveProviders.runtimeProviders,
+    ...bootstrapped.effectiveProviders.moduleProviders,
   ];
 
-  return resolveLifecycleInstances(bootstrapped.container, lifecycleProviders);
+  return resolveLifecycleInstances(bootstrapped.container, lifecycleProviders, resolvedInstances);
 }
 
 async function runBootstrapLifecycle(
@@ -206,39 +333,42 @@ async function runBootstrapLifecycle(
   lifecycleInstances: unknown[],
   logger: ApplicationLogger,
   platformShell: RuntimePlatformShell,
+  bootstrapReadySignal: MutableBootstrapReadySignal,
 ): Promise<void> {
 ```
 
 이 발췌는 lifecycle 대상 목록을 runtime provider와 compiled module provider에서 함께 만든다는 점을 보여 줍니다. 다음 발췌는 그 목록을 실제 bootstrap phase에서 어떻게 실행하는지로 초점을 좁힙니다.
 
-`path:packages/runtime/src/bootstrap.ts:830-841`
+`path:packages/runtime/src/bootstrap.ts:1346-1358`
 ```typescript
 async function runBootstrapLifecycle(
   modules: CompiledModule[],
   lifecycleInstances: unknown[],
   logger: ApplicationLogger,
   platformShell: RuntimePlatformShell,
+  bootstrapReadySignal: MutableBootstrapReadySignal,
 ): Promise<void> {
   resetReadinessState(modules);
   await runBootstrapHooks(lifecycleInstances);
   await platformShell.start();
   markReadinessState(modules);
+  bootstrapReadySignal.markReady();
   logCompiledModules(logger, modules);
 }
 ```
 
 따라서 context bootstrap도 platform shell startup과 application bootstrap hook을 실제로 실행합니다. 차이는 HTTP adapter surface가 없다는 점이지, lifecycle phase가 생략된다는 뜻이 아닙니다.
 
-즉 context bootstrap은 dry-run mode가 아닙니다. lifecycle hook에 참여할 singleton provider를 eager하게 만들고, full application shell과 같은 runtime hook을 실제로 수행합니다.
+즉 context bootstrap은 dry-run mode가 아닙니다. Direct singleton lifecycle candidate를 eager하게 resolve하고, full application shell과 같은 runtime hook을 실제로 수행합니다.
 
-timing diagnostics도 같은 패턴을 따릅니다. `path:packages/runtime/src/bootstrap.test.ts:584-610`은 기본적으로 `bootstrapTiming`이 없지만, `diagnostics.timing`을 켜면 사용할 수 있음을 보여 줍니다. runtime은 timing instrumentation을 HTTP app에만 제한하지 않습니다.
+timing diagnostics도 같은 패턴을 따릅니다. `path:packages/runtime/src/bootstrap.test.ts:1387-1411`은 기본적으로 `bootstrapTiming`이 없지만, `diagnostics.timing`을 켜면 사용할 수 있음을 보여 줍니다. runtime은 timing instrumentation을 HTTP app에만 제한하지 않습니다.
 
 context bootstrap 흐름을 요약하면 다음과 같습니다.
 
 ```text
 createApplicationContext(rootModule)
   -> bootstrapModule()
-  -> register RUNTIME_CONTAINER + COMPILED_MODULES + PLATFORM_SHELL
+  -> register context/lifecycle runtime tokens without HTTP_APPLICATION_ADAPTER
   -> resolve singleton lifecycle instances
   -> run bootstrap hooks
   -> return DI-only shell with get() and close()

--- a/book/advanced/ch09-app-context.md
+++ b/book/advanced/ch09-app-context.md
@@ -100,15 +100,16 @@ The tests reinforce this shared ancestry. `path:packages/runtime/src/bootstrap.t
 This shared bootstrap spine is the foundation of this chapter. To understand the rest of the runtime contract, first see that the context, application, and microservice shells are siblings built from one compiled module and container baseline.
 
 ## 9.2 Application context is the adapterless baseline and still runs full lifecycle bootstrap
-`FluoApplicationContext` is defined in `path:packages/runtime/src/bootstrap.ts:531-575`. Its surface is intentionally small. It stores only the `container`, `modules`, `rootModule`, optional bootstrap timing diagnostics, lifecycle instances, and cleanup callbacks.
+`FluoApplicationContext` is defined in `path:packages/runtime/src/bootstrap.ts:808-859`. Its surface is intentionally small. It stores the `container`, `modules`, `rootModule`, optional bootstrap timing diagnostics, lifecycle instances, cleanup callbacks, and the narrow context-resolution cache used by `get()`.
 
 The context shell itself shows that intent. The stored values are the ones needed for the compiled Module baseline and lifecycle cleanup, and the public behavior is DI lookup and close.
 
-`path:packages/runtime/src/bootstrap.ts:531-548`
+`path:packages/runtime/src/bootstrap.ts:808-831`
 ```typescript
 class FluoApplicationContext implements ApplicationContext {
   private closed = false;
   private closingPromise: Promise<void> | undefined;
+  private readonly contextResolutionCache: ContextResolutionCache = new Map();
 
   constructor(
     readonly container: Container,
@@ -117,29 +118,138 @@ class FluoApplicationContext implements ApplicationContext {
     readonly bootstrapTiming: ApplicationContext['bootstrapTiming'],
     private readonly lifecycleInstances: unknown[],
     private readonly runtimeCleanup: Array<() => void>,
-  ) {}
+    private readonly contextCacheableTokens: ContextCacheableTokens,
+  ) {
+    installContextCacheInvalidation(this.container, this.contextResolutionCache, this.contextCacheableTokens);
+  }
 
   async get<T>(token: Token<T>): Promise<T> {
-    return this.container.resolve(token);
+    if (this.closed) {
+      return this.container.resolve(token);
+    }
+
+    return resolveContextToken(this.container, token, this.contextCacheableTokens, this.contextResolutionCache);
   }
 ```
 
-This excerpt has no dispatcher, adapter, or listen state. So a context is not a less bootstrapped application. It is a separate shell that promises only DI and lifecycle behavior.
+This excerpt still has no dispatcher, adapter, or listen state. So a context is not a less bootstrapped application. It is a separate shell that promises only DI and lifecycle behavior. The added cache is not a second DI system: it is a guarded fast path in front of the same container.
 
 The only public methods are `get()` and `close()`. That minimal surface is the point. An application context is the runtime baseline for CLI tasks, workers, migrations, and every DI-driven process that does not need an HTTP listener.
 
-The actual bootstrap path is `FluoFactory.createApplicationContext()` in `path:packages/runtime/src/bootstrap.ts:1059-1153`. Compared with `bootstrapApplication()`, most of the order is the same. It still creates the logger, platform shell, runtime Provider list, compiled Module, runtime context Tokens, lifecycle instances, and timing diagnostics.
+For application-authored Providers, cache eligibility is limited to effective runtime Providers and Providers declared directly on the root Module. Bare classes and class/factory Providers must also be singleton, while aliases, values, and `multi: true` Providers are excluded. Internal runtime Tokens are seeded explicitly. Imported-Module Providers still use the container's own singleton cache, but `ApplicationContext.get()` does not add a second context-cache entry for them.
 
-The key difference is Token registration. In a full application, `registerRuntimeBootstrapTokens()` adds both `HTTP_APPLICATION_ADAPTER` and `PLATFORM_SHELL`. In a context, `registerRuntimeApplicationContextTokens()` adds only `PLATFORM_SHELL`.
+`path:packages/runtime/src/bootstrap.ts:1074-1113`
+```typescript
+function createContextCacheableTokenSet(
+  effectiveProviders: BootstrapEffectiveProviders,
+  runtimeTokens: readonly Token[],
+): Set<Token> {
+  const cacheableTokens = new Set<Token>(runtimeTokens);
 
-The Token registration functions show this difference in the smallest form. The application branch adds the HTTP adapter Token. The context branch adds only the platform shell, then falls through to the shared context Token registration helper.
+  for (const provider of effectiveProviders.runtimeProviders) {
+    if (isDirectSingletonContextProvider(provider)) {
+      cacheableTokens.add(providerToken(provider));
+    }
+  }
 
-`path:packages/runtime/src/bootstrap.ts:783-795`
+  for (const provider of effectiveProviders.rootModuleProviders) {
+    if (isDirectSingletonContextProvider(provider)) {
+      cacheableTokens.add(providerToken(provider));
+    }
+  }
+
+  return cacheableTokens;
+}
+
+function isDirectSingletonContextProvider(provider: Provider): boolean {
+  if (isMultiProvider(provider)) {
+    return false;
+  }
+
+  if (typeof provider === 'function') {
+    return providerScope(provider) === 'singleton';
+  }
+
+  if ('useExisting' in provider || 'useValue' in provider) {
+    return false;
+  }
+
+  return providerScope(provider) === 'singleton';
+}
+```
+
+The resolution helper memoizes the in-flight Promise only for those eligible Tokens and removes failed resolutions. Every other lookup delegates directly to DI, preserving alias target scope, request-scope errors, transient recreation, and fresh multi-provider contribution arrays. `container.override()` clears existing entries and recomputes eligibility for each overridden Token. After `close()`, `get()` deliberately bypasses the context cache and reaches the disposed container, so a previously cached singleton cannot hide the required post-close failure.
+
+`path:packages/runtime/src/bootstrap.ts:1129-1178`
+```typescript
+function installContextCacheInvalidation(
+  container: Container,
+  cache: ContextResolutionCache,
+  cacheableTokens: ContextCacheableTokens,
+): void {
+  const cacheInvalidatingContainer = container as CacheInvalidatingContainer;
+  const override = cacheInvalidatingContainer.override.bind(container);
+
+  cacheInvalidatingContainer.override = (...providers: Provider[]): Container => {
+    const result = override(...providers);
+    cache.clear();
+
+    for (const provider of providers) {
+      const token = providerToken(provider);
+
+      if (isDirectSingletonContextProvider(provider)) {
+        cacheableTokens.add(token);
+      } else {
+        cacheableTokens.delete(token);
+      }
+    }
+
+    return result;
+  };
+}
+
+async function resolveContextToken<T>(
+  container: Container,
+  token: Token<T>,
+  cacheableTokens: ReadonlySet<Token>,
+  cache: ContextResolutionCache,
+): Promise<T> {
+  if (!cacheableTokens.has(token)) {
+    return container.resolve(token);
+  }
+
+  const cached = cache.get(token);
+
+  if (cached) {
+    return cached as Promise<T>;
+  }
+
+  const resolution = container.resolve(token).catch((error: unknown) => {
+    cache.delete(token);
+    throw error;
+  });
+  cache.set(token, resolution);
+
+  return resolution;
+}
+```
+
+The regression coverage makes the boundary executable. `path:packages/runtime/src/bootstrap.test.ts:687-885` covers direct singleton memoization, duplicate-winner eligibility, transient overrides, and multi-provider delegation. `path:packages/runtime/src/application.test.ts:2783-2886` covers transient and request-scoped aliases, singleton override invalidation, and post-close failures for both `ApplicationContext.get()` and `Application.get()`.
+
+The actual bootstrap path is `FluoFactory.createApplicationContext()` in `path:packages/runtime/src/bootstrap.ts:1619-1740`. Compared with `bootstrapApplication()`, most of the order is the same. It still creates the logger, platform shell, runtime Provider list, compiled Module, runtime context Tokens, lifecycle instances, and timing diagnostics.
+
+The key difference is Token registration. In a full application, `registerRuntimeBootstrapTokens()` adds both `HTTP_APPLICATION_ADAPTER` and `PLATFORM_SHELL`. A context registers the same platform, cleanup-registration, bootstrap-ready, container, and compiled-module baseline, but it omits `HTTP_APPLICATION_ADAPTER`.
+
+The Token registration functions show this difference in the smallest form. The application branch adds the HTTP adapter Token alongside the shared lifecycle Tokens. The context branch keeps those lifecycle Tokens but omits the adapter, then both branches fall through to the shared context Token registration helper.
+
+`path:packages/runtime/src/bootstrap.ts:1280-1300`
 ```typescript
 function registerRuntimeBootstrapTokens(
   bootstrapped: BootstrapResult,
   adapter: HttpApplicationAdapter,
   platformShell: RuntimePlatformShell,
+  runtimeCleanup: Array<() => void>,
+  bootstrapReadySignal: BootstrapReadySignal,
 ): void {
   registerRuntimeContextTokens(bootstrapped, {
     provide: HTTP_APPLICATION_ADAPTER,
@@ -147,13 +257,19 @@ function registerRuntimeBootstrapTokens(
   }, {
     provide: PLATFORM_SHELL,
     useValue: platformShell,
+  }, {
+    provide: RUNTIME_CLEANUP_REGISTRATION,
+    useValue: createRuntimeCleanupRegistration(runtimeCleanup),
+  }, {
+    provide: BOOTSTRAP_READY_SIGNAL,
+    useValue: bootstrapReadySignal,
   });
 }
 ```
 
 This first excerpt narrows the full application branch to the fact that it adds the HTTP adapter Token. The shared helper below closes the comparison by showing that the context branch shares the same baseline Tokens while excluding only the adapter Token.
 
-`path:packages/runtime/src/bootstrap.ts:797-816`
+`path:packages/runtime/src/bootstrap.ts:1302-1332`
 ```typescript
 function registerRuntimeContextTokens(bootstrapped: BootstrapResult, ...providers: Provider[]): void {
   bootstrapped.container.register(
@@ -169,36 +285,47 @@ function registerRuntimeContextTokens(bootstrapped: BootstrapResult, ...provider
   );
 }
 
-function registerRuntimeApplicationContextTokens(bootstrapped: BootstrapResult, platformShell: RuntimePlatformShell): void {
+function registerRuntimeApplicationContextTokens(
+  bootstrapped: BootstrapResult,
+  platformShell: RuntimePlatformShell,
+  runtimeCleanup: Array<() => void>,
+  bootstrapReadySignal: BootstrapReadySignal,
+): void {
   registerRuntimeContextTokens(bootstrapped, {
     provide: PLATFORM_SHELL,
     useValue: platformShell,
+  }, {
+    provide: RUNTIME_CLEANUP_REGISTRATION,
+    useValue: createRuntimeCleanupRegistration(runtimeCleanup),
+  }, {
+    provide: BOOTSTRAP_READY_SIGNAL,
+    useValue: bootstrapReadySignal,
   });
 }
 ```
 
 The second excerpt shows the shared helper and the context-specific wrapper together. That matches the claim that both shells have `RUNTIME_CONTAINER` and `COMPILED_MODULES`, but only a full application has `HTTP_APPLICATION_ADAPTER`.
 
-This difference is fixed explicitly by tests. `path:packages/runtime/src/bootstrap.test.ts:523-541` verifies that application service resolution succeeds, `context.get(HTTP_APPLICATION_ADAPTER)` fails with `No provider registered`, and `context.get(PLATFORM_SHELL)` succeeds.
+This difference is fixed explicitly by tests. `path:packages/runtime/src/bootstrap.test.ts:667-685` verifies that application service resolution succeeds, `context.get(HTTP_APPLICATION_ADAPTER)` fails with `No provider registered`, and `context.get(PLATFORM_SHELL)` succeeds.
 
 The important point is subtle. An application context is not a half-bootstrapped state. It is fully bootstrapped for the capabilities it promises. It simply does not promise adapter access.
 
-Lifecycle behavior is also complete. `path:packages/runtime/src/bootstrap.test.ts:543-582` in the same test file shows that context bootstrap runs `onModuleInit()` and `onApplicationBootstrap()`, and later `close()` runs `onModuleDestroy()` and `onApplicationShutdown()`.
+Lifecycle behavior is also complete. `path:packages/runtime/src/bootstrap.test.ts:1090-1129` in the same test file shows that context bootstrap runs `onModuleInit()` and `onApplicationBootstrap()`, and later `close()` runs `onModuleDestroy()` and `onApplicationShutdown()`.
 
 The fact that context and application share lifecycle behavior is visible in the shared helpers. Bootstrap resolves singleton lifecycle instances, runs hooks, starts the platform shell, and marks readiness state.
 
-`path:packages/runtime/src/bootstrap.ts:818-841`
+`path:packages/runtime/src/bootstrap.ts:1334-1358`
 ```typescript
 async function resolveBootstrapLifecycleInstances(
   bootstrapped: BootstrapResult,
-  runtimeProviders: Provider[],
+  resolvedInstances?: unknown[],
 ): Promise<unknown[]> {
   const lifecycleProviders = [
-    ...runtimeProviders,
-    ...bootstrapped.modules.flatMap((compiledModule) => compiledModule.definition.providers ?? []),
+    ...bootstrapped.effectiveProviders.runtimeProviders,
+    ...bootstrapped.effectiveProviders.moduleProviders,
   ];
 
-  return resolveLifecycleInstances(bootstrapped.container, lifecycleProviders);
+  return resolveLifecycleInstances(bootstrapped.container, lifecycleProviders, resolvedInstances);
 }
 
 async function runBootstrapLifecycle(
@@ -206,39 +333,42 @@ async function runBootstrapLifecycle(
   lifecycleInstances: unknown[],
   logger: ApplicationLogger,
   platformShell: RuntimePlatformShell,
+  bootstrapReadySignal: MutableBootstrapReadySignal,
 ): Promise<void> {
 ```
 
 This excerpt shows that the lifecycle target list is built from both runtime Providers and compiled Module Providers. The next excerpt narrows the focus to how that list runs in the actual bootstrap phase.
 
-`path:packages/runtime/src/bootstrap.ts:830-841`
+`path:packages/runtime/src/bootstrap.ts:1346-1358`
 ```typescript
 async function runBootstrapLifecycle(
   modules: CompiledModule[],
   lifecycleInstances: unknown[],
   logger: ApplicationLogger,
   platformShell: RuntimePlatformShell,
+  bootstrapReadySignal: MutableBootstrapReadySignal,
 ): Promise<void> {
   resetReadinessState(modules);
   await runBootstrapHooks(lifecycleInstances);
   await platformShell.start();
   markReadinessState(modules);
+  bootstrapReadySignal.markReady();
   logCompiledModules(logger, modules);
 }
 ```
 
 So context bootstrap also performs platform shell startup and application bootstrap hooks. The difference is the absence of an HTTP adapter surface, not the omission of a lifecycle phase.
 
-That means context bootstrap is not dry-run mode. It eagerly creates singleton Providers that participate in lifecycle hooks and actually performs the same runtime hooks as the full application shell.
+That means context bootstrap is not dry-run mode. It eagerly resolves direct singleton lifecycle candidates and actually performs the same runtime hooks as the full application shell.
 
-Timing diagnostics follow the same pattern. `path:packages/runtime/src/bootstrap.test.ts:584-610` shows that `bootstrapTiming` is absent by default, but available when `diagnostics.timing` is enabled. The runtime does not restrict timing instrumentation to HTTP applications.
+Timing diagnostics follow the same pattern. `path:packages/runtime/src/bootstrap.test.ts:1387-1411` shows that `bootstrapTiming` is absent by default, but available when `diagnostics.timing` is enabled. The runtime does not restrict timing instrumentation to HTTP applications.
 
 The context bootstrap flow can be summarized like this:
 
 ```text
 createApplicationContext(rootModule)
   -> bootstrapModule()
-  -> register RUNTIME_CONTAINER + COMPILED_MODULES + PLATFORM_SHELL
+  -> register context/lifecycle runtime tokens without HTTP_APPLICATION_ADAPTER
   -> resolve singleton lifecycle instances
   -> run bootstrap hooks
   -> return DI-only shell with get() and close()


### PR DESCRIPTION
## Summary

Refresh the advanced book runtime internals so the EN/KO learning path matches the existing `@fluojs/runtime` behavioral contract and implementation.

Linked context: https://github.com/fluojs/fluo/issues/2870

Closes #2870

## Changes

- Update the EN/KO application-context chapter with the guarded direct-root-singleton `ApplicationContext.get()` cache path and its alias, request, transient, multi-provider, post-close, and `container.override()` semantics.
- Update the EN/KO module-graph chapter to show concurrent independent singleton lifecycle resolution followed by deterministic provider-order lifecycle hooks.
- Refresh the affected source excerpts, line references, explanations, and lifecycle diagram against the current runtime source and regression tests.

## Testing

- `git diff --check` — passed.
- `pnpm docs:sync-check` — passed: 42 EN/KO page pairs and 10 navigation metadata pairs.
- Targeted changed-book EN/KO heading parity, relative-link, and runtime-contract marker assertions — passed.
- `pnpm verify:platform-consistency-governance` — passed.
- `pnpm vitest run tooling/governance/verify-platform-consistency-governance.test.ts --maxWorkers=1` — passed: 117 tests.
- `pnpm verify` — build, typecheck, and lint passed; the parallel full-test phase reported 23 failures after 4,537 tests passed and 1 skipped.
- `pnpm vitest run packages/cli/src/cli.test.ts packages/microservices/src/root-import-runtime-safety.test.ts packages/platform-cloudflare-workers/src/published-artifact-surface.test.ts packages/throttler/src/module.test.ts packages/socket.io/src/module.test.ts packages/platform-bun/src/published-declaration-surface.test.ts packages/cli/src/commands/typegen-navigation.test.ts packages/cli/src/commands/typegen.test.ts packages/cli/src/new/scaffold.test.ts packages/http/src/context/request-context-isolation.test.ts --maxWorkers=1` — passed: all 10 affected files and 374 tests, confirming the parallel-run failures are unrelated to this Markdown-only diff.

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

No changeset is included because this PR changes only four advanced-book Markdown files. It does not change published `@fluojs/*` behavior, API surface, package contents, runtime code, release metadata, or the already-correct runtime package README contract.

## Public export documentation

- [x] Not applicable: no `packages/*/src` files or public exports changed.
- [x] Not applicable: no exported function parameters, return values, or source examples changed.
- [x] The canonical `packages/runtime/README.md` and `README.ko.md` examples and contract remain unchanged because they were already current.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] No new behavioral contract was introduced; the advanced book now reflects the existing runtime contract.
- [x] Alias, scope, multi-provider, override, post-close, concurrent-resolution, and deterministic-hook invariants are stated explicitly.
- [x] Existing runtime regression tests are cited as executable evidence; runtime source and tests are unchanged.

## Platform consistency governance (SSOT)

- [x] Both affected English/Korean book pairs were updated together with matching heading structure and semantic scope.
- [x] Current runtime source/test references back the refreshed excerpts and explanations.
- [x] Canonical runtime README EN/KO mirrors were reviewed and required no edits.
- [x] Platform consistency governance and its 117-test regression suite passed.
- [x] No platform contract documents, tooling contracts, or CI enforcement surfaces changed.

## Risks

- Runtime risk is none because the diff is documentation-only.
- Source line references can drift as `packages/runtime/src/bootstrap.ts` evolves; this PR pins them to the current `main` implementation and nearby regression tests.