### PR TITLE
Resolve #2903: cover zero-candidate conservative account linking

### DIFF
--- a/packages/passport/src/account/account-linking.test.ts
+++ b/packages/passport/src/account/account-linking.test.ts
@@ -2,10 +2,10 @@ import { describe, expect, it } from 'vitest';
 
 import {
   AccountLinkConflictError,
+  type AccountLinkContext,
   AccountLinkRejectedError,
   createConservativeAccountLinkPolicy,
   resolveAccountLinking,
-  type AccountLinkContext,
 } from './account-linking.js';
 
 function createContext(overrides: Partial<AccountLinkContext> = {}): AccountLinkContext {
@@ -47,6 +47,15 @@ describe('resolveAccountLinking', () => {
       accountId: 'account-1',
       reason: 'Identity linked after explicit user confirmation.',
       status: 'linked',
+    });
+  });
+
+  it('creates an account when the conservative policy finds no candidates', async () => {
+    const result = await resolveAccountLinking(createContext(), createConservativeAccountLinkPolicy());
+
+    expect(result).toEqual({
+      reason: 'No matching account candidate found for this external identity.',
+      status: 'create-account',
     });
   });
 


### PR DESCRIPTION
## Summary

Add executable regression evidence for the documented conservative account-linking outcome when no candidate accounts exist.

Linked context: Closes #2903

## Changes

- Add a focused `createConservativeAccountLinkPolicy(...)` test with zero candidates.
- Assert the normalized `create-account` resolution and documented reason.

## Testing

- `pnpm test -- src/account/account-linking.test.ts` (11 files, 121 tests passed)
- `pnpm typecheck` (`@fluojs/passport`)
- `pnpm exec biome check packages/passport/src/account/account-linking.test.ts`
- `pnpm --filter @fluojs/passport... build`
- `git diff --check origin/main...HEAD`

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

Test-only contract preservation; no published behavior, API surface, package contents, or release metadata changes. No changeset is required.

## Public export documentation

- [x] Not applicable: no public exports changed.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

This PR adds direct executable evidence for the existing `packages/passport/README.md` account-linking contract; runtime behavior and documentation remain unchanged.

## Platform consistency governance (SSOT)

- [x] Not applicable: no governance, platform contract, package README, or adapter conformance surfaces changed.