### PR TITLE
Resolve #2873: Remove runtime test port reservation race

### DIFF
--- a/packages/runtime/src/application.test.ts
+++ b/packages/runtime/src/application.test.ts
@@ -1,5 +1,5 @@
 import { request as httpsRequest } from 'node:https';
-import { createServer } from 'node:net';
+import { type AddressInfo, createServer } from 'node:net';
 import { Inject, Scope } from '@fluojs/core';
 import type { Container } from '@fluojs/di';
 import {
@@ -27,7 +27,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { bootstrapApplication, defineModule, FluoFactory } from './bootstrap.js';
 import { ModuleInjectionMetadataError } from './errors.js';
 import { createHealthModule } from './health/health.js';
-import { bootstrapNodeApplication, createNodeHttpAdapter, runNodeApplication } from './node/node.js';
+import { bootstrapNodeApplication, createNodeHttpAdapter, NodeHttpApplicationAdapter, runNodeApplication } from './node/node.js';
 import { COMPILED_MODULES, HTTP_APPLICATION_ADAPTER, RUNTIME_CLEANUP_REGISTRATION, RUNTIME_CONTAINER } from './tokens.js';
 import type { ApplicationLogger, CompiledModule, ExceptionFilterContext, ExceptionFilterHandler, OnApplicationBootstrap, OnModuleInit, RuntimeCleanupRegistration } from './types.js';
 
@@ -1873,34 +1873,48 @@ describe('bootstrapApplication', () => {
       controllers: [SlowController],
     });
 
-    const port = await findAvailablePort();
-    const app = registerAppForCleanup(await bootstrapNodeApplication(AppModule, {
+    const app = await bootstrapNodeApplication(AppModule, {
       cors: false,
-      port,
+      port: 0,
       shutdownTimeoutMs: 1_000,
-    }));
-
-    await app.listen();
-
-    const responsePromise = fetchForTest(`http://127.0.0.1:${String(port)}/slow`);
-    await requestStarted.promise;
-
-    let closeResolved = false;
-    const closePromise = app.close().then(() => {
-      closeResolved = true;
     });
 
-    await new Promise((resolve) => setTimeout(resolve, 50));
-    expect(closeResolved).toBe(false);
+    try {
+      await app.listen();
 
-    allowResponse.resolve();
+      const adapter = await app.get(HTTP_APPLICATION_ADAPTER);
+      if (!(adapter instanceof NodeHttpApplicationAdapter)) {
+        throw new Error('Expected the runtime Node HTTP application adapter.');
+      }
 
-    const response = await responsePromise;
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ ok: true });
+      const address: AddressInfo | string | null = adapter.getServer().address();
+      if (!address || typeof address === 'string') {
+        throw new Error('Failed to resolve the bound test port.');
+      }
 
-    await closePromise;
-    expect(closeResolved).toBe(true);
+      const responsePromise = fetchForTest(`http://127.0.0.1:${String(address.port)}/slow`);
+      await requestStarted.promise;
+
+      let closeResolved = false;
+      const closePromise = app.close().then(() => {
+        closeResolved = true;
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(closeResolved).toBe(false);
+
+      allowResponse.resolve();
+
+      const response = await responsePromise;
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({ ok: true });
+
+      await closePromise;
+      expect(closeResolved).toBe(true);
+    } finally {
+      allowResponse.resolve();
+      await app.close();
+    }
   });
 
   it('forces shutdown when the drain timeout expires', async () => {


### PR DESCRIPTION
## Summary

Remove the reserve-close-rebind race from the runtime in-flight shutdown network test by letting the application bind an OS-assigned port directly.

Linked context: https://github.com/fluojs/fluo/issues/2873

Closes #2873

## Changes

- Configure the cited Node runtime test with `port: 0` instead of reserving and releasing a port first.
- Resolve the bound `NodeHttpApplicationAdapter` after `listen()` and read the actual server address for the test request.
- Release the blocked response and close the application in `finally` so assertion failures cannot leave shutdown waiting indefinitely.
- Keep the shared reservation helper and its unrelated call sites unchanged.

## Testing

- Focused in-flight shutdown test: 1 passed.
- Repeated focused flake check: 20/20 passed.
- `pnpm --filter @fluojs/runtime typecheck` - passed.
- `pnpm --filter @fluojs/runtime test` - 29 files, 311 tests passed.
- Biome check - passed.
- LSP diagnostics - no errors or warnings; only pre-existing deprecation hints in the test file.
- `git diff --check HEAD^..HEAD` - passed.

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

No Changeset is required because this changes only test setup and cleanup; published runtime behavior, API surface, and package contents are unchanged.

## Public export documentation

- [x] Not applicable: no public exports or source documentation changed.

## Behavioral contract

- [x] No documented behavioral contract changed.
- [x] The existing in-flight shutdown assertion remains intact while its network setup is made race-free.
- [x] Production runtime source is unchanged.

## Platform consistency governance (SSOT)

- [x] Not applicable: no platform contract, adapter implementation, governance document, or conformance claim changed.
