### PR TITLE
Resolve #2901: strengthen JWT boundary regression coverage

### DIFF
--- a/packages/jwt/src/runtime-boundary.test.ts
+++ b/packages/jwt/src/runtime-boundary.test.ts
@@ -8,6 +8,8 @@ const packageSourceRoot = dirname(fileURLToPath(import.meta.url));
 
 const rootImportSurfaceFiles = [
   'index.ts',
+  'module.ts',
+  'service.ts',
   'signing/jwks.ts',
   'signing/signer.ts',
   'signing/verifier.ts',

--- a/packages/jwt/src/runtime-boundary.test.ts
+++ b/packages/jwt/src/runtime-boundary.test.ts
@@ -8,8 +8,11 @@ const packageSourceRoot = dirname(fileURLToPath(import.meta.url));
 
 const rootImportSurfaceFiles = [
   'index.ts',
+  'errors.ts',
   'module.ts',
   'service.ts',
+  'status.ts',
+  'types.ts',
   'signing/jwks.ts',
   'signing/signer.ts',
   'signing/verifier.ts',

--- a/packages/jwt/src/service.test.ts
+++ b/packages/jwt/src/service.test.ts
@@ -213,6 +213,22 @@ describe('JwtService', () => {
     expect(service.decode('invalid-token')).toBeNull();
   });
 
+  it('decodes invalid-signature claims as unverified input while verify rejects the token', async () => {
+    const service = createJwtService({
+      algorithms: ['HS256'],
+      issuer: 'jwt-service-tests',
+      secret: 'service-secret',
+    });
+    const token = createHs256Token('attacker-secret', {
+      exp: Math.floor(Date.now() / 1000) + 60,
+      iss: 'jwt-service-tests',
+      sub: 'attacker-controlled-user',
+    });
+
+    expect(service.decode(token)).toMatchObject({ sub: 'attacker-controlled-user' });
+    await expect(service.verify(token)).rejects.toBeInstanceOf(JwtInvalidTokenError);
+  });
+
   it('reuses the shared jwks cache when verify options override claim policy', async () => {
     const originalFetch = globalThis.fetch;
     const { privateKey, publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });

--- a/packages/jwt/src/signing/jwks.test.ts
+++ b/packages/jwt/src/signing/jwks.test.ts
@@ -71,6 +71,24 @@ describe('JwksClient', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it('refetches on every lookup when cache ttl is zero', async () => {
+    const { publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+    const jwk = publicKey.export({ format: 'jwk' });
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ keys: [{ ...jwk, kid: 'key-1' }] }), {
+        headers: { 'content-type': 'application/json' },
+        status: 200,
+      }),
+    );
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const client = new JwksClient('https://example.test/.well-known/jwks.json', 0);
+    await client.getSigningKey('key-1');
+    await client.getSigningKey('key-1');
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it('refetches after ttl expires', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));


### PR DESCRIPTION
## Summary
Strengthen executable coverage for three documented `@fluojs/jwt` boundaries without changing runtime behavior.

Closes #2901

## Changes
- verify `jwksCacheTtl: 0` refetches on every lookup
- include `module.ts` and `service.ts` in the root static `node:crypto` import guard
- verify `decode()` returns attacker-controlled claims while `verify()` rejects an invalid signature

## Testing
- `pnpm --dir packages/jwt test` (127 tests passed)
- `pnpm --dir packages/jwt typecheck`
- changed-file LSP diagnostics
- `git diff --check origin/main...HEAD`

## Public export documentation
Not applicable. No public exports or TSDoc surfaces changed.

## Behavioral contract
Preserves existing documented JWT cache, runtime import, and decode trust-boundary behavior. This PR only adds regression evidence.

No changeset is required because the change is test-only and does not affect consumer-visible behavior, API surface, package contents, or release metadata.

## Platform consistency governance (SSOT)
Not applicable. No platform adapter, runtime matrix, governed docs, or environment-isolation behavior changed.