### PR TITLE
Resolve #2905: reject unknown Studio route kinds

### DIFF
--- a/.changeset/reject-unknown-studio-route-kinds.md
+++ b/.changeset/reject-unknown-studio-route-kinds.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/studio': patch
+---
+
+Reject unknown supplied route kinds in static and live Studio artifacts while preserving the legacy `http` default when `kind` is omitted.

--- a/packages/studio/src/contracts.test.ts
+++ b/packages/studio/src/contracts.test.ts
@@ -506,6 +506,40 @@ describe('parseStudioPayload', () => {
     }))).toThrow('Invalid Studio live route descriptor params payload.');
   });
 
+  it('rejects unknown supplied route kinds in static inspect snapshots', () => {
+    expect(() => parseStudioPayload(JSON.stringify({
+      ...snapshotFixture,
+      routes: [
+        {
+          controller: 'ProductRouter',
+          handler: 'show',
+          id: 'GET /products/:productId ProductRouter show',
+          kind: 'unknown',
+          method: 'GET',
+          params: ['productId'],
+          path: '/products/:productId',
+        },
+      ],
+    }))).toThrow('Invalid Studio live route descriptor kind payload.');
+  });
+
+  it('defaults omitted route kinds to http in legacy static inspect snapshots', () => {
+    const parsed = parseStudioPayload(JSON.stringify({
+      ...snapshotFixture,
+      routes: [
+        {
+          controller: 'LegacyController',
+          handler: 'show',
+          id: 'GET /legacy LegacyController show',
+          method: 'GET',
+          path: '/legacy',
+        },
+      ],
+    }));
+
+    expect(parsed.payload.snapshot?.routes?.[0]?.kind).toBe('http');
+  });
+
   it('rejects arbitrary JSON objects that are not Studio inspect artifacts', () => {
     expect(() =>
       parseStudioPayload(

--- a/packages/studio/src/contracts.ts
+++ b/packages/studio/src/contracts.ts
@@ -81,7 +81,7 @@ export interface StudioRouteDescriptor {
   controller: string;
   handler: string;
   id: string;
-  kind?: string;
+  kind?: 'http' | 'react-page';
   method: string;
   module?: string;
   params?: string[];

--- a/packages/studio/src/contracts.ts
+++ b/packages/studio/src/contracts.ts
@@ -378,6 +378,11 @@ function validateStudioRouteDescriptor(value: unknown): StudioRouteDescriptor {
     throw new Error('Invalid Studio live route descriptor payload.');
   }
 
+  const kind = value.kind;
+  if (kind !== undefined && kind !== 'http' && kind !== 'react-page') {
+    throw new Error('Invalid Studio live route descriptor kind payload.');
+  }
+
   const params = value.params;
   if (params !== undefined && !isStringArray(params)) {
     throw new Error('Invalid Studio live route descriptor params payload.');
@@ -387,9 +392,7 @@ function validateStudioRouteDescriptor(value: unknown): StudioRouteDescriptor {
     controller: validateString(value.controller, 'Invalid Studio live route descriptor payload.'),
     handler: validateString(value.handler, 'Invalid Studio live route descriptor payload.'),
     id: validateString(value.id, 'Invalid Studio live route descriptor payload.'),
-    kind: value.kind === undefined
-      ? 'http'
-      : validateString(value.kind, 'Invalid Studio live route descriptor kind payload.'),
+    kind: kind ?? 'http',
     method: validateString(value.method, 'Invalid Studio live route descriptor payload.'),
     params: params === undefined ? [] : [...params],
     path: validateString(value.path, 'Invalid Studio live route descriptor payload.'),

--- a/packages/studio/src/entities/studio/model.ts
+++ b/packages/studio/src/entities/studio/model.ts
@@ -48,7 +48,7 @@ export interface StudioDashboardState {
 }
 
 type StudioDisplayRouteDescriptor = Omit<StudioRouteDescriptor, 'kind' | 'params'> & {
-  kind: string;
+  kind: NonNullable<StudioRouteDescriptor['kind']>;
   params: string[];
 };
 

--- a/packages/studio/src/live-contracts.test.ts
+++ b/packages/studio/src/live-contracts.test.ts
@@ -86,6 +86,53 @@ describe('Studio live event contracts', () => {
     }
   });
 
+  it('rejects unknown supplied route kinds in live snapshots', () => {
+    const event = {
+      ...liveEvents[0],
+      payload: {
+        ...liveEvents[0].payload,
+        routes: [
+          {
+            controller: 'HealthController',
+            handler: 'getHealth',
+            id: 'route:health',
+            kind: 'unknown',
+            method: 'GET',
+            params: [],
+            path: '/health',
+          },
+        ],
+      },
+    };
+
+    expect(isStudioLiveEvent(event)).toBe(false);
+    expect(() => parseStudioLiveEvent(JSON.stringify(event))).toThrow(
+      'Invalid Studio live route descriptor kind payload.',
+    );
+  });
+
+  it('defaults omitted route kinds to http in legacy live snapshots', () => {
+    const event = {
+      ...liveEvents[0],
+      payload: {
+        ...liveEvents[0].payload,
+        routes: [
+          {
+            controller: 'LegacyController',
+            handler: 'getHealth',
+            id: 'route:legacy',
+            method: 'GET',
+            path: '/legacy',
+          },
+        ],
+      },
+    };
+
+    expect(parseStudioLiveEvent(JSON.stringify(event))).toMatchObject({
+      payload: { routes: [{ kind: 'http' }] },
+    });
+  });
+
   it('rejects body-like request fields before Studio state can retain them', () => {
     const bodyLikeFields = ['body', 'headers', 'payload', 'rawBody', 'requestBody', 'responseBody'] as const;
 

--- a/tooling/governance/react-page-catalog-contract.mjs
+++ b/tooling/governance/react-page-catalog-contract.mjs
@@ -11,7 +11,12 @@ const sourceRequirements = [
   ['packages/cli/src/commands/inspect.ts', ['createRuntimeInspectionSnapshot', 'describeRoutes']],
   [
     'packages/studio/src/contracts.ts',
-    ['StudioRouteDescriptor', 'kind: value.kind === undefined', "? 'http'", 'params: params === undefined ? []'],
+    [
+      'StudioRouteDescriptor',
+      "kind !== undefined && kind !== 'http' && kind !== 'react-page'",
+      "kind: kind ?? 'http'",
+      'params: params === undefined ? []',
+    ],
   ],
 ];
 


### PR DESCRIPTION
## Summary

Reject unknown supplied Studio route kinds instead of silently presenting them as ordinary HTTP diagnostics. Preserve the documented legacy fallback to `http` when `kind` is omitted.

Linked context: Closes #2905

## Changes

- narrow `StudioRouteDescriptor.kind` to `http | react-page`
- validate supplied route kinds in static and live Studio artifacts
- preserve omitted-kind normalization to `http`
- add static/live regression coverage
- add an `@fluojs/studio` patch Changeset

## Testing

- `pnpm --filter @fluojs/studio test` (67 tests passed)
- `pnpm --filter @fluojs/studio typecheck`
- `pnpm --filter @fluojs/studio build`
- `pnpm verify:changeset-release-lane`
- changed-file LSP diagnostics: clean

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Patch Changeset: `.changeset/reject-unknown-studio-route-kinds.md`.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No exported function signatures changed. The existing interface documentation already describes the route descriptor; this PR narrows its documented field type to the existing closed contract.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

The package README and governed toolchain docs already define the intended `http | react-page` contract, so no documentation correction is required.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests.

No platform or governance documents changed. Static and live parser tests provide the regression evidence for the existing Studio contract.