### PR TITLE
Resolve #2943: Correct core metadata chapter claims

### DIFF
--- a/book/advanced/ch02-metadata.ko.md
+++ b/book/advanced/ch02-metadata.ko.md
@@ -193,11 +193,35 @@ export function getStandardMetadataBag(target: object): StandardMetadataBag | un
 ```
 이 helper는 active metadata symbol을 해석하고, target의 own current/native bag, target의 own fallback-era bag, inherited bag 순서로 조회합니다. Own bag과 inherited bag이 함께 있으면 `overlayStandardMetadataBag(...)`이 own-key precedence를 보존하면서 inherited record를 계속 보이게 합니다. 앞서 설명한 `Object.hasOwn`과 `Reflect.get` 연산은 하위 own-bag reader에서 수행합니다.
 
-Fluo에서 `Reflect` 사용의 또 다른 예는 대상에 데코레이터 시퀀스를 수동으로 적용하는 `applyDecorators` 유틸리티 내에 있습니다. 여기서 `Reflect` 메서드는 속성 기술자(descriptor)와 클래스 정의가 명세에 따라 처리되도록 보장하여 데코레이팅된 엘리먼트의 무결성을 유지하는 데 사용됩니다. 이는 메서드의 반환 값이나 속성의 기술자를 수정할 수 있는 데코레이터들을 조합할 때 특히 중요합니다.
+Metadata property map 병합은 별도 경로를 따르며 `Reflect.ownKeys`를 호출하지 않습니다.
+`path:packages/core/src/metadata/shared.ts:369-397`
+```typescript
+export function mergeMetadataPropertyKeys<TStored, TStandard>(
+  stored: ReadonlyMap<MetadataPropertyKey, TStored> | undefined,
+  standard: ReadonlyMap<MetadataPropertyKey, TStandard> | undefined,
+): MetadataPropertyKey[] {
+  const keys: MetadataPropertyKey[] = [];
+  const seen = new Set<MetadataPropertyKey>();
 
-우리는 또한 메타데이터 병합 로직에서 `Reflect.ownKeys`를 사용합니다. 이를 통해 심볼을 포함한 메타데이터 가방의 모든 키를 검색하여 깊은 병합 및 중복 제거를 수행할 수 있습니다. `Object.keys` 대신 `Reflect.ownKeys`를 사용함으로써 Fluo 구성의 핵심을 형성하는 심볼릭 메타데이터를 하나도 놓치지 않도록 보장합니다. 이러한 철저함은 복잡한 상속이나 조합 시나리오에서 프레임워크가 구성을 놓치는 것을 방지합니다.
+  for (const source of [stored, standard]) {
+    if (!source) {
+      continue;
+    }
 
-이러한 `Reflect.ownKeys`의 활용은 특히 여러 패키지가 하나의 클래스에 각자의 데코레이터를 붙이는 다중 확장 시나리오에서 빛을 발합니다. 예를 들어 `@Controller` (HTTP), `@ApiTag` (OpenAPI), `@Inject(TOKEN)` (DI)이 동시에 적용된 클래스에서, Fluo는 모든 메타데이터 키를 안전하게 수집하여 각 서브시스템이 자신의 데이터만 정확히 추출해 갈 수 있도록 보장합니다. 이는 문자열 키를 사용했을 때 발생할 수 있는 덮어쓰기 위험을 원천 차단하는 가장 표준적인 방법입니다.
+    for (const key of source.keys()) {
+      if (!seen.has(key)) {
+        seen.add(key);
+        keys.push(key);
+      }
+    }
+  }
+
+  return keys;
+}
+```
+`mergeMetadataPropertyKeys`는 명시적인 Fluo store를 먼저 확인하고 standard metadata map을 그다음 확인합니다. 각 map은 `Map` insertion order에 따라 key를 제공하고, `seen`은 처음 나타난 위치를 바꾸지 않으면서 중복을 제거합니다. `MetadataPropertyKey`에는 string key와 symbol key가 모두 포함되므로 reflective object-key scan 없이 두 형태를 모두 보존합니다. 이는 정렬된 key list를 병합하는 동작이며 metadata bag을 deep merge하는 동작이 아닙니다.
+
+`Reflect.ownKeys`는 core의 다른 위치인 `packages/core/src/utils.ts:86-95`의 fallback object-cloning 경로에서 사용됩니다. 그곳에서는 값을 clone할 때 모든 own string/symbol property descriptor를 보존합니다. 이는 metadata merge mechanism이 아닙니다.
 
 DI 컨테이너에서는 `Reflect.construct`를 사용하여 프로바이더를 인스턴스화합니다. 이는 대상의 생성자 로직을 존중하면서 인자 배열을 동적으로 전달할 수 있게 해주기 때문에 `new` 연산자보다 선호됩니다. 또한 사용자에게 구현 세부 사항을 노출하지 않고도 요청 범위 프로바이더나 transient 수명 주기와 같은 기능을 지원하는 데 필수적인 "프록시 생성자(proxied constructors)"와 같은 고급 패턴을 가능하게 합니다.
 

--- a/book/advanced/ch02-metadata.md
+++ b/book/advanced/ch02-metadata.md
@@ -193,11 +193,35 @@ export function getStandardMetadataBag(target: object): StandardMetadataBag | un
 ```
 This helper resolves the active metadata symbol, prefers the target's own current/native bag, falls back to the target's own fallback-era bag, and then reads inherited bags. When own and inherited bags coexist, `overlayStandardMetadataBag(...)` preserves own-key precedence while leaving inherited records visible. The lower-level own-bag reader performs the `Object.hasOwn` and `Reflect.get` operations described earlier.
 
-Another example of `Reflect` use in Fluo appears inside the `applyDecorators` utility, which manually applies a sequence of Decorators to a target. Here, `Reflect` methods are used to ensure property descriptors and class definitions are processed according to the specification, preserving the integrity of decorated elements. This is especially important when composing Decorators that may modify a method's return value or a property's descriptor.
+Metadata property-map merging follows a separate path and does not call `Reflect.ownKeys`.
+`path:packages/core/src/metadata/shared.ts:369-397`
+```typescript
+export function mergeMetadataPropertyKeys<TStored, TStandard>(
+  stored: ReadonlyMap<MetadataPropertyKey, TStored> | undefined,
+  standard: ReadonlyMap<MetadataPropertyKey, TStandard> | undefined,
+): MetadataPropertyKey[] {
+  const keys: MetadataPropertyKey[] = [];
+  const seen = new Set<MetadataPropertyKey>();
 
-We also use `Reflect.ownKeys` in metadata merge logic. This retrieves every key in the metadata bag, including symbols, so deep merging and deduplication can be performed. By using `Reflect.ownKeys` instead of `Object.keys`, Fluo ensures it does not miss any symbolic metadata that forms the core of Fluo configuration. This thoroughness prevents the framework from missing configuration in complex inheritance or composition scenarios.
+  for (const source of [stored, standard]) {
+    if (!source) {
+      continue;
+    }
 
-This use of `Reflect.ownKeys` is especially valuable in multi-extension scenarios where several packages attach their own Decorators to a single class. For example, in a class with `@Controller` (HTTP), `@ApiTag` (OpenAPI), and `@Inject(TOKEN)` (DI) applied at the same time, Fluo safely collects every metadata key so each subsystem can extract exactly its own data. This is the most standard way to eliminate the overwrite risk that string keys can create.
+    for (const key of source.keys()) {
+      if (!seen.has(key)) {
+        seen.add(key);
+        keys.push(key);
+      }
+    }
+  }
+
+  return keys;
+}
+```
+`mergeMetadataPropertyKeys` examines the explicit Fluo store first and the standard metadata map second. Each map contributes keys in its `Map` insertion order, while `seen` removes duplicates without changing the first occurrence's position. Because `MetadataPropertyKey` includes string and symbol keys, both forms are retained without a reflective object-key scan. This merges ordered key lists; it does not deep-merge metadata bags.
+
+`Reflect.ownKeys` does appear elsewhere in core, in the fallback object-cloning path at `packages/core/src/utils.ts:86-95`. There it preserves every own string and symbol property descriptor while cloning a value. It is not the metadata merge mechanism.
 
 The DI container uses `Reflect.construct` to instantiate Providers. This is preferred over the `new` operator because it respects the target's constructor logic while allowing argument arrays to be passed dynamically. It also enables advanced patterns such as proxied constructors, which are essential for supporting features such as request-scoped Providers or transient lifecycles without exposing implementation details to users.
 

--- a/tooling/governance/verify-platform-consistency-governance.test.ts
+++ b/tooling/governance/verify-platform-consistency-governance.test.ts
@@ -434,6 +434,28 @@ describe('changedFilesFromGit', () => {
 });
 
 describe('enforceAdvancedBookCoreBoundaryCompanions', () => {
+  it('keeps the advanced metadata key-merge examples synchronized with core source', () => {
+    // Given: the authoritative core implementation and both localized chapter mirrors.
+    const source = readFileSync(join(repoRoot, 'packages/core/src/metadata/shared.ts'), 'utf8');
+    const english = readFileSync(join(repoRoot, 'book/advanced/ch02-metadata.md'), 'utf8');
+    const korean = readFileSync(join(repoRoot, 'book/advanced/ch02-metadata.ko.md'), 'utf8');
+
+    // When: the implementation and path-anchored documentation examples are extracted.
+    const implementationMatch = /export function mergeMetadataPropertyKeys[\s\S]*?\n\}\n/u.exec(source);
+    const documentedExamplePattern = /`path:packages\/core\/src\/metadata\/shared\.ts:369-397`\n```typescript\n([\s\S]*?)\n```/u;
+    const englishMatch = documentedExamplePattern.exec(english);
+    const koreanMatch = documentedExamplePattern.exec(korean);
+
+    if (!implementationMatch || !englishMatch || !koreanMatch) {
+      throw new TypeError('Expected the core metadata key-merge implementation and both documented examples.');
+    }
+
+    const implementation = implementationMatch[0].trimEnd();
+
+    // Then: each mirror presents the exact ordered Map-key merge implemented by core.
+    expect([englishMatch[1], koreanMatch[1]]).toEqual([implementation, implementation]);
+  });
+
   it('requires advanced metadata chapter EN/KO companions to change together', async () => {
     const { enforceAdvancedBookCoreBoundaryCompanions } = await loadGovernanceInternals();
 


### PR DESCRIPTION
## Summary

Correct the advanced metadata chapter so the English and Korean learning-path mirrors describe the current `@fluojs/core` implementation instead of nonexistent or misattributed APIs.

Linked context: https://github.com/fluojs/fluo/issues/2943

Closes #2943

## Changes

- Remove the nonexistent `applyDecorators` claim from both chapter mirrors.
- Document `mergeMetadataPropertyKeys(...)` as an ordered `Map.keys()` merge with first-seen deduplication.
- Clarify that `Reflect.ownKeys` belongs to the fallback object-cloning path, not metadata merging.
- Add focused governance regression coverage that keeps both localized code examples synchronized with the core source implementation.
- Preserve all 15 EN/KO headings without structural changes.

## Testing

- `pnpm verify:platform-consistency-governance` — passed.
- `pnpm docs:sync-check` — passed (42 EN/KO page pairs and 10 navigation metadata pairs).
- `pnpm vitest run tooling/governance/verify-platform-consistency-governance.test.ts` — passed (1 file, 119 tests).
- `pnpm build` — passed.
- `pnpm typecheck` — passed.
- `pnpm lint` — passed; existing repository diagnostics remained informational/warnings only.
- Focused heading comparison — 15/15 headings are identical across `ch02-metadata.md` and `ch02-metadata.ko.md`.
- `pnpm test` extra full-suite run — all 408 files and 4,729 executed tests passed on the first run, but Vitest exited non-zero on one worker RPC `onTaskUpdate` timeout. A retry while multiple other worktree suites were concurrently active produced unrelated timeout failures. No full-suite green result is claimed; changed-scope governance tests are green.

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

Documentation-only correction; no package behavior, API surface, package contents, or release metadata changed, so no `.changeset/*.md` file is included.

## Public export documentation

- [ ] Changed public exports include a source-level summary.
- [ ] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [ ] Source `@example` blocks and README scenario examples still play complementary roles.

Not applicable: no public exports or package source files changed.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [ ] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [ ] Runtime invariants are covered by regression tests.

No runtime contract changed. The book now matches the existing metadata lookup, ordered key merge, and clone implementation.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by the applicable platform harness tests.

No platform contract docs or package conformance claims changed. The EN/KO book mirrors remain structurally synchronized and the focused governance test locks their source example to `packages/core/src/metadata/shared.ts`.