### PR TITLE
Resolve #2911: cover SSE abort and request-scope teardown lifecycle

### DIFF
--- a/packages/graphql/src/sse-lifecycle.test.ts
+++ b/packages/graphql/src/sse-lifecycle.test.ts
@@ -13,17 +13,63 @@ describe('GraphQL SSE lifecycle', () => {
   it('finalizes the AsyncIterable and destroys its request scope once when the client aborts', async () => {
     // Given
     let iteratorFinalizations = 0;
+    let iteratorReturns = 0;
     let providerTeardowns = 0;
     let requestAbortObserved = false;
     const expectExactlyOnceAbortLifecycle = (): void => {
       expect(requestAbortObserved).toBe(true);
       expect(iteratorFinalizations).toBe(1);
+      expect(iteratorReturns).toBe(1);
       expect(providerTeardowns).toBe(1);
     };
-    let releaseResolver: (() => void) | undefined;
-    const resolverRelease = new Promise<void>((resolve) => {
-      releaseResolver = resolve;
-    });
+
+    class BlockingSseIterator implements AsyncIterableIterator<string> {
+      private completed = false;
+      private deliveredFirstEvent = false;
+      private pendingNext: ((result: IteratorResult<string, void>) => void) | undefined;
+
+      [Symbol.asyncIterator](): AsyncIterableIterator<string> {
+        return this;
+      }
+
+      next(): Promise<IteratorResult<string, void>> {
+        if (this.completed) {
+          return Promise.resolve({ done: true, value: undefined });
+        }
+
+        if (!this.deliveredFirstEvent) {
+          this.deliveredFirstEvent = true;
+          return Promise.resolve({ done: false, value: 'connected' });
+        }
+
+        return new Promise((resolve) => {
+          this.pendingNext = resolve;
+        });
+      }
+
+      return(): Promise<IteratorResult<string, void>> {
+        iteratorReturns += 1;
+
+        if (!this.completed) {
+          iteratorFinalizations += 1;
+          this.release();
+        }
+
+        return Promise.resolve({ done: true, value: undefined });
+      }
+
+      release(): void {
+        if (this.completed) {
+          return;
+        }
+
+        this.completed = true;
+        this.pendingNext?.({ done: true, value: undefined });
+        this.pendingNext = undefined;
+      }
+    }
+
+    let activeIterator: BlockingSseIterator | undefined;
 
     @Inject()
     @Scope('request')
@@ -42,32 +88,23 @@ describe('GraphQL SSE lifecycle', () => {
       }
 
       @Subscription()
-      async *blockingEvents(_input: undefined, context: GraphQLContext): AsyncGenerator<string, void, void> {
+      blockingEvents(_input: undefined, context: GraphQLContext): AsyncIterable<string> {
         const requestSignal = context.request.signal;
 
         if (!requestSignal) {
           throw new Error('Expected the Node HTTP request to expose an abort signal.');
         }
 
-        const clientAbort = new Promise<void>((resolve) => {
-          if (requestSignal.aborted) {
-            requestAbortObserved = true;
-            resolve();
-            return;
-          }
-
+        if (requestSignal.aborted) {
+          requestAbortObserved = true;
+        } else {
           requestSignal.addEventListener('abort', () => {
             requestAbortObserved = true;
-            resolve();
           }, { once: true });
-        });
-
-        try {
-          yield 'connected';
-          await Promise.race([clientAbort, resolverRelease]);
-        } finally {
-          iteratorFinalizations += 1;
         }
+
+        activeIterator = new BlockingSseIterator();
+        return activeIterator;
       }
     }
 
@@ -83,6 +120,24 @@ describe('GraphQL SSE lifecycle', () => {
 
     const adapter = createNodeHttpAdapter({ port: 0, shutdownTimeoutMs: 100 });
     const app = await FluoFactory.create(AppModule, { adapter });
+    const clientController = new AbortController();
+    const waitForClientOperation = async <T>(operation: Promise<T>, description: string): Promise<T> => {
+      let timeout: ReturnType<typeof setTimeout> | undefined;
+      const timeoutRejection = new Promise<never>((_resolve, reject) => {
+        timeout = setTimeout(() => {
+          clientController.abort();
+          reject(new Error(`Timed out waiting for ${description}.`));
+        }, 2_000);
+      });
+
+      try {
+        return await Promise.race([operation, timeoutRejection]);
+      } finally {
+        if (timeout) {
+          clearTimeout(timeout);
+        }
+      }
+    };
 
     try {
       await app.listen();
@@ -99,16 +154,18 @@ describe('GraphQL SSE lifecycle', () => {
         throw new Error('Expected the Node HTTP adapter to expose its assigned port.');
       }
 
-      const clientController = new AbortController();
-      const response = await fetch(
-        `http://127.0.0.1:${String(address.port)}/graphql?query=${encodeURIComponent('subscription { blockingEvents }')}`,
-        {
-          headers: {
-            accept: 'text/event-stream',
+      const response = await waitForClientOperation(
+        fetch(
+          `http://127.0.0.1:${String(address.port)}/graphql?query=${encodeURIComponent('subscription { blockingEvents }')}`,
+          {
+            headers: {
+              accept: 'text/event-stream',
+            },
+            method: 'GET',
+            signal: clientController.signal,
           },
-          method: 'GET',
-          signal: clientController.signal,
-        },
+        ),
+        'the GraphQL SSE response',
       );
       const reader = response.body?.getReader();
 
@@ -116,15 +173,27 @@ describe('GraphQL SSE lifecycle', () => {
         throw new Error('Expected the SSE response body to expose a reader.');
       }
 
-      const firstChunk = await reader.read();
+      const decoder = new TextDecoder();
+      const eventBoundary = /\r?\n\r?\n/;
+      let firstEvent = '';
 
-      if (firstChunk.done) {
-        throw new Error('Expected the SSE subscription to remain open after its first event.');
+      while (!eventBoundary.test(firstEvent)) {
+        const chunk = await waitForClientOperation(reader.read(), 'a complete GraphQL SSE event');
+
+        if (chunk.done) {
+          throw new Error('Expected a complete SSE event before the response stream closed.');
+        }
+
+        firstEvent += decoder.decode(chunk.value, { stream: true });
+
+        if (firstEvent.length > 64 * 1024) {
+          throw new Error('Expected the first SSE event to fit within 64 KiB.');
+        }
       }
 
       expect(response.status).toBe(200);
       expect(response.headers.get('content-type')).toContain('text/event-stream');
-      expect(new TextDecoder().decode(firstChunk.value)).toContain('blockingEvents');
+      expect(firstEvent).toContain('blockingEvents');
 
       // When
       clientController.abort();
@@ -132,7 +201,8 @@ describe('GraphQL SSE lifecycle', () => {
       // Then
       await vi.waitFor(expectExactlyOnceAbortLifecycle);
     } finally {
-      releaseResolver?.();
+      clientController.abort();
+      activeIterator?.release();
       await app.close();
     }
 

--- a/packages/graphql/src/sse-lifecycle.test.ts
+++ b/packages/graphql/src/sse-lifecycle.test.ts
@@ -1,0 +1,141 @@
+import { Server } from 'node:http';
+
+import { Inject, Scope } from '@fluojs/core';
+import { defineModule, FluoFactory } from '@fluojs/runtime';
+import { createNodeHttpAdapter } from '@fluojs/runtime/node';
+import { describe, expect, it, vi } from 'vitest';
+
+import { Resolver, Subscription } from './decorators.js';
+import { GraphqlModule } from './module.js';
+import type { GraphQLContext } from './types.js';
+
+describe('GraphQL SSE lifecycle', () => {
+  it('finalizes the AsyncIterable and destroys its request scope once when the client aborts', async () => {
+    // Given
+    let iteratorFinalizations = 0;
+    let providerTeardowns = 0;
+    let requestAbortObserved = false;
+    const expectExactlyOnceAbortLifecycle = (): void => {
+      expect(requestAbortObserved).toBe(true);
+      expect(iteratorFinalizations).toBe(1);
+      expect(providerTeardowns).toBe(1);
+    };
+    let releaseResolver: (() => void) | undefined;
+    const resolverRelease = new Promise<void>((resolve) => {
+      releaseResolver = resolve;
+    });
+
+    @Inject()
+    @Scope('request')
+    class SseRequestLifecycleProbe {
+      onDestroy(): void {
+        providerTeardowns += 1;
+      }
+    }
+
+    @Inject(SseRequestLifecycleProbe)
+    @Scope('request')
+    @Resolver('SseAbortLifecycleResolver')
+    class SseAbortLifecycleResolver {
+      constructor(probe: SseRequestLifecycleProbe) {
+        void probe;
+      }
+
+      @Subscription()
+      async *blockingEvents(_input: undefined, context: GraphQLContext): AsyncGenerator<string, void, void> {
+        const requestSignal = context.request.signal;
+
+        if (!requestSignal) {
+          throw new Error('Expected the Node HTTP request to expose an abort signal.');
+        }
+
+        const clientAbort = new Promise<void>((resolve) => {
+          if (requestSignal.aborted) {
+            requestAbortObserved = true;
+            resolve();
+            return;
+          }
+
+          requestSignal.addEventListener('abort', () => {
+            requestAbortObserved = true;
+            resolve();
+          }, { once: true });
+        });
+
+        try {
+          yield 'connected';
+          await Promise.race([clientAbort, resolverRelease]);
+        } finally {
+          iteratorFinalizations += 1;
+        }
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [
+        GraphqlModule.forRoot({
+          resolvers: [SseAbortLifecycleResolver],
+        }),
+      ],
+      providers: [SseRequestLifecycleProbe, SseAbortLifecycleResolver],
+    });
+
+    const adapter = createNodeHttpAdapter({ port: 0, shutdownTimeoutMs: 100 });
+    const app = await FluoFactory.create(AppModule, { adapter });
+
+    try {
+      await app.listen();
+
+      const server = adapter.getServer?.();
+
+      if (!(server instanceof Server)) {
+        throw new Error('Expected the Node HTTP adapter to expose its server.');
+      }
+
+      const address = server.address();
+
+      if (!address || typeof address === 'string') {
+        throw new Error('Expected the Node HTTP adapter to expose its assigned port.');
+      }
+
+      const clientController = new AbortController();
+      const response = await fetch(
+        `http://127.0.0.1:${String(address.port)}/graphql?query=${encodeURIComponent('subscription { blockingEvents }')}`,
+        {
+          headers: {
+            accept: 'text/event-stream',
+          },
+          method: 'GET',
+          signal: clientController.signal,
+        },
+      );
+      const reader = response.body?.getReader();
+
+      if (!reader) {
+        throw new Error('Expected the SSE response body to expose a reader.');
+      }
+
+      const firstChunk = await reader.read();
+
+      if (firstChunk.done) {
+        throw new Error('Expected the SSE subscription to remain open after its first event.');
+      }
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('content-type')).toContain('text/event-stream');
+      expect(new TextDecoder().decode(firstChunk.value)).toContain('blockingEvents');
+
+      // When
+      clientController.abort();
+
+      // Then
+      await vi.waitFor(expectExactlyOnceAbortLifecycle);
+    } finally {
+      releaseResolver?.();
+      await app.close();
+    }
+
+    expectExactlyOnceAbortLifecycle();
+  });
+});


### PR DESCRIPTION
## Summary

Adds direct executable evidence for the documented GraphQL SSE abort lifecycle.

Closes #2911

## Changes

- Add a real Node HTTP SSE subscription test with a blocking request-scoped resolver.
- Abort the client after the first event and assert the server request observes cancellation.
- Assert the subscription AsyncIterable `finally` and request-scoped provider `onDestroy` each run exactly once, including after application shutdown.

## Testing

- `pnpm build`
- `pnpm --dir packages/graphql typecheck`
- `pnpm --dir packages/graphql test` — 12 files, 100 tests passed
- `pnpm exec biome check packages/graphql/src/sse-lifecycle.test.ts`
- Changed-file TypeScript diagnostics and two-axis standards/spec review

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

Test-only contract evidence; no published behavior, API surface, package contents, or release metadata changes.

## Public export documentation

- [x] No public exports changed; source TSDoc requirements are not applicable.
- [x] No exported function signatures or README examples changed.

## Behavioral contract

- [x] No documented behavioral contracts were removed or changed.
- [x] No new behavioral contract was introduced; this PR adds executable evidence for the existing SSE cancellation and operation-scope teardown contract.
- [x] Runtime invariants are covered by the new regression test.

## Platform consistency governance (SSOT)

- [x] No governance docs or English/Korean mirrors changed.
- [x] No platform contract claims changed; platform harness and companion documentation updates are not applicable.
- [x] The test uses the package-documented supported Node.js HTTP/SSE boundary.