### PR TITLE
Resolve #2913: strengthen Prisma transaction regression coverage

### DIFF
--- a/packages/prisma/src/module-global-visibility.test.ts
+++ b/packages/prisma/src/module-global-visibility.test.ts
@@ -1,0 +1,84 @@
+import { Inject } from '@fluojs/core';
+import { bootstrapApplication, defineModule } from '@fluojs/runtime';
+import { describe, expect, it } from 'vitest';
+
+import {
+  getPrismaServiceToken,
+  PRISMA_CLIENT,
+  PRISMA_OPTIONS,
+  PrismaModule,
+  PrismaService,
+  PrismaTransactionInterceptor,
+} from './index.js';
+
+describe('PrismaModule.forRootAsync global visibility', () => {
+  it('makes unnamed providers and tokens visible to a sibling module', async () => {
+    // Given
+    const events: string[] = [];
+    const transactionClient = {};
+    const client = {
+      async $connect() {
+        events.push('connect');
+      },
+      async $disconnect() {
+        events.push('disconnect');
+      },
+      async $transaction<T>(callback: (value: typeof transactionClient) => Promise<T>): Promise<T> {
+        return callback(transactionClient);
+      },
+    };
+
+    @Inject(PrismaService, PrismaTransactionInterceptor)
+    class ProviderConsumer {
+      constructor(
+        readonly prisma: PrismaService<typeof client, typeof transactionClient>,
+        readonly interceptor: PrismaTransactionInterceptor,
+      ) {}
+    }
+
+    @Inject(PRISMA_CLIENT, PRISMA_OPTIONS, getPrismaServiceToken())
+    class TokenConsumer {
+      constructor(
+        readonly rawClient: typeof client,
+        readonly options: { readonly strictTransactions: boolean },
+        readonly prisma: PrismaService<typeof client, typeof transactionClient>,
+      ) {}
+    }
+
+    class FeatureModule {}
+    defineModule(FeatureModule, {
+      exports: [ProviderConsumer, TokenConsumer],
+      providers: [ProviderConsumer, TokenConsumer],
+    });
+
+    const prismaModule = PrismaModule.forRootAsync<typeof client, typeof transactionClient>({
+      global: true,
+      useFactory: () => ({ client }),
+    });
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [prismaModule, FeatureModule],
+    });
+
+    // When
+    const app = await bootstrapApplication({ rootModule: AppModule });
+
+    try {
+      const providerConsumer = await app.container.resolve(ProviderConsumer);
+      const tokenConsumer = await app.container.resolve(TokenConsumer);
+
+      // Then
+      expect(providerConsumer.prisma.current()).toBe(client);
+      expect(providerConsumer.interceptor).toBeInstanceOf(PrismaTransactionInterceptor);
+      expect(tokenConsumer.rawClient).toBe(client);
+      expect(tokenConsumer.options).toEqual({ strictTransactions: false });
+      expect(tokenConsumer.prisma).toBe(providerConsumer.prisma);
+      expect(events).toEqual(['connect']);
+    } finally {
+      await app.close();
+    }
+
+    expect(events).toEqual(['connect', 'disconnect']);
+  });
+});

--- a/packages/prisma/src/shutdown-drain-status.test.ts
+++ b/packages/prisma/src/shutdown-drain-status.test.ts
@@ -1,0 +1,102 @@
+import { bootstrapApplication, defineModule } from '@fluojs/runtime';
+import { describe, expect, it } from 'vitest';
+
+import { PrismaModule, PrismaService } from './index.js';
+
+describe('Prisma request transaction shutdown status', () => {
+  it('reports the pending request transaction until shutdown cleanup settles', async () => {
+    // Given
+    const events: string[] = [];
+    let notifyTransactionStarted: () => void = () => undefined;
+    let notifyRollbackStarted: () => void = () => undefined;
+    let releaseRollback: () => void = () => undefined;
+    const transactionStarted = new Promise<void>((resolve) => {
+      notifyTransactionStarted = resolve;
+    });
+    const rollbackStarted = new Promise<void>((resolve) => {
+      notifyRollbackStarted = resolve;
+    });
+    const rollbackReleased = new Promise<void>((resolve) => {
+      releaseRollback = resolve;
+    });
+    const transactionClient = {};
+    const client = {
+      async $connect() {
+        events.push('connect');
+      },
+      async $disconnect() {
+        events.push('disconnect');
+      },
+      async $transaction<T>(callback: (value: typeof transactionClient) => Promise<T>): Promise<T> {
+        events.push('transaction:start');
+        notifyTransactionStarted();
+
+        try {
+          return await callback(transactionClient);
+        } catch (error) {
+          events.push('transaction:rollback:pending');
+          notifyRollbackStarted();
+          await rollbackReleased;
+          events.push('transaction:rollback:done');
+          throw error;
+        } finally {
+          events.push('transaction:end');
+        }
+      },
+    };
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [PrismaModule.forRoot<typeof client, typeof transactionClient>({ client })],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+    const prisma = await app.container.resolve(PrismaService<typeof client, typeof transactionClient>);
+    const openTransaction = prisma.requestTransaction(async () => new Promise<never>(() => undefined));
+    const openTransactionResult = expect(openTransaction).rejects.toThrow(
+      'Application shutdown interrupted an open request transaction.',
+    );
+    let shutdown: Promise<void> | undefined;
+
+    try {
+      await transactionStarted;
+
+      // When
+      shutdown = app.close();
+      await rollbackStarted;
+
+      // Then
+      expect(prisma.createPlatformStatusSnapshot()).toMatchObject({
+        details: {
+          activeRequestTransactions: 1,
+          lifecycleState: 'shutting-down',
+        },
+        health: { status: 'degraded' },
+        readiness: { status: 'not-ready' },
+      });
+      expect(events).toEqual(['connect', 'transaction:start', 'transaction:rollback:pending']);
+
+      releaseRollback();
+      await openTransactionResult;
+      await shutdown;
+
+      expect(prisma.createPlatformStatusSnapshot()).toMatchObject({
+        details: {
+          activeRequestTransactions: 0,
+          lifecycleState: 'stopped',
+        },
+      });
+      expect(events).toEqual([
+        'connect',
+        'transaction:start',
+        'transaction:rollback:pending',
+        'transaction:rollback:done',
+        'transaction:end',
+        'disconnect',
+      ]);
+    } finally {
+      releaseRollback();
+      await Promise.allSettled([openTransaction, shutdown ?? app.close()]);
+    }
+  });
+});

--- a/packages/prisma/src/transaction-interceptor-compat.test.ts
+++ b/packages/prisma/src/transaction-interceptor-compat.test.ts
@@ -1,7 +1,15 @@
 import { Inject } from '@fluojs/core';
-import { type FrameworkRequest, type FrameworkResponse, Get, UseInterceptors } from '@fluojs/http';
+import {
+  type CallHandler,
+  type FrameworkRequest,
+  type FrameworkResponse,
+  Get,
+  type Interceptor,
+  type InterceptorContext,
+  UseInterceptors,
+} from '@fluojs/http';
 import { bootstrapApplication, defineModule } from '@fluojs/runtime';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { PrismaModule, PrismaService, PrismaTransactionInterceptor } from './index.js';
 
@@ -75,6 +83,144 @@ describe('PrismaTransactionInterceptor compatibility', () => {
       expect(response.body).toBe('transaction');
       expect(events).toEqual(['transaction:start', 'handler', 'transaction:end']);
     } finally {
+      await app.close();
+    }
+  });
+
+  it('forwards routed cancellation to the transaction boundary and waits for cleanup', async () => {
+    // Given
+    const events: string[] = [];
+    let notifyHandlerStarted: () => void = () => undefined;
+    let releaseHandler: () => void = () => undefined;
+    let notifyHandlerFinished: () => void = () => undefined;
+    let releaseTransactionCleanup: () => void = () => undefined;
+    const handlerStarted = new Promise<void>((resolve) => {
+      notifyHandlerStarted = resolve;
+    });
+    const handlerReleased = new Promise<void>((resolve) => {
+      releaseHandler = resolve;
+    });
+    const handlerFinished = new Promise<void>((resolve) => {
+      notifyHandlerFinished = resolve;
+    });
+    const transactionCleanupReleased = new Promise<void>((resolve) => {
+      releaseTransactionCleanup = resolve;
+    });
+    const transactionClient = { source: 'transaction' } as const;
+    const client = {
+      source: 'root' as const,
+      async $transaction<T>(
+        callback: (value: typeof transactionClient) => Promise<T>,
+        options?: { signal?: AbortSignal },
+      ): Promise<T> {
+        events.push('transaction:start');
+        const signal = options?.signal;
+
+        if (!signal) {
+          events.push('transaction:no-signal');
+          return callback(transactionClient);
+        }
+
+        events.push('transaction:signal');
+        const onAbort = () => {
+          const reason = signal.reason;
+          events.push(`transaction:abort:${reason instanceof Error ? reason.message : 'unknown'}`);
+        };
+        signal.addEventListener('abort', onAbort, { once: true });
+
+        try {
+          return await callback(transactionClient);
+        } finally {
+          signal.removeEventListener('abort', onAbort);
+          events.push('transaction:cleanup:pending');
+          await transactionCleanupReleased;
+          events.push('transaction:cleanup:done');
+        }
+      },
+    };
+
+    class CallerProbeInterceptor implements Interceptor {
+      async intercept(_context: InterceptorContext, next: CallHandler): Promise<unknown> {
+        try {
+          return await next.handle();
+        } catch (error) {
+          events.push(error instanceof Error ? `caller:rejected:${error.message}` : 'caller:rejected:unknown');
+          throw error;
+        }
+      }
+    }
+
+    @Inject(PrismaService)
+    class CompatibilityController {
+      constructor(private readonly prisma: PrismaService<typeof client, typeof transactionClient>) {}
+
+      @Get('/compat')
+      @UseInterceptors(CallerProbeInterceptor, PrismaTransactionInterceptor)
+      async waitForCancellation(): Promise<string> {
+        events.push(`handler:start:${this.prisma.current().source}`);
+        notifyHandlerStarted();
+        await handlerReleased;
+        events.push('handler:end');
+        notifyHandlerFinished();
+
+        return 'late-result';
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [CompatibilityController],
+      imports: [
+        PrismaModule.forRoot<typeof client, typeof transactionClient, { signal?: AbortSignal }>({ client }),
+      ],
+      providers: [CallerProbeInterceptor],
+    });
+    const app = await bootstrapApplication({ rootModule: AppModule });
+    const prisma = await app.container.resolve(
+      PrismaService<typeof client, typeof transactionClient, { signal?: AbortSignal }>,
+    );
+    const controller = new AbortController();
+
+    try {
+      const response = createResponse();
+      const dispatch = app.dispatch(createRequest(controller.signal), response);
+      await handlerStarted;
+
+      // When
+      controller.abort(new Error('compatibility caller cancelled'));
+      await vi.waitFor(() => expect(events).toContain('transaction:cleanup:pending'));
+
+      // Then
+      expect(events).toEqual([
+        'transaction:start',
+        'transaction:signal',
+        'handler:start:transaction',
+        'transaction:abort:compatibility caller cancelled',
+        'transaction:cleanup:pending',
+      ]);
+      expect(prisma.createPlatformStatusSnapshot().details).toMatchObject({ activeRequestTransactions: 1 });
+
+      releaseTransactionCleanup();
+      await expect(dispatch).resolves.toBeUndefined();
+      await vi.waitFor(() => {
+        expect(prisma.createPlatformStatusSnapshot().details).toMatchObject({ activeRequestTransactions: 0 });
+      });
+      expect(events).toEqual([
+        'transaction:start',
+        'transaction:signal',
+        'handler:start:transaction',
+        'transaction:abort:compatibility caller cancelled',
+        'transaction:cleanup:pending',
+        'transaction:cleanup:done',
+        'caller:rejected:compatibility caller cancelled',
+      ]);
+
+      releaseHandler();
+      await handlerFinished;
+      expect(events.at(-1)).toBe('handler:end');
+    } finally {
+      releaseHandler();
+      releaseTransactionCleanup();
       await app.close();
     }
   });


### PR DESCRIPTION
## Summary

Add deterministic regression coverage for Prisma interceptor cancellation, shutdown-drain status, and async global provider visibility.

Closes #2913

## Changes

- Verify routed cancellation reaches the Prisma transaction signal and waits for cleanup.
- Verify shutdown status remains not-ready/degraded with one active request transaction until rollback settles.
- Verify unnamed `forRootAsync({ global: true })` providers and public tokens resolve from a sibling consumer module.

## Testing

- `pnpm --dir packages/prisma test` - 63 passed.
- `pnpm --dir packages/prisma typecheck` - passed.
- Changed-file LSP diagnostics - no errors or warnings; expected deprecation hints only for compatibility coverage.
- `git diff --check origin/main...HEAD` - passed.

## Public export documentation

해당 없음. Public export 또는 declaration surface 변경이 없다.

## Behavioral contract

기존 README의 cancellation, shutdown status, global visibility 계약을 테스트로 고정한다. Runtime behavior와 문서는 변경하지 않는다.

## Platform consistency governance (SSOT)

해당 없음. Platform adapter 또는 governed SSOT 문서 변경이 없다.

## Release impact

Changeset 없음. Regression test-only 변경이며 consumer-visible API, behavior, package contents, release metadata를 변경하지 않는다.