### PR TITLE
Resolve #2909: Exhaust OpenAPI test teardown callbacks

### DIFF
--- a/packages/openapi/src/openapi-module.test.ts
+++ b/packages/openapi/src/openapi-module.test.ts
@@ -40,8 +40,22 @@ const teardownCallbacks: Array<() => Promise<void>> = [];
 const explicitlyClosedApps = new WeakSet<TestCloseable>();
 
 async function runTeardownCallbacks(): Promise<void> {
+  const errors: unknown[] = [];
+
   while (teardownCallbacks.length > 0) {
-    await teardownCallbacks.pop()?.();
+    try {
+      await teardownCallbacks.pop()?.();
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+
+  if (errors.length > 1) {
+    throw new AggregateError(errors, 'OpenAPI test teardown failed.');
+  }
+
+  if (errors.length === 1) {
+    throw errors[0];
   }
 }
 
@@ -190,6 +204,49 @@ function resolveAssignedPort(adapter: { getServer?: () => unknown }): number {
 }
 
 describe('OpenApiModule', () => {
+  it('runs every cleanup callback before aggregating teardown failures', async () => {
+    // Given
+    const firstError = new Error('first close failed');
+    const secondError = new Error('second close failed');
+    const cleanupOrder: string[] = [];
+    let cleanupFinished = false;
+
+    registerResponseForCleanup(new Response(new ReadableStream({
+      cancel() {
+        cleanupOrder.push('response');
+      },
+    })));
+    registerAppForCleanup({
+      async close() {
+        cleanupOrder.push('second app');
+        if (!cleanupFinished) {
+          throw secondError;
+        }
+      },
+    });
+    registerAppForCleanup({
+      async close() {
+        cleanupOrder.push('first app');
+        throw firstError;
+      },
+    });
+
+    // When
+    let cleanupError: unknown;
+    try {
+      await runTeardownCallbacks();
+    } catch (error) {
+      cleanupError = error;
+    } finally {
+      cleanupFinished = true;
+    }
+
+    // Then
+    expect(cleanupOrder).toEqual(['first app', 'second app', 'response']);
+    expect(cleanupError).toBeInstanceOf(AggregateError);
+    expect(cleanupError).toMatchObject({ errors: [firstError, secondError] });
+  });
+
   it('surfaces app cleanup failures unless the app was explicitly closed', async () => {
     const closingError = new Error('close failed');
     let closeCalls = 0;


### PR DESCRIPTION
## Summary

Make the OpenAPI shared test teardown helper exhaust every registered cleanup callback before surfacing failures.

Linked context: Closes #2909

## Changes

- Continue draining the teardown callback stack after individual cleanup failures.
- Preserve direct rethrow for one cleanup failure and aggregate multiple failures with `AggregateError` after cleanup completes.
- Add a regression covering LIFO execution across app and Response cleanup callbacks plus aggregate error ordering.

## Testing

- TDD RED: focused regression failed because only the first app callback ran.
- `pnpm vitest run packages/openapi/src/openapi-module.test.ts --project packages -t "cleanup callback|cleanup failures"` — 3 passed.
- `pnpm --filter @fluojs/openapi test` — 71 passed.
- `pnpm --filter @fluojs/openapi... build && pnpm --filter @fluojs/openapi typecheck` — passed.
- `pnpm exec biome lint packages/openapi/src/openapi-module.test.ts` — passed.
- OpenAPI package LSP diagnostics — 0 errors.
- `pnpm vitest run --maxWorkers=1` — 404 files passed; 4700 tests passed, 1 skipped.
- `pnpm verify` build, typecheck, and lint stages passed. Its default parallel test stage exposed unrelated declaration-race/time-out flakes; the failing declaration test passed alone and the full serialized suite passed.

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

Test infrastructure only; no published package behavior, API, contents, or release metadata changed, so no changeset is required.

## Public export documentation

Not applicable: no public exports or source TSDoc surfaces changed.

- [x] Public export documentation remains unchanged.

## Behavioral contract

- [x] No documented behavioral contracts were removed or changed.
- [x] The test-infrastructure cleanup invariant is covered by a regression test.
- [x] Runtime and consumer-facing behavior remains unchanged.

## Platform consistency governance (SSOT)

Not applicable: no platform implementation, conformance claim, governance document, or EN/KO SSOT surface changed.