### PR TITLE
Resolve #2902: lock Passport.js bridge terminal semantics

### DIFF
--- a/packages/passport/src/adapters/passport-js.guard.test.ts
+++ b/packages/passport/src/adapters/passport-js.guard.test.ts
@@ -1,0 +1,204 @@
+import { getModuleMetadata } from '@fluojs/core/internal';
+import { Container, type Provider } from '@fluojs/di';
+import {
+  Controller,
+  createDispatcher,
+  createHandlerMapping,
+  type FrameworkRequest,
+  type FrameworkResponse,
+  Get,
+  type GuardContext,
+} from '@fluojs/http';
+import { describe, expect, it } from 'vitest';
+
+import { RequireScopes, UseAuth } from '../decorators.js';
+import { PassportModule } from '../module.js';
+import type { AuthStrategy, AuthStrategyResult } from '../types.js';
+import { createPassportJsStrategyBridge } from './passport-js.js';
+
+function createPassportModuleProviders(
+  options: Parameters<typeof PassportModule.forRoot>[0],
+  strategies: Parameters<typeof PassportModule.forRoot>[1],
+): Provider[] {
+  const metadata = getModuleMetadata(PassportModule.forRoot(options, strategies)) as {
+    providers?: Provider[];
+  };
+
+  if (!Array.isArray(metadata.providers)) {
+    throw new Error('Expected PassportModule.forRoot(...) to expose runtime providers.');
+  }
+
+  return metadata.providers;
+}
+
+function createRequest(path: string, headers: FrameworkRequest['headers'] = {}): FrameworkRequest {
+  return {
+    body: undefined,
+    cookies: {},
+    headers,
+    method: 'GET',
+    params: {},
+    path,
+    query: {},
+    raw: {},
+    url: path,
+  };
+}
+
+function createResponse(): FrameworkResponse & { body?: unknown } {
+  return {
+    committed: false,
+    headers: {},
+    redirect(status: number, location: string) {
+      this.setStatus(status);
+      this.setHeader('Location', location);
+      this.committed = true;
+    },
+    send(body: unknown) {
+      this.body = body;
+      this.committed = true;
+    },
+    setHeader(name: string, value: string | string[]) {
+      this.headers[name] = value;
+    },
+    setStatus(code: number) {
+      this.statusCode = code;
+      this.statusSet = true;
+    },
+    statusCode: undefined,
+    statusSet: false,
+  };
+}
+
+describe('Passport.js bridge guard terminal semantics', () => {
+  it.each([
+    { claims: null, label: 'null' },
+    { claims: [], label: 'array' },
+    { claims: 'scalar', label: 'scalar' },
+  ])('rejects custom mapper principals with $label claims through the canonical auth path', async ({
+    claims,
+    label,
+  }) => {
+    // Given
+    class PassportLikeInvalidClaimsStrategy {
+      success?: (user: unknown, info?: unknown) => void;
+
+      authenticate() {
+        this.success?.({ id: 'google-user-1' });
+      }
+    }
+
+    const mappedPrincipal = { claims: {}, subject: 'mapped-user' };
+    Object.defineProperty(mappedPrincipal, 'claims', { value: claims });
+    const bridge = createPassportJsStrategyBridge('google-invalid-claims', PassportLikeInvalidClaimsStrategy, {
+      mapPrincipal: () => mappedPrincipal,
+    });
+
+    @Controller('/oauth')
+    class ProtectedController {
+      @Get('/profile')
+      @UseAuth('google-invalid-claims')
+      getProfile() {
+        return { ok: true };
+      }
+    }
+
+    const root = new Container().register(
+      ProtectedController,
+      PassportLikeInvalidClaimsStrategy,
+      ...bridge.providers,
+      ...createPassportModuleProviders({ defaultStrategy: 'google-invalid-claims' }, [bridge.strategy]),
+    );
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: ProtectedController }]),
+      rootContainer: root,
+    });
+    const response = createResponse();
+
+    // When
+    await dispatcher.dispatch(
+      createRequest('/oauth/profile', { 'x-request-id': `req-invalid-${label}-claims` }),
+      response,
+    );
+
+    // Then
+    expect(response.statusCode).toBe(401);
+    expect(response.body).toEqual({
+      error: {
+        code: 'UNAUTHORIZED',
+        details: undefined,
+        message: 'Authentication required.',
+        meta: undefined,
+        requestId: `req-invalid-${label}-claims`,
+        status: 401,
+      },
+    });
+  });
+
+  it('skips principal assignment, failing scopes, and the handler for a committed handled result', async () => {
+    // Given
+    let handlerCalled = false;
+    let handledRequestContext: GuardContext['requestContext'] | undefined;
+    let scopeReads = 0;
+    const principal = new Proxy(
+      {
+        claims: { source: 'handled' },
+        scopes: [],
+        subject: 'handled-user',
+      },
+      {
+        get(target, property, receiver) {
+          if (property === 'scopes') {
+            scopeReads += 1;
+          }
+
+          return Reflect.get(target, property, receiver);
+        },
+      },
+    );
+
+    class CommittedHandledStrategy implements AuthStrategy {
+      async authenticate(context: GuardContext): Promise<AuthStrategyResult> {
+        handledRequestContext = context.requestContext;
+        context.requestContext.response.setStatus(202);
+        context.requestContext.response.send({ outcome: 'strategy' });
+
+        return { handled: true, principal };
+      }
+    }
+
+    @Controller('/protected')
+    class ProtectedController {
+      @Get('/')
+      @UseAuth('handled')
+      @RequireScopes('profile:read')
+      getResource() {
+        handlerCalled = true;
+        return { ok: true };
+      }
+    }
+
+    const root = new Container().register(
+      ProtectedController,
+      CommittedHandledStrategy,
+      ...createPassportModuleProviders({ defaultStrategy: 'handled' }, [
+        { name: 'handled', token: CommittedHandledStrategy },
+      ]),
+    );
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: ProtectedController }]),
+      rootContainer: root,
+    });
+    const response = createResponse();
+
+    // When
+    await dispatcher.dispatch(createRequest('/protected'), response);
+
+    // Then
+    expect(scopeReads).toBe(0);
+    expect(handledRequestContext?.principal).toBeUndefined();
+    expect(handlerCalled).toBe(false);
+    expect(response.statusCode).toBe(202);
+    expect(response.body).toEqual({ outcome: 'strategy' });
+  });
+});

--- a/packages/passport/src/adapters/passport-js.test.ts
+++ b/packages/passport/src/adapters/passport-js.test.ts
@@ -164,13 +164,20 @@ describe('PassportJsAuthStrategy terminal actions', () => {
   it('settles once with success when fail follows success', async () => {
     // Given
     vi.useFakeTimers();
+    let challengeMessageReads = 0;
+    const lateChallenge = {
+      get message() {
+        challengeMessageReads += 1;
+        return 'late failure';
+      },
+    };
     class SuccessThenFailStrategy implements PassportJsStrategyLike {
       fail?: (challenge?: unknown, status?: number) => void;
       success?: (user: unknown) => void;
 
       authenticate(): void {
         this.success?.({ id: 'passport-user' });
-        this.fail?.('late failure', 401);
+        this.fail?.(lateChallenge, 401);
       }
     }
     const mapPrincipal = vi.fn(() => ({ claims: {}, subject: 'passport-user' }));
@@ -189,6 +196,7 @@ describe('PassportJsAuthStrategy terminal actions', () => {
     expect(principal).toEqual({ claims: {}, subject: 'passport-user' });
     expect(mapPrincipal).toHaveBeenCalledTimes(1);
     expect(settlement).toHaveBeenCalledTimes(1);
+    expect(challengeMessageReads).toBe(0);
     expect(vi.getTimerCount()).toBe(0);
   });
 

--- a/packages/passport/src/adapters/passport-js.test.ts
+++ b/packages/passport/src/adapters/passport-js.test.ts
@@ -102,6 +102,23 @@ describe('PassportJsAuthStrategy action timeout', () => {
     expect(vi.getTimerCount()).toBe(0);
   });
 
+  it('uses the 30,000 ms default and clears the timer after timeout settlement', async () => {
+    // Given
+    vi.useFakeTimers();
+    const strategy = new PassportJsAuthStrategy(new UnsettledStrategy());
+
+    // When
+    const authentication = strategy.authenticate(createGuardContext());
+    const rejection = expect(authentication).rejects.toThrow(AuthenticationRequiredError);
+    await vi.advanceTimersByTimeAsync(29_999);
+
+    // Then
+    expect(vi.getTimerCount()).toBe(1);
+    await vi.advanceTimersByTimeAsync(1);
+    await rejection;
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
   it('clears the pending action timeout after successful strategy settlement', async () => {
     // Given
     vi.useFakeTimers();
@@ -112,7 +129,7 @@ describe('PassportJsAuthStrategy action timeout', () => {
         this.success?.({ id: 'passport-user' });
       }
     }
-    const strategy = new PassportJsAuthStrategy(new SuccessfulStrategy(), { actionTimeoutMs: 1_000 });
+    const strategy = new PassportJsAuthStrategy(new SuccessfulStrategy());
 
     // When
     const principal = await strategy.authenticate(createGuardContext());
@@ -139,6 +156,69 @@ describe('PassportJsAuthStrategy action timeout', () => {
 
     // Then
     await expect(authentication).rejects.toThrow(AuthenticationRequiredError);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});
+
+describe('PassportJsAuthStrategy terminal actions', () => {
+  it('settles once with success when fail follows success', async () => {
+    // Given
+    vi.useFakeTimers();
+    class SuccessThenFailStrategy implements PassportJsStrategyLike {
+      fail?: (challenge?: unknown, status?: number) => void;
+      success?: (user: unknown) => void;
+
+      authenticate(): void {
+        this.success?.({ id: 'passport-user' });
+        this.fail?.('late failure', 401);
+      }
+    }
+    const mapPrincipal = vi.fn(() => ({ claims: {}, subject: 'passport-user' }));
+    const strategy = new PassportJsAuthStrategy(new SuccessThenFailStrategy(), {
+      actionTimeoutMs: 1_000,
+      mapPrincipal,
+    });
+
+    // When
+    const authentication = strategy.authenticate(createGuardContext());
+    const settlement = vi.fn();
+    void authentication.then(settlement, settlement);
+    const principal = await authentication;
+
+    // Then
+    expect(principal).toEqual({ claims: {}, subject: 'passport-user' });
+    expect(mapPrincipal).toHaveBeenCalledTimes(1);
+    expect(settlement).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('settles once with failure when success follows fail', async () => {
+    // Given
+    vi.useFakeTimers();
+    class FailThenSuccessStrategy implements PassportJsStrategyLike {
+      fail?: (challenge?: unknown, status?: number) => void;
+      success?: (user: unknown) => void;
+
+      authenticate(): void {
+        this.fail?.('credentials rejected', 401);
+        this.success?.({ id: 'late-user' });
+      }
+    }
+    const mapPrincipal = vi.fn(() => ({ claims: {}, subject: 'late-user' }));
+    const strategy = new PassportJsAuthStrategy(new FailThenSuccessStrategy(), {
+      actionTimeoutMs: 1_000,
+      mapPrincipal,
+    });
+
+    // When
+    const authentication = strategy.authenticate(createGuardContext());
+    const settlement = vi.fn();
+    void authentication.then(settlement, settlement);
+
+    // Then
+    await expect(authentication).rejects.toThrow('credentials rejected');
+    expect(mapPrincipal).not.toHaveBeenCalled();
+    expect(settlement).toHaveBeenCalledTimes(1);
     expect(vi.getTimerCount()).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
Add executable regression coverage for the documented Passport.js bridge terminal-state contract without changing runtime behavior.

Closes #2902

## Changes
- lock the 30,000 ms default action timeout and timer cleanup
- verify competing Passport actions settle exactly once
- reject custom mapper principals with null, array, or scalar claims through canonical dispatch
- verify committed handled results skip principal assignment, scope checks, and protected handler execution

## Testing
- `pnpm --dir packages/passport test` (120 tests passed)
- `pnpm --dir packages/passport typecheck`
- changed-file diagnostics and `git diff --check origin/main...HEAD`
- repeated after rebasing onto current `origin/main`

## Public export documentation
Not applicable. No public exports or TSDoc surfaces changed.

## Behavioral contract
Preserves the existing documented Passport.js bridge contract and adds direct regression evidence at strategy and request-dispatch seams.

No changeset is required because the change is test-only and does not affect consumer-visible behavior, API surface, package contents, or release metadata.

## Platform consistency governance (SSOT)
Not applicable. No platform adapter, runtime matrix, governed docs, or environment-isolation behavior changed.