### PR TITLE
Resolve #2869: Cover normal drain settlement in Node response tests

### DIFF
--- a/packages/runtime/src/node/node-response.test.ts
+++ b/packages/runtime/src/node/node-response.test.ts
@@ -105,6 +105,28 @@ describe('createFrameworkResponse', () => {
     expect(endSpy).toHaveBeenCalledWith(Buffer.from('hello', 'utf8'));
   });
 
+  it('settles waitForDrain and removes terminal listeners when the response drains', async () => {
+    const rawResponse = createMockServerResponse();
+    const frameworkResponse = createFrameworkResponse(rawResponse);
+    let settled = false;
+
+    const waitForDrain = frameworkResponse.stream?.waitForDrain?.();
+    void waitForDrain?.then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+
+    expect(settled).toBe(false);
+
+    rawResponse.emit('drain');
+
+    await expect(waitForDrain).resolves.toBeUndefined();
+    expect(settled).toBe(true);
+    expect(rawResponse.listenerCount('drain')).toBe(0);
+    expect(rawResponse.listenerCount('close')).toBe(0);
+    expect(rawResponse.listenerCount('error')).toBe(0);
+  });
+
   it('settles waitForDrain when the response closes before drain', async () => {
     const rawResponse = createMockServerResponse();
     const frameworkResponse = createFrameworkResponse(rawResponse);


### PR DESCRIPTION
## Summary

Add the missing success-path regression coverage for the documented Node response backpressure contract.

Linked context: Closes #2869

## Changes

- add a focused `waitForDrain()` test for the ordinary `drain` event
- assert the promise remains pending before `drain` and settles afterward
- assert `drain`, `close`, and `error` listeners are removed after settlement

## Testing

- `pnpm vitest run packages/runtime/src/node/node-response.test.ts` (8 passed)
- `pnpm verify` (reported by implementer: build, typecheck, lint, and 4,575 tests passed; 1 skipped)
- changed-file LSP diagnostics: clean
- `git diff --check origin/main...HEAD`

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

Test-only coverage of existing documented behavior; no Changeset is required.

## Public export documentation

- [x] No public exports changed.
- [x] Existing source and README documentation remains unchanged.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] No new behavioral contract was introduced.
- [x] The existing `waitForDrain()` terminal-event invariant now has direct normal-drain regression coverage.

## Platform consistency governance (SSOT)

- [x] No platform contract docs or governance SSOT changed.
- [x] The change is isolated to the runtime Node response unit test and preserves existing adapter behavior.