### PR TITLE
Resolve #2912: Cover direct Redis client optional-peer ownership

### DIFF
--- a/packages/cache-manager/src/optional-peer.test.ts
+++ b/packages/cache-manager/src/optional-peer.test.ts
@@ -1,11 +1,44 @@
+import { getModuleMetadata } from '@fluojs/core/internal';
+import { bootstrapApplication, defineModule } from '@fluojs/runtime';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { getModuleMetadata } from '@fluojs/core/internal';
-
-import { CACHE_OPTIONS, CACHE_STORE } from './tokens.js';
 import { CacheModule } from './module.js';
+import { CacheService } from './service.js';
 import { MemoryStore } from './stores/memory-store.js';
-import type { NormalizedCacheModuleOptions } from './types.js';
+import { CACHE_OPTIONS, CACHE_STORE } from './tokens.js';
+import type { NormalizedCacheModuleOptions, RedisCompatibleClient } from './types.js';
+
+class ApplicationOwnedRedisClient implements RedisCompatibleClient {
+  readonly close = vi.fn(async () => undefined);
+  readonly disconnect = vi.fn(() => undefined);
+  readonly quit = vi.fn(async () => undefined);
+  private readonly entries = new Map<string, string>();
+
+  async del(key: string, ...keys: string[]): Promise<number> {
+    let deleted = 0;
+
+    for (const currentKey of [key, ...keys]) {
+      if (this.entries.delete(currentKey)) {
+        deleted += 1;
+      }
+    }
+
+    return deleted;
+  }
+
+  async get(key: string): Promise<string | null> {
+    return this.entries.get(key) ?? null;
+  }
+
+  async scan(_cursor: string, ..._args: Array<string | number>): Promise<[string, string[]]> {
+    return ['0', []];
+  }
+
+  async set(key: string, value: string, ..._args: Array<string | number>): Promise<'OK'> {
+    this.entries.set(key, value);
+    return 'OK';
+  }
+}
 
 function isNormalizedOptionsProvider(
   provider: unknown,
@@ -36,6 +69,46 @@ function getModuleProviders(options?: Parameters<typeof CacheModule.forRoot>[0])
 }
 
 describe('optional Redis peer contract', () => {
+  it('uses a direct application-owned client without resolving or closing the optional Redis peer', async () => {
+    // Given
+    const optionalRedisPeerFactory = vi.fn(() => {
+      throw Object.assign(new Error("Cannot find package '@fluojs/redis'"), {
+        code: 'ERR_MODULE_NOT_FOUND',
+      });
+    });
+    vi.doMock('@fluojs/redis', optionalRedisPeerFactory);
+
+    const redisClient = new ApplicationOwnedRedisClient();
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [CacheModule.forRoot({
+        keyPrefix: 'direct:',
+        redis: { client: redisClient },
+        store: 'redis',
+      })],
+    });
+
+    // When
+    const app = await bootstrapApplication({ rootModule: AppModule });
+    const cache = await app.container.resolve(CacheService);
+    const cached = await (async () => {
+      try {
+        await cache.set('users', { count: 3 }, 30);
+        return await cache.get('users');
+      } finally {
+        await app.close();
+      }
+    })();
+
+    // Then
+    expect(cached).toEqual({ count: 3 });
+    expect(optionalRedisPeerFactory).not.toHaveBeenCalled();
+    expect(redisClient.close).not.toHaveBeenCalled();
+    expect(redisClient.disconnect).not.toHaveBeenCalled();
+    expect(redisClient.quit).not.toHaveBeenCalled();
+  });
+
   it('keeps the root barrel importable for memory-only consumers when Redis peers are absent', async () => {
     vi.doMock('@fluojs/redis', () => {
       throw Object.assign(new Error("Cannot find package '@fluojs/redis'"), {


### PR DESCRIPTION
## Summary

Add executable evidence for the documented direct Redis client installation and ownership contract in `@fluojs/cache-manager`.

Linked context: https://github.com/fluojs/fluo/issues/2912

Closes #2912

## Changes

- Add a Redis-compatible application-owned test client with observable `close`, `disconnect`, and `quit` hooks.
- Bootstrap `CacheModule` with direct `redis.client` while `@fluojs/redis` is mocked as unavailable.
- Exercise `CacheService.set()` / `get()` and verify application shutdown does not close the supplied client.

## Testing

- `pnpm vitest run packages/cache-manager/src/optional-peer.test.ts`
- `pnpm --filter @fluojs/cache-manager test` — 143 passed
- `pnpm --filter @fluojs/cache-manager typecheck`
- `pnpm --filter @fluojs/cache-manager... build`
- `pnpm exec biome check packages/cache-manager/src/optional-peer.test.ts`
- LSP diagnostics for `packages/cache-manager` — 0 diagnostics
- `FLUO_CLI_SANDBOX_ROOT=<isolated-temp> pnpm verify:release-readiness`
- Mutation checks confirmed the regression fails if direct-client bootstrap resolves the optional peer or if `RedisStore` participates in shutdown teardown.

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

Test-only coverage for an existing documented contract; no published behavior, API, package contents, or release metadata changes.

## Public export documentation

- [x] Not applicable: no public exports changed.
- [x] No source TSDoc or README updates are required for this test-only change.

## Behavioral contract

- [x] No documented behavioral contracts were removed or changed.
- [x] The existing direct-client optional-peer and application-ownership invariants now have combined regression coverage.
- [x] No intentional limitation changed.

## Platform consistency governance (SSOT)

- [x] No governance or platform contract documents changed.
- [x] EN/KO mirror structure is unaffected.
- [x] The canonical release-readiness verifier passed with an isolated CLI sandbox root.