### PR TITLE
Resolve #2914: strengthen Drizzle transaction regression coverage

### DIFF
--- a/packages/drizzle/src/module.test.ts
+++ b/packages/drizzle/src/module.test.ts
@@ -568,6 +568,59 @@ describe('@fluojs/drizzle', () => {
     }
   });
 
+  it('rejects nested request transactions after shutdown begins without opening another database transaction', async () => {
+    const nestedAttemptBarrier = createDeferred();
+    const outerWaiting = createDeferred();
+    let transactionCalls = 0;
+    const transactionDatabase = {};
+    const database = {
+      async transaction<T>(callback: (value: typeof transactionDatabase) => Promise<T>): Promise<T> {
+        transactionCalls += 1;
+        return callback(transactionDatabase);
+      },
+    };
+    const drizzle = new DrizzleDatabase<typeof database, typeof transactionDatabase>(database);
+
+    const outerTransaction = drizzle.transaction(async () => {
+      outerWaiting.resolve();
+      await nestedAttemptBarrier.promise;
+
+      await expect(drizzle.requestTransaction(async () => 'late-nested-request')).rejects.toThrow(
+        'Drizzle request transactions are not available during shutdown.',
+      );
+
+      return 'outer-complete';
+    });
+    let nestedAttemptReleased = false;
+    let shutdown: Promise<void> | undefined;
+
+    try {
+      // Given: one manual database transaction remains active at an explicit checkpoint.
+      await outerWaiting.promise;
+      expect(transactionCalls).toBe(1);
+
+      // When: shutdown closes transaction admission before the nested request attempt continues.
+      shutdown = drizzle.onApplicationShutdown();
+      nestedAttemptReleased = true;
+      nestedAttemptBarrier.resolve();
+
+      // Then: the nested request is rejected and the outer transaction remains the only database boundary.
+      await expect(outerTransaction).resolves.toBe('outer-complete');
+      await shutdown;
+      expect(transactionCalls).toBe(1);
+    } finally {
+      if (!nestedAttemptReleased) {
+        nestedAttemptReleased = true;
+        nestedAttemptBarrier.resolve();
+      }
+
+      await Promise.allSettled([
+        outerTransaction,
+        shutdown ?? drizzle.onApplicationShutdown(),
+      ]);
+    }
+  });
+
   it('waits for transaction runner settlement before reporting late request aborts', async () => {
     const events: string[] = [];
     const transactionDatabase = {};

--- a/packages/drizzle/src/transaction-decorator.red.test.ts
+++ b/packages/drizzle/src/transaction-decorator.red.test.ts
@@ -404,6 +404,41 @@ describe('@fluojs/drizzle Transaction decorator — named/accessor contract', ()
     ]);
   });
 
+  it('selects a nested .db target when it is the only transaction-capable host candidate', async () => {
+    const events: string[] = [];
+    const nestedDatabase = {
+      async transaction<T>(callback: () => Promise<T>): Promise<T> {
+        events.push('nested:transaction:start');
+        const result = await callback();
+        events.push('nested:transaction:end');
+        return result;
+      },
+    };
+
+    class NestedDatabaseService {
+      readonly repository = { db: nestedDatabase };
+
+      @Transaction()
+      async run() {
+        events.push('nested:work');
+        return 'nested-result';
+      }
+    }
+
+    // Given: a decorated host whose only transaction-capable candidate is repository.db.
+    const service = new NestedDatabaseService();
+
+    // When: the default transaction decorator resolves its host target.
+    await expect(service.run()).resolves.toBe('nested-result');
+
+    // Then: the nested database owns the complete transaction boundary.
+    expect(events).toEqual([
+      'nested:transaction:start',
+      'nested:work',
+      'nested:transaction:end',
+    ]);
+  });
+
   it('uses explicit accessor to select a specific DrizzleDatabase', async () => {
       const drizzlePackage = await import('./index.js');
     const ExportedTransaction = (drizzlePackage as { Transaction?: unknown }).Transaction;
@@ -475,6 +510,54 @@ describe('@fluojs/drizzle Transaction decorator — named/accessor contract', ()
     expect(primaryEvents).not.toContain('primary:transaction:start');
 
     await app.close();
+  });
+
+  it('routes combined accessor options only to the selected transaction target', async () => {
+    const transactionOptions = {
+      accessMode: 'read only',
+      isolationLevel: 'read committed',
+    } as const;
+    const primaryOptionsCalls: Array<typeof transactionOptions | undefined> = [];
+    const analyticsOptionsCalls: Array<typeof transactionOptions | undefined> = [];
+    const primaryDatabase = {
+      async transaction<T>(
+        callback: () => Promise<T>,
+        options?: typeof transactionOptions,
+      ): Promise<T> {
+        primaryOptionsCalls.push(options);
+        return callback();
+      },
+    };
+    const analyticsDatabase = {
+      async transaction<T>(
+        callback: () => Promise<T>,
+        options?: typeof transactionOptions,
+      ): Promise<T> {
+        analyticsOptionsCalls.push(options);
+        return callback();
+      },
+    };
+
+    class AccessorOptionsService {
+      readonly primaryDb = primaryDatabase;
+      readonly analyticsDb = analyticsDatabase;
+
+      @Transaction((self: AccessorOptionsService) => self.analyticsDb, transactionOptions)
+      async run() {
+        return 'analytics-result';
+      }
+    }
+
+    // Given: two transaction-capable targets and explicit options for the non-default target.
+    const service = new AccessorOptionsService();
+
+    // When: the accessor-and-options decorator form executes.
+    await expect(service.run()).resolves.toBe('analytics-result');
+
+    // Then: only the accessor-selected target receives the exact options object.
+    expect(primaryOptionsCalls).toEqual([]);
+    expect(analyticsOptionsCalls).toHaveLength(1);
+    expect(analyticsOptionsCalls[0]).toBe(transactionOptions);
   });
 
   it('does not confuse two Drizzle databases when only one accessor is decorated', async () => {


### PR DESCRIPTION
## Summary

Add direct regression coverage for documented Drizzle transaction target selection and shutdown admission behavior.

Linked context: Closes #2914

## Changes

- Verify `@Transaction()` selects a nested-only `.db` target.
- Verify combined `@Transaction(accessor, options)` routes exact options only to the selected target.
- Verify nested `requestTransaction(...)` is rejected after shutdown begins while an outer manual transaction drains, without opening a second database transaction.

## Testing

- `pnpm --dir packages/drizzle test` — 6 files, 58 tests passed.
- `pnpm --dir packages/drizzle typecheck` — passed.
- `pnpm exec biome check packages/drizzle/src/transaction-decorator.red.test.ts packages/drizzle/src/module.test.ts` — passed.
- Changed-file LSP diagnostics — clean.
- `git diff --check origin/main..HEAD` — passed.

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

Test-only changes do not alter public API, runtime behavior, package contents, or release metadata, so no changeset is required.

## Public export documentation

- [x] Not applicable: no public exports or source documentation changed.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [ ] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations remain explicitly documented.
- [x] Runtime invariants are covered by regression tests.

This PR locks existing documented behavior and introduces no contract change.

## Platform consistency governance (SSOT)

- [x] Not applicable: no platform contract or governance documentation changed.
- [x] Existing English/Korean documentation remains untouched and synchronized.