### PR TITLE
Resolve #2919: add metrics scrape request contract coverage

### DIFF
--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -49,6 +49,7 @@
     "prom-client": "^15.1.3"
   },
   "devDependencies": {
+    "@fluojs/testing": "workspace:^",
     "@types/node": "^22.0.0",
     "vitest": "^3.2.4"
   }

--- a/packages/metrics/src/metrics-module.request.test.ts
+++ b/packages/metrics/src/metrics-module.request.test.ts
@@ -1,0 +1,95 @@
+import { ForbiddenException } from '@fluojs/http';
+import { defineModule } from '@fluojs/runtime';
+import { createTestApp } from '@fluojs/testing';
+import { Registry } from 'prom-client';
+import { describe, expect, it } from 'vitest';
+
+import { MetricsModule } from './metrics-module.js';
+
+describe('MetricsModule request contract', () => {
+  it('serves the default Prometheus scrape response through the request helper', async () => {
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [MetricsModule.forRoot({ defaultMetrics: false })],
+    });
+
+    const app = await createTestApp({ rootModule: AppModule });
+
+    try {
+      // Given: the metrics module exposes its default scrape endpoint.
+
+      // When: a consumer requests the endpoint through the canonical test app surface.
+      const response = await app.request('GET', '/metrics').send();
+
+      // Then: the response preserves the documented Prometheus HTTP contract.
+      expect(response.status).toBe(200);
+      expect(response.headers['content-type']).toBe(Registry.PROMETHEUS_CONTENT_TYPE);
+      expect(response.body).toEqual(expect.stringContaining('fluo_metrics_registry_mode{mode="isolated"} 1'));
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('returns not found through the request helper when the scrape endpoint is disabled', async () => {
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [MetricsModule.forRoot({ defaultMetrics: false, path: false })],
+    });
+
+    const app = await createTestApp({ rootModule: AppModule });
+
+    try {
+      // Given: the metrics module disables its scrape endpoint explicitly.
+
+      // When: a consumer requests the default metrics path.
+      const response = await app.request('GET', '/metrics').send();
+
+      // Then: the real request pipeline reports the route as missing.
+      expect(response.status).toBe(404);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('records endpoint middleware failures from request helper dispatch', async () => {
+    class RejectMetricsRequestMiddleware {
+      async handle(): Promise<void> {
+        throw new ForbiddenException('Metrics scrape rejected.');
+      }
+    }
+
+    const registry = new Registry();
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [
+        MetricsModule.forRoot({
+          defaultMetrics: false,
+          endpointMiddleware: [RejectMetricsRequestMiddleware],
+          http: true,
+          registry,
+        }),
+      ],
+    });
+
+    const app = await createTestApp({ rootModule: AppModule });
+
+    try {
+      // Given: HTTP instrumentation observes a protected metrics endpoint.
+
+      // When: endpoint middleware rejects a request through the canonical helper.
+      const response = await app.request('GET', '/metrics').send();
+
+      // Then: the request failure remains observable in both HTTP collectors.
+      const metricsText = await registry.metrics();
+      expect(response.status).toBe(403);
+      expect(metricsText).toContain('http_requests_total{method="GET",path="/metrics",status="403"} 1');
+      expect(metricsText).toContain('http_errors_total{method="GET",path="/metrics",status="403"} 1');
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -640,6 +640,9 @@ importers:
         specifier: ^15.1.3
         version: 15.1.3
     devDependencies:
+      '@fluojs/testing':
+        specifier: workspace:^
+        version: link:../testing
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.15


### PR DESCRIPTION
## Summary

Add executable request-level evidence for the documented `@fluojs/metrics` scrape endpoint contract.

Linked context: https://github.com/fluojs/fluo/issues/2919

Closes #2919

## Changes

- add `@fluojs/testing` as a metrics package development dependency
- cover the default `/metrics` status, Prometheus content type, and registry body through `createTestApp(...).request(...).send()`
- cover `path: false` returning 404 through the same request helper
- cover endpoint middleware 403 failures appearing in `http_requests_total` and `http_errors_total`
- close every test app from `finally`

## Testing

- `lsp_diagnostics packages/metrics/src/metrics-module.request.test.ts` — no diagnostics
- `pnpm --filter @fluojs/metrics exec vitest run -c vitest.config.ts src/metrics-module.request.test.ts` — 3 passed
- `pnpm --filter @fluojs/metrics test` — 66 passed
- `pnpm --filter @fluojs/metrics typecheck` — passed
- `pnpm --filter @fluojs/metrics build` — passed
- `pnpm lint` — passed; changed-mode public export TSDoc checks passed
- `pnpm vitest run --project packages --maxWorkers=1` — 364 files passed, 4,285 tests passed, 1 skipped
- `pnpm test` — 407 files passed and 1 unrelated `packages/platform-bun` declaration-surface test failed during the parallel run because `@fluojs/http` declarations were temporarily unavailable; that test passed when rerun alone, and the serial packages project passed completely

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

No Changeset is included because this PR changes only test coverage and a development-only workspace dependency. Published runtime behavior, API surface, package files, and release metadata are unchanged.

## Public export documentation

- [x] No public exports changed, so source-level summary requirements are not applicable.
- [x] No exported function signatures changed, so `@param` / `@returns` updates are not applicable.
- [x] README examples and source examples are unchanged.

## Behavioral contract

- [x] No documented behavioral contracts were removed or changed.
- [x] No new behavioral contract was introduced; the existing metrics README remains authoritative.
- [x] Intentional limitations remain unchanged.
- [x] The documented request-facing metrics invariants now have canonical request-helper regression coverage.

## Platform consistency governance (SSOT)

- [x] No governance documents or English/Korean mirror structures changed.
- [x] No platform contract docs changed, so companion index/tooling updates are not applicable.
- [x] No platform conformance claim changed; this PR exercises the application-level request seam rather than an adapter portability seam.