### PR TITLE
Resolve #2923: Complete throttler validation boundary coverage

### DIFF
--- a/packages/throttler/src/module.test.ts
+++ b/packages/throttler/src/module.test.ts
@@ -295,22 +295,22 @@ describe('@fluojs/throttler decorators', () => {
   });
 
   it.each([
-    { caseName: 'limit=0', expectedField: /limit/i, options: { limit: 0, ttl: 60 } },
-    { caseName: 'limit=NaN', expectedField: /limit/i, options: { limit: Number.NaN, ttl: 60 } },
+    { caseName: 'limit=0', expectedField: /^Invalid throttler limit:/, options: { limit: 0, ttl: 60 } },
+    { caseName: 'limit=NaN', expectedField: /^Invalid throttler limit:/, options: { limit: Number.NaN, ttl: 60 } },
     {
       caseName: 'limit=Infinity',
-      expectedField: /limit/i,
+      expectedField: /^Invalid throttler limit:/,
       options: { limit: Number.POSITIVE_INFINITY, ttl: 60 },
     },
-    { caseName: 'limit=1.5', expectedField: /limit/i, options: { limit: 1.5, ttl: 60 } },
-    { caseName: 'ttl=0', expectedField: /ttl/i, options: { limit: 1, ttl: 0 } },
-    { caseName: 'ttl=NaN', expectedField: /ttl/i, options: { limit: 1, ttl: Number.NaN } },
+    { caseName: 'limit=1.5', expectedField: /^Invalid throttler limit:/, options: { limit: 1.5, ttl: 60 } },
+    { caseName: 'ttl=0', expectedField: /^Invalid throttler ttl:/, options: { limit: 1, ttl: 0 } },
+    { caseName: 'ttl=NaN', expectedField: /^Invalid throttler ttl:/, options: { limit: 1, ttl: Number.NaN } },
     {
       caseName: 'ttl=Infinity',
-      expectedField: /ttl/i,
+      expectedField: /^Invalid throttler ttl:/,
       options: { limit: 1, ttl: Number.POSITIVE_INFINITY },
     },
-    { caseName: 'ttl=0.5', expectedField: /ttl/i, options: { limit: 1, ttl: 0.5 } },
+    { caseName: 'ttl=0.5', expectedField: /^Invalid throttler ttl:/, options: { limit: 1, ttl: 0.5 } },
   ])(
     'rejects invalid @Throttle options eagerly for $caseName',
     ({ expectedField, options }: { expectedField: RegExp; options: ThrottlerHandlerOptions }) => {
@@ -406,23 +406,23 @@ describe('ThrottlerGuard — in-memory store', () => {
   });
 
   it.each([
-    { caseName: 'limit=0', expectedField: /limit/i, options: { limit: 0, ttl: 60 } },
-    { caseName: 'limit=NaN', expectedField: /limit/i, options: { limit: Number.NaN, ttl: 60 } },
+    { caseName: 'limit=0', expectedField: /^Invalid throttler limit:/, options: { limit: 0, ttl: 60 } },
+    { caseName: 'limit=NaN', expectedField: /^Invalid throttler limit:/, options: { limit: Number.NaN, ttl: 60 } },
     {
       caseName: 'limit=Infinity',
-      expectedField: /limit/i,
+      expectedField: /^Invalid throttler limit:/,
       options: { limit: Number.POSITIVE_INFINITY, ttl: 60 },
     },
-    { caseName: 'limit=1.5', expectedField: /limit/i, options: { limit: 1.5, ttl: 60 } },
-    { caseName: 'ttl=-1', expectedField: /ttl/i, options: { limit: 1, ttl: -1 } },
-    { caseName: 'ttl=0', expectedField: /ttl/i, options: { limit: 1, ttl: 0 } },
-    { caseName: 'ttl=NaN', expectedField: /ttl/i, options: { limit: 1, ttl: Number.NaN } },
+    { caseName: 'limit=1.5', expectedField: /^Invalid throttler limit:/, options: { limit: 1.5, ttl: 60 } },
+    { caseName: 'ttl=-1', expectedField: /^Invalid throttler ttl:/, options: { limit: 1, ttl: -1 } },
+    { caseName: 'ttl=0', expectedField: /^Invalid throttler ttl:/, options: { limit: 1, ttl: 0 } },
+    { caseName: 'ttl=NaN', expectedField: /^Invalid throttler ttl:/, options: { limit: 1, ttl: Number.NaN } },
     {
       caseName: 'ttl=Infinity',
-      expectedField: /ttl/i,
+      expectedField: /^Invalid throttler ttl:/,
       options: { limit: 1, ttl: Number.POSITIVE_INFINITY },
     },
-    { caseName: 'ttl=0.5', expectedField: /ttl/i, options: { limit: 1, ttl: 0.5 } },
+    { caseName: 'ttl=0.5', expectedField: /^Invalid throttler ttl:/, options: { limit: 1, ttl: 0.5 } },
   ])(
     'rejects invalid module-level $caseName before request handling starts',
     ({ expectedField, options }: { expectedField: RegExp; options: ThrottlerModuleOptions }) => {

--- a/packages/throttler/src/module.test.ts
+++ b/packages/throttler/src/module.test.ts
@@ -10,6 +10,7 @@ import { ThrottlerGuard } from './guard.js';
 import type {
   RedisThrottlerClient,
   ThrottlerConsumeInput,
+  ThrottlerHandlerOptions,
   ThrottlerModuleOptions,
   ThrottlerStore,
   ThrottlerStoreEntry,
@@ -293,43 +294,36 @@ describe('@fluojs/throttler decorators', () => {
     expect(bag[Symbol.for('fluo.throttler.class-throttle')]).toEqual({ limit: 100, ttl: 60 });
   });
 
-  it('rejects invalid @Throttle options eagerly', () => {
-    expect(() => {
-      class AuthController {
-        @Throttle({ limit: 0, ttl: 60 })
-        login() {}
-      }
+  it.each([
+    { caseName: 'limit=0', expectedField: /limit/i, options: { limit: 0, ttl: 60 } },
+    { caseName: 'limit=NaN', expectedField: /limit/i, options: { limit: Number.NaN, ttl: 60 } },
+    {
+      caseName: 'limit=Infinity',
+      expectedField: /limit/i,
+      options: { limit: Number.POSITIVE_INFINITY, ttl: 60 },
+    },
+    { caseName: 'limit=1.5', expectedField: /limit/i, options: { limit: 1.5, ttl: 60 } },
+    { caseName: 'ttl=0', expectedField: /ttl/i, options: { limit: 1, ttl: 0 } },
+    { caseName: 'ttl=NaN', expectedField: /ttl/i, options: { limit: 1, ttl: Number.NaN } },
+    {
+      caseName: 'ttl=Infinity',
+      expectedField: /ttl/i,
+      options: { limit: 1, ttl: Number.POSITIVE_INFINITY },
+    },
+    { caseName: 'ttl=0.5', expectedField: /ttl/i, options: { limit: 1, ttl: 0.5 } },
+  ])(
+    'rejects invalid @Throttle options eagerly for $caseName',
+    ({ expectedField, options }: { expectedField: RegExp; options: ThrottlerHandlerOptions }) => {
+      expect(() => {
+        class AuthController {
+          @Throttle(options)
+          login() {}
+        }
 
-      return AuthController;
-    }).toThrow(/limit/i);
-
-    expect(() => {
-      class AuthController {
-        @Throttle({ limit: 1, ttl: Number.NaN })
-        login() {}
-      }
-
-      return AuthController;
-    }).toThrow(/ttl/i);
-
-    expect(() => {
-      class AuthController {
-        @Throttle({ limit: 1.5, ttl: 60 })
-        login() {}
-      }
-
-      return AuthController;
-    }).toThrow(/limit/i);
-
-    expect(() => {
-      class AuthController {
-        @Throttle({ limit: 1, ttl: 0.5 })
-        login() {}
-      }
-
-      return AuthController;
-    }).toThrow(/ttl/i);
-  });
+        return AuthController;
+      }).toThrow(expectedField);
+    },
+  );
 
   it('captures @Throttle options by value to avoid shared mutable metadata', () => {
     const options = { limit: 5, ttl: 60 };
@@ -411,13 +405,30 @@ describe('ThrottlerGuard — in-memory store', () => {
     };
   });
 
-  it('rejects invalid module-level ttl and limit before request handling starts', () => {
-    expect(() => ThrottlerModule.forRoot({ limit: 0, ttl: 60 })).toThrow(/limit/i);
-    expect(() => ThrottlerModule.forRoot({ limit: 1, ttl: -1 })).toThrow(/ttl/i);
-    expect(() => ThrottlerModule.forRoot({ limit: Number.POSITIVE_INFINITY, ttl: 60 })).toThrow(/limit/i);
-    expect(() => ThrottlerModule.forRoot({ limit: 1.5, ttl: 60 })).toThrow(/limit/i);
-    expect(() => ThrottlerModule.forRoot({ limit: 1, ttl: 0.5 })).toThrow(/ttl/i);
-  });
+  it.each([
+    { caseName: 'limit=0', expectedField: /limit/i, options: { limit: 0, ttl: 60 } },
+    { caseName: 'limit=NaN', expectedField: /limit/i, options: { limit: Number.NaN, ttl: 60 } },
+    {
+      caseName: 'limit=Infinity',
+      expectedField: /limit/i,
+      options: { limit: Number.POSITIVE_INFINITY, ttl: 60 },
+    },
+    { caseName: 'limit=1.5', expectedField: /limit/i, options: { limit: 1.5, ttl: 60 } },
+    { caseName: 'ttl=-1', expectedField: /ttl/i, options: { limit: 1, ttl: -1 } },
+    { caseName: 'ttl=0', expectedField: /ttl/i, options: { limit: 1, ttl: 0 } },
+    { caseName: 'ttl=NaN', expectedField: /ttl/i, options: { limit: 1, ttl: Number.NaN } },
+    {
+      caseName: 'ttl=Infinity',
+      expectedField: /ttl/i,
+      options: { limit: 1, ttl: Number.POSITIVE_INFINITY },
+    },
+    { caseName: 'ttl=0.5', expectedField: /ttl/i, options: { limit: 1, ttl: 0.5 } },
+  ])(
+    'rejects invalid module-level $caseName before request handling starts',
+    ({ expectedField, options }: { expectedField: RegExp; options: ThrottlerModuleOptions }) => {
+      expect(() => ThrottlerModule.forRoot(options)).toThrow(expectedField);
+    },
+  );
 
   it('rejects malformed keyGenerator and store.consume options before request handling starts', () => {
     const malformedKeyGeneratorOptions = { keyGenerator: 'api-key', limit: 1, ttl: 60 };


### PR DESCRIPTION
## Summary

Complete the missing positive-finite-integer boundary coverage for `@fluojs/throttler` module and decorator policy validation.

Linked context: https://github.com/fluojs/fluo/issues/2923

Closes #2923

## Changes

- Convert the existing module-level and decorator-level invalid policy assertions into per-case validation tables.
- Cover module options for `ttl=0`, `ttl=NaN`, `ttl=Infinity`, and `limit=NaN`.
- Cover `@Throttle(...)` options for `limit=NaN`, `limit=Infinity`, `ttl=0`, and `ttl=Infinity`.
- Assert that every rejection identifies the corresponding `limit` or `ttl` field.

## Testing

- `pnpm --filter @fluojs/throttler... build`
- `pnpm --filter @fluojs/throttler typecheck`
- `pnpm --filter @fluojs/throttler test` — 4 files and 81 tests passed.
- `pnpm exec biome lint packages/throttler/src/module.test.ts`
- LSP diagnostics for `packages/throttler`: 0 errors.

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

No changeset is required because this PR changes tests only and preserves the existing documented and implemented validation contract.

## Public export documentation

- [x] Not applicable: no public exports or source TSDoc changed.

## Behavioral contract

- [x] No documented behavioral contracts were removed or changed.
- [x] The existing positive-finite-integer runtime invariant now has complete module-level and decorator-level boundary regression coverage.
- [x] No intentional limitations changed.

## Platform consistency governance (SSOT)

- [x] Not applicable: no governance docs, platform contracts, or README claims changed.
- [x] Existing cross-runtime behavior remains unchanged because this is test-only coverage.