### PR TITLE
Resolve #2915: protect Mongoose session isolation and cancellation

### DIFF
--- a/packages/mongoose/src/session-isolation.test.ts
+++ b/packages/mongoose/src/session-isolation.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+
+import { MongooseConnection } from './index.js';
+import type { MongooseModelFacade, MongooseSessionLike } from './types.js';
+
+type Branch = 'first' | 'second';
+
+function createFakeSession(branch: Branch, events: string[]): MongooseSessionLike {
+  return {
+    abortTransaction() {
+      events.push(`${branch}:transaction:abort`);
+    },
+    commitTransaction() {
+      events.push(`${branch}:transaction:commit`);
+    },
+    endSession() {
+      events.push(`${branch}:session:end`);
+    },
+    startTransaction() {
+      events.push(`${branch}:transaction:start`);
+    },
+  };
+}
+
+describe('MongooseConnection session isolation', () => {
+  it('keeps overlapping async branches bound to their own ambient and facade sessions', async () => {
+    // Given
+    const events: string[] = [];
+    const firstSession = createFakeSession('first', events);
+    const secondSession = createFakeSession('second', events);
+    const sessions = [firstSession, secondSession] as const;
+    const operationSessions: Array<{
+      readonly branch: Branch;
+      readonly session: MongooseSessionLike | undefined;
+    }> = [];
+    const UserModel = {
+      async create(
+        docs: readonly [{ readonly branch: Branch }],
+        options?: { readonly session?: MongooseSessionLike },
+      ): Promise<readonly []> {
+        operationSessions.push({ branch: docs[0].branch, session: options?.session });
+
+        return [];
+      },
+    };
+    let sessionIndex = 0;
+    const connection = {
+      model() {
+        return UserModel;
+      },
+      async startSession(): Promise<MongooseSessionLike> {
+        const session = sessions[sessionIndex];
+        sessionIndex += 1;
+
+        if (session === undefined) {
+          throw new RangeError('The test connection only provides two sessions.');
+        }
+
+        return session;
+      },
+    };
+    const mongoose = new MongooseConnection(connection);
+    let enteredBranches = 0;
+    let releaseOverlap: () => void = () => undefined;
+    const branchesOverlapping = new Promise<void>((resolve) => {
+      releaseOverlap = resolve;
+    });
+    const runBranch = (branch: Branch) =>
+      mongoose.transaction(async () => {
+        const ambientBeforeOverlap = mongoose.currentSession();
+        enteredBranches += 1;
+
+        if (enteredBranches === sessions.length) {
+          releaseOverlap();
+        }
+
+        await branchesOverlapping;
+
+        const ambientAfterOverlap = mongoose.currentSession();
+        await mongoose.model<MongooseModelFacade<Promise<readonly []>>>('User').create([{ branch }]);
+
+        return { ambientAfterOverlap, ambientBeforeOverlap };
+      });
+
+    // When
+    const [firstResult, secondResult] = await Promise.all([
+      runBranch('first'),
+      runBranch('second'),
+    ]);
+
+    // Then
+    expect(firstResult).toEqual({
+      ambientAfterOverlap: firstSession,
+      ambientBeforeOverlap: firstSession,
+    });
+    expect(secondResult).toEqual({
+      ambientAfterOverlap: secondSession,
+      ambientBeforeOverlap: secondSession,
+    });
+    expect(operationSessions).toHaveLength(2);
+    expect(operationSessions).toEqual(expect.arrayContaining([
+      { branch: 'first', session: firstSession },
+      { branch: 'second', session: secondSession },
+    ]));
+    expect(mongoose.currentSession()).toBeUndefined();
+    expect(events).toHaveLength(6);
+    expect(events).toEqual(expect.arrayContaining([
+      'first:transaction:start',
+      'first:transaction:commit',
+      'first:session:end',
+      'second:transaction:start',
+      'second:transaction:commit',
+      'second:session:end',
+    ]));
+  });
+});

--- a/packages/mongoose/src/transaction-interceptor-compat.test.ts
+++ b/packages/mongoose/src/transaction-interceptor-compat.test.ts
@@ -171,6 +171,7 @@ describe('MongooseTransactionInterceptor compatibility', () => {
 
       // When
       controller.abort(new Error('compatibility caller cancelled'));
+      await new Promise<void>((resolve) => setImmediate(resolve));
 
       // Then
       expect(events).toEqual(['session:start', 'transaction:start', 'handler:start:true']);

--- a/packages/mongoose/src/transaction-interceptor-compat.test.ts
+++ b/packages/mongoose/src/transaction-interceptor-compat.test.ts
@@ -1,7 +1,15 @@
 import { Inject } from '@fluojs/core';
-import { type FrameworkRequest, type FrameworkResponse, Get, UseInterceptors } from '@fluojs/http';
+import {
+  type CallHandler,
+  type FrameworkRequest,
+  type FrameworkResponse,
+  Get,
+  type Interceptor,
+  type InterceptorContext,
+  UseInterceptors,
+} from '@fluojs/http';
 import { bootstrapApplication, defineModule } from '@fluojs/runtime';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { MongooseConnection, MongooseModule, MongooseTransactionInterceptor } from './index.js';
 import type { MongooseSessionLike } from './types.js';
@@ -78,6 +86,123 @@ describe('MongooseTransactionInterceptor compatibility', () => {
       expect(response.body).toBe(true);
       expect(events).toEqual(['session:start', 'transaction:start', 'handler', 'transaction:commit', 'session:end']);
     } finally {
+      await app.close();
+    }
+  });
+
+  it('rejects a cancelled routed caller and cleans up the compatibility transaction', async () => {
+    // Given
+    const events: string[] = [];
+    let notifyHandlerStarted: () => void = () => undefined;
+    let releaseHandler: () => void = () => undefined;
+    let notifySessionEnded: () => void = () => undefined;
+    const handlerStarted = new Promise<void>((resolve) => {
+      notifyHandlerStarted = resolve;
+    });
+    const handlerReleased = new Promise<void>((resolve) => {
+      releaseHandler = resolve;
+    });
+    const sessionEnded = new Promise<void>((resolve) => {
+      notifySessionEnded = resolve;
+    });
+    const session: MongooseSessionLike = {
+      abortTransaction() {
+        events.push('transaction:abort');
+      },
+      commitTransaction() {
+        events.push('transaction:commit');
+      },
+      endSession() {
+        events.push('session:end');
+        notifySessionEnded();
+      },
+      startTransaction() {
+        events.push('transaction:start');
+      },
+    };
+    const connection = {
+      async startSession(): Promise<MongooseSessionLike> {
+        events.push('session:start');
+        return session;
+      },
+    };
+
+    class CallerProbeInterceptor implements Interceptor {
+      async intercept(_context: InterceptorContext, next: CallHandler): Promise<unknown> {
+        try {
+          return await next.handle();
+        } catch (error) {
+          events.push(error instanceof Error ? `caller:rejected:${error.message}` : 'caller:rejected:unknown');
+          throw error;
+        }
+      }
+    }
+
+    @Inject(MongooseConnection)
+    class CompatibilityController {
+      constructor(private readonly mongoose: MongooseConnection<typeof connection>) {}
+
+      @Get('/compat')
+      @UseInterceptors(CallerProbeInterceptor, MongooseTransactionInterceptor)
+      async waitForCancellation(): Promise<string> {
+        events.push(`handler:start:${this.mongoose.currentSession() === session}`);
+        notifyHandlerStarted();
+        await handlerReleased;
+        events.push('handler:end');
+
+        return 'late-result';
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [CompatibilityController],
+      imports: [MongooseModule.forRoot({ connection })],
+      providers: [CallerProbeInterceptor],
+    });
+    const app = await bootstrapApplication({ rootModule: AppModule });
+    const mongoose = await app.container.resolve(MongooseConnection<typeof connection>);
+    const controller = new AbortController();
+
+    try {
+      const response = createResponse();
+      const dispatch = app.dispatch(createRequest(controller.signal), response);
+      await handlerStarted;
+
+      // When
+      controller.abort(new Error('compatibility caller cancelled'));
+
+      // Then
+      expect(events).toEqual(['session:start', 'transaction:start', 'handler:start:true']);
+      expect(mongoose.createPlatformStatusSnapshot()).toMatchObject({
+        details: {
+          activeRequestTransactions: 1,
+          activeSessions: 1,
+        },
+      });
+
+      releaseHandler();
+      await expect(dispatch).resolves.toBeUndefined();
+      await sessionEnded;
+      await vi.waitFor(() => {
+        expect(mongoose.createPlatformStatusSnapshot()).toMatchObject({
+          details: {
+            activeRequestTransactions: 0,
+            activeSessions: 0,
+          },
+        });
+      });
+      expect(events).toEqual([
+        'session:start',
+        'transaction:start',
+        'handler:start:true',
+        'handler:end',
+        'transaction:abort',
+        'session:end',
+        'caller:rejected:compatibility caller cancelled',
+      ]);
+    } finally {
+      releaseHandler();
       await app.close();
     }
   });


### PR DESCRIPTION
## Summary

Add deterministic regression coverage for overlapping Mongoose ALS sessions and compatibility interceptor cancellation.

Closes #2915

## Changes

- Add a controlled two-transaction overlap test that verifies ambient and facade sessions remain branch-local.
- Extend the compatibility interceptor suite with routed cancellation, rollback, session cleanup, and active-count assertions.

## Testing

- `pnpm --dir packages/mongoose test` - 88 passed, 1 skipped.
- `pnpm --dir packages/mongoose typecheck` - passed.
- Changed-file LSP diagnostics - no errors or warnings; expected deprecation hints only for compatibility coverage.
- `git diff --check origin/main...HEAD` - passed.

## Public export documentation

해당 없음. Public export 또는 declaration surface 변경이 없다.

## Behavioral contract

기존 README의 ALS session isolation 및 request cancellation 계약을 테스트로 고정한다. Runtime behavior와 문서는 변경하지 않는다.

## Platform consistency governance (SSOT)

해당 없음. Platform adapter 또는 governed SSOT 문서 변경이 없다.

## Release impact

Changeset 없음. Regression test-only 변경이며 consumer-visible API, behavior, package contents, release metadata를 변경하지 않는다.