### PR TITLE
Resolve #2908: cover cache shutdown ordering for in-flight store operations

### DIFF
--- a/packages/cache-manager/src/cache-service.shutdown.test.ts
+++ b/packages/cache-manager/src/cache-service.shutdown.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { CacheService } from './service.js';
+import type { CacheStore, NormalizedCacheModuleOptions } from './types.js';
+
+const cacheOptions: NormalizedCacheModuleOptions = {
+  global: false,
+  httpKeyStrategy: 'route',
+  keyPrefix: 'fluo:cache:',
+  principalScopeResolver: undefined,
+  store: 'memory',
+  ttl: 0,
+};
+
+interface Deferred<T> {
+  readonly promise: Promise<T>;
+  resolve(value: T): void;
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolveDeferred: ((value: T) => void) | undefined;
+  const promise = new Promise<T>((resolve) => {
+    resolveDeferred = resolve;
+  });
+
+  return {
+    promise,
+    resolve(value: T) {
+      if (!resolveDeferred) {
+        throw new Error('Deferred resolver was not initialized.');
+      }
+
+      resolveDeferred(value);
+    },
+  };
+}
+
+describe('CacheService shutdown ordering', () => {
+  it('waits for an in-flight store get before closing the store exactly once', async () => {
+    // Given
+    const events: string[] = [];
+    const getDeferred = createDeferred<undefined>();
+    const close = vi.fn(async () => {
+      events.push('close');
+    });
+    const store: CacheStore = {
+      close,
+      async del() {},
+      async get() {
+        events.push('get:start');
+        await getDeferred.promise;
+        events.push('get:end');
+        return undefined;
+      },
+      async reset() {},
+      async set() {},
+    };
+    const cache = new CacheService(store, cacheOptions);
+    const pendingGet = cache.get('key');
+
+    await vi.waitFor(() => {
+      expect(events).toEqual(['get:start']);
+    });
+
+    // When
+    const pendingClose = cache.close();
+    await Promise.resolve();
+
+    // Then
+    expect(close).not.toHaveBeenCalled();
+
+    getDeferred.resolve(undefined);
+    await expect(pendingGet).resolves.toBeUndefined();
+    await pendingClose;
+    await cache.close();
+
+    expect(events).toEqual(['get:start', 'get:end', 'close']);
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('waits for an in-flight store set before disposing the store exactly once', async () => {
+    // Given
+    const events: string[] = [];
+    const setDeferred = createDeferred<void>();
+    const dispose = vi.fn(async () => {
+      events.push('dispose');
+    });
+    const store: CacheStore = {
+      async del() {},
+      dispose,
+      async get() {
+        return undefined;
+      },
+      async reset() {},
+      async set() {
+        events.push('set:start');
+        await setDeferred.promise;
+        events.push('set:end');
+      },
+    };
+    const cache = new CacheService(store, cacheOptions);
+    const pendingSet = cache.set('key', 'value');
+
+    await vi.waitFor(() => {
+      expect(events).toEqual(['set:start']);
+    });
+
+    // When
+    const pendingClose = cache.close();
+    await Promise.resolve();
+
+    // Then
+    expect(dispose).not.toHaveBeenCalled();
+
+    setDeferred.resolve();
+    await pendingSet;
+    await pendingClose;
+    await cache.close();
+
+    expect(events).toEqual(['set:start', 'set:end', 'dispose']);
+    expect(dispose).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Add direct executable evidence for the documented `CacheService.close()` shutdown ordering contract.

Linked context: https://github.com/fluojs/fluo/issues/2908

Closes #2908

## Changes

- add a deferred in-flight store `get` regression proving store `close()` waits for completion
- add a deferred in-flight store `set` regression proving store `dispose()` waits for completion
- assert each teardown hook is invoked exactly once, including after a repeated `CacheService.close()` call
- keep the change test-only because the existing implementation already satisfies the contract

## Testing

- mutation red checks: each focused test failed when teardown was temporarily moved ahead of the store-operation queue; the implementation mutation was reverted before commit
- `pnpm --dir packages/cache-manager exec vitest run -c vitest.config.ts src/cache-service.shutdown.test.ts` — 2 passed
- `pnpm --filter @fluojs/cache-manager test` — 142 passed
- `pnpm --filter @fluojs/cache-manager... build` — passed
- `pnpm --filter @fluojs/cache-manager typecheck` — passed after building workspace dependencies
- `pnpm exec biome check packages/cache-manager/src/cache-service.shutdown.test.ts` — passed
- changed-file LSP diagnostics — no diagnostics
- `pnpm vitest run --maxWorkers=1` — 407 files passed, 4709 tests passed, 1 skipped

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

Test-only regression coverage for an existing documented behavior; no `.changeset/*.md` is required.

## Public export documentation

No public exports changed, so source TSDoc requirements are not applicable.

- [x] Changed public exports include a source-level summary. (Not applicable: no public export changes.)
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable. (Not applicable.)
- [x] Source `@example` blocks and README scenario examples still play complementary roles. (Not applicable.)

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README. (Not applicable: this covers the existing README contract.)
- [x] Intentional limitations are explicitly stated. (No limitation changes.)
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. (Not applicable: no docs changed.)
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. (Not applicable.)
- [x] Any package README alignment/conformance claims are backed by applicable platform harness tests. (Not applicable: no platform claim changed.)