### PR TITLE
Resolve #2920: Metrics bootstrap test cleanup을 finally로 보장

### DIFF
--- a/packages/metrics/src/metrics-module.test.ts
+++ b/packages/metrics/src/metrics-module.test.ts
@@ -487,19 +487,21 @@ describe('MetricsModule', () => {
     const app = await bootstrapApplication({
       rootModule: AppModule,
     });
-    const response = createResponse();
 
-    await app.dispatch(createRequest('/metrics'), response);
+    try {
+      const response = createResponse();
+      await app.dispatch(createRequest('/metrics'), response);
 
-    expect(response.statusCode).toBe(200);
-    expect(String(response.body)).toContain(
-      'fluo_component_ready{component_id="runtime.shell",component_kind="runtime",operation="readiness",result="ready",env="production",instance="api-1"} 1',
-    );
-    expect(String(response.body)).toContain(
-      'fluo_component_health{component_id="runtime.shell",component_kind="runtime",operation="health",result="healthy",env="production",instance="api-1"} 1',
-    );
-
-    await app.close();
+      expect(response.statusCode).toBe(200);
+      expect(String(response.body)).toContain(
+        'fluo_component_ready{component_id="runtime.shell",component_kind="runtime",operation="readiness",result="ready",env="production",instance="api-1"} 1',
+      );
+      expect(String(response.body)).toContain(
+        'fluo_component_health{component_id="runtime.shell",component_kind="runtime",operation="health",result="healthy",env="production",instance="api-1"} 1',
+      );
+    } finally {
+      await app.close();
+    }
   });
 
   it('uses an isolated registry for each forRoot call', async () => {
@@ -516,23 +518,29 @@ describe('MetricsModule', () => {
     const firstApp = await bootstrapApplication({
       rootModule: FirstAppModule,
     });
-    const secondApp = await bootstrapApplication({
-      rootModule: SecondAppModule,
-    });
 
-    const firstResponse = createResponse();
-    const secondResponse = createResponse();
+    try {
+      const secondApp = await bootstrapApplication({
+        rootModule: SecondAppModule,
+      });
 
-    await firstApp.dispatch(createRequest('/metrics-a'), firstResponse);
-    await secondApp.dispatch(createRequest('/metrics-b'), secondResponse);
+      try {
+        const firstResponse = createResponse();
+        const secondResponse = createResponse();
 
-    expect(firstResponse.statusCode).toBe(200);
-    expect(secondResponse.statusCode).toBe(200);
-    expect(String(firstResponse.body)).toContain('process_cpu_seconds_total');
-    expect(String(secondResponse.body)).toContain('process_cpu_seconds_total');
+        await firstApp.dispatch(createRequest('/metrics-a'), firstResponse);
+        await secondApp.dispatch(createRequest('/metrics-b'), secondResponse);
 
-    await firstApp.close();
-    await secondApp.close();
+        expect(firstResponse.statusCode).toBe(200);
+        expect(secondResponse.statusCode).toBe(200);
+        expect(String(firstResponse.body)).toContain('process_cpu_seconds_total');
+        expect(String(secondResponse.body)).toContain('process_cpu_seconds_total');
+      } finally {
+        await secondApp.close();
+      }
+    } finally {
+      await firstApp.close();
+    }
   });
 
   it('records thrown middleware errors with 500 status labels', async () => {
@@ -1546,16 +1554,18 @@ describe('MetricsModule', () => {
       rootModule: AppModule,
     });
 
-    const response = createResponse();
-    await app.dispatch(createRequest('/metrics'), response);
+    try {
+      const response = createResponse();
+      await app.dispatch(createRequest('/metrics'), response);
 
-    const metricsText = String(response.body);
+      const metricsText = String(response.body);
 
-    expect(response.statusCode).toBe(200);
-    expect(metricsText).toContain('app_active_connections');
-    expect(metricsText).toContain('process_cpu_seconds_total');
-
-    await app.close();
+      expect(response.statusCode).toBe(200);
+      expect(metricsText).toContain('app_active_connections');
+      expect(metricsText).toContain('process_cpu_seconds_total');
+    } finally {
+      await app.close();
+    }
   });
 
   it('throws on duplicate metric names when using shared registry with MetricsService', async () => {
@@ -1685,30 +1695,39 @@ describe('MetricsModule', () => {
       imports: [MetricsRuntimeModule],
     });
 
-    const firstApp = await bootstrapApplication({
-      rootModule: AppModule,
-    });
-    const firstMetricsService = (await firstApp.container.resolve(MetricsService)) as MetricsService;
-    const firstRegistry = firstMetricsService.getRegistry();
+    const firstRegistry = await (async () => {
+      const firstApp = await bootstrapApplication({
+        rootModule: AppModule,
+      });
 
-    firstMetricsService.counter({
-      help: 'Counter scoped to the first bootstrap only',
-      name: 'bootstrap_local_counter_total',
-    });
+      try {
+        const firstMetricsService = (await firstApp.container.resolve(MetricsService)) as MetricsService;
+        const registry = firstMetricsService.getRegistry();
 
-    expect(await firstRegistry.metrics()).toContain('bootstrap_local_counter_total');
+        firstMetricsService.counter({
+          help: 'Counter scoped to the first bootstrap only',
+          name: 'bootstrap_local_counter_total',
+        });
 
-    await firstApp.close();
+        expect(await registry.metrics()).toContain('bootstrap_local_counter_total');
+        return registry;
+      } finally {
+        await firstApp.close();
+      }
+    })();
 
     const secondApp = await bootstrapApplication({
       rootModule: AppModule,
     });
-    const secondMetricsService = (await secondApp.container.resolve(MetricsService)) as MetricsService;
-    const secondRegistry = secondMetricsService.getRegistry();
 
-    expect(secondRegistry).not.toBe(firstRegistry);
-    expect(await secondRegistry.metrics()).not.toContain('bootstrap_local_counter_total');
+    try {
+      const secondMetricsService = (await secondApp.container.resolve(MetricsService)) as MetricsService;
+      const secondRegistry = secondMetricsService.getRegistry();
 
-    await secondApp.close();
+      expect(secondRegistry).not.toBe(firstRegistry);
+      expect(await secondRegistry.metrics()).not.toContain('bootstrap_local_counter_total');
+    } finally {
+      await secondApp.close();
+    }
   });
 });


### PR DESCRIPTION
## Summary

Metrics bootstrap 테스트에서 dispatch, assertion, 후속 bootstrap이 실패해도 생성된 application이 반드시 정리되도록 lifecycle cleanup을 `finally` 경로로 이동합니다.

Linked context: Closes #2920

## Changes

- 이슈에 지목된 단일 application 테스트 2곳의 `app.close()`를 `finally`에서 실행합니다.
- 복수 application 테스트에서 중첩 `try/finally`를 사용해 두 번째 bootstrap 실패를 포함한 모든 경로에서 이미 생성된 app을 닫습니다.
- 재사용 dynamic metrics module 테스트는 첫 번째 app을 닫은 뒤 registry 비교를 이어가는 기존 순서를 보존하면서 각 app을 독립적인 `finally`에서 정리합니다.
- #2919가 추가한 `metrics-module.request.test.ts`와 production source는 변경하지 않습니다.

## Testing

- `pnpm --filter @fluojs/metrics... build` — 통과
- `pnpm --dir packages/metrics exec vitest run -c vitest.config.ts src/metrics-module.test.ts -t "uses explicit platform telemetry labels|uses an isolated registry for each forRoot call|emits both framework and custom metrics from shared registry|creates a fresh isolated registry for each bootstrap of a reused dynamic metrics module"` — 4 passed
- `pnpm --dir packages/metrics typecheck` — 통과
- `pnpm --dir packages/metrics test` — 4 files, 66 tests passed
- `pnpm exec biome lint packages/metrics/src/metrics-module.test.ts` — 통과
- changed-file LSP diagnostics — 없음
- `pnpm test` — 4,712 passed, 1 skipped, unrelated `packages/platform-bun/src/published-declaration-surface.test.ts` 1건이 병렬 fresh-worktree declaration lookup에서 실패
- `pnpm --filter @fluojs/platform-bun... build && pnpm vitest run packages/platform-bun/src/published-declaration-surface.test.ts` — 위 실패 테스트 단독 재검증 1 passed

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

Test-only lifecycle cleanup이며 public package behavior, API surface, package contents, release metadata를 변경하지 않아 Changeset을 추가하지 않았습니다.

## Public export documentation

해당 없음 — public export와 source TSDoc을 변경하지 않습니다.

- [x] Changed public exports include a source-level summary. (N/A)
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable. (N/A)
- [x] Source `@example` blocks and README scenario examples still play complementary roles. (N/A)

## Behavioral contract

runtime behavior와 문서화된 metrics contract는 변경하지 않습니다. 기존 dispatch와 assertion은 유지하고 테스트 실패 경로의 resource cleanup만 강화합니다.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README. (N/A)
- [x] Intentional limitations are explicitly stated. (N/A)
- [x] Runtime invariants are covered by regression tests. (기존 assertions 유지)

## Platform consistency governance (SSOT)

해당 없음 — platform contract, governed docs, EN/KO mirror, conformance claim을 변경하지 않습니다.

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. (N/A)
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. (N/A)
- [x] Any package README alignment/conformance claims are backed by applicable platform harness tests. (N/A)
