### PR TITLE
Resolve #2868: Cover async rejection cleanup in raceWithAbort

### DIFF
--- a/packages/runtime/src/abort.test.ts
+++ b/packages/runtime/src/abort.test.ts
@@ -74,6 +74,23 @@ describe('raceWithAbort', () => {
     await raceWithAbort(async () => 'ok', controller.signal);
     expect(removeSpy).toHaveBeenCalledWith('abort', expect.any(Function));
   });
+
+  it('removes the abort listener after fn rejects asynchronously', async () => {
+    const controller = new AbortController();
+    const addSpy = vi.spyOn(controller.signal, 'addEventListener');
+    const removeSpy = vi.spyOn(controller.signal, 'removeEventListener');
+    const originalError = new Error('async rejection');
+
+    const promise = raceWithAbort(async () => {
+      await Promise.resolve();
+      throw originalError;
+    }, controller.signal);
+
+    await expect(promise).rejects.toBe(originalError);
+    expect(addSpy).toHaveBeenCalledTimes(1);
+    const abortListener = addSpy.mock.calls[0]?.[1];
+    expect(removeSpy).toHaveBeenCalledWith('abort', abortListener);
+  });
 });
 
 describe('createAbortError', () => {


### PR DESCRIPTION
## Summary

Add the missing asynchronous-rejection regression coverage for the documented `raceWithAbort()` listener cleanup contract.

Linked context: Closes #2868

## Changes

- add a deterministic microtask-delayed rejection case
- assert `raceWithAbort()` preserves the original rejection object
- assert the exact race-owned abort listener is removed after rejection

## Testing

- `pnpm vitest run packages/runtime/src/abort.test.ts` (10 passed)
- `pnpm --filter @fluojs/runtime typecheck`
- `pnpm --filter @fluojs/runtime test` (27 files, 301 passed)
- changed-file LSP diagnostics: clean
- full `pnpm verify` passed build/typecheck/lint; two unrelated parallel-suite failures passed when rerun in isolation, so canonical GitHub CI is the merge gate

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

Test-only coverage of existing behavior; no Changeset is required.

## Public export documentation

- [x] No public exports changed.
- [x] Existing source and README documentation remains unchanged.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] No new behavioral contract was introduced.
- [x] The existing all-settlement listener cleanup invariant now covers asynchronous rejection directly.

## Platform consistency governance (SSOT)

- [x] No platform contract docs or governance SSOT changed.
- [x] The change is isolated to the canonical runtime abort unit test.