### PR TITLE
Resolve #2941: lock WebSocket runtime contracts and cleanup paths

### DIFF
--- a/packages/websockets/src/bun/bun.test.ts
+++ b/packages/websockets/src/bun/bun.test.ts
@@ -325,6 +325,59 @@ describe('@fluojs/websockets/bun', () => {
     }
   });
 
+  it('joins, leaves, broadcasts, and reads rooms through the Bun lifecycle service', async () => {
+    const adapter = new TestBunAdapter();
+
+    @WebSocketGateway({ path: '/rooms' })
+    class RoomGateway {
+      @OnMessage('ping')
+      onPing() {}
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [BunWebSocketModule.forRoot()],
+      providers: [RoomGateway],
+    });
+
+    const app = await bootstrapApplication({ adapter, rootModule: AppModule });
+    const service = await app.container.resolve<BunWebSocketGatewayLifecycleService>(BunWebSocketGatewayLifecycleService);
+
+    try {
+      await app.listen();
+      const server = adapter.getServer();
+      const upgradeResponse = await server?.fetch(new Request('http://127.0.0.1:3000/rooms', {
+        headers: { upgrade: 'websocket' },
+      }));
+      await flushAsyncWork();
+
+      const socket = server?.lastSocket;
+      const socketRegistry = Reflect.get(service, 'socketRegistry') as Map<string, BunServerWebSocket>;
+      const socketId = socketRegistry.keys().next().value;
+      expect(upgradeResponse).toBeUndefined();
+
+      if (!socket || typeof socketId !== 'string') {
+        throw new Error('Expected Bun room test socket registration after websocket upgrade.');
+      }
+
+      service.joinRoom(socketId, 'room-a');
+      service.joinRoom(socketId, 'room-b');
+
+      expect(Array.from(service.getRooms(socketId)).sort()).toEqual(['room-a', 'room-b']);
+
+      service.broadcastToRoom('room-a', 'order.updated', { orderId: 'ord_bun' });
+      service.leaveRoom(socketId, 'room-a');
+      service.broadcastToRoom('room-a', 'order.updated', { orderId: 'ord_after_leave' });
+
+      expect(socket.sentMessages).toEqual([
+        JSON.stringify({ data: { orderId: 'ord_bun' }, event: 'order.updated' }),
+      ]);
+      expect(Array.from(service.getRooms(socketId))).toEqual(['room-b']);
+    } finally {
+      await app.close();
+    }
+  });
+
   it('awaits raw Bun handler return promises before ignoring returned values', async () => {
     const adapter = new TestBunAdapter();
     const handlerGate = createDeferred<void>();
@@ -389,6 +442,43 @@ describe('@fluojs/websockets/bun', () => {
 
       expect(state.messages).toEqual([{ value: 'ignored' }, { value: 'after' }]);
       expect(socket.sentMessages).toEqual([]);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it.each([
+    ['true', (): true => true, undefined],
+    ['undefined', (): undefined => undefined, undefined],
+    ['no return value', (): void => {}, undefined],
+    ['false', (): false => false, 403],
+  ] as const)('maps a Bun guard %s outcome to the documented upgrade decision', async (_outcome, guard, expectedStatus) => {
+    const adapter = new TestBunAdapter();
+
+    @WebSocketGateway({ path: '/guard-outcome' })
+    class GuardedGateway {
+      @OnMessage('ping')
+      onPing() {}
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [BunWebSocketModule.forRoot({ upgrade: { guard } })],
+      providers: [GuardedGateway],
+    });
+
+    const app = await bootstrapApplication({ adapter, rootModule: AppModule });
+    try {
+      await app.listen();
+
+      const server = adapter.getServer();
+      const response = await server?.fetch(new Request('http://127.0.0.1:3000/guard-outcome', {
+        headers: { upgrade: 'websocket' },
+      }));
+      await flushAsyncWork();
+
+      expect(response?.status).toBe(expectedStatus);
+      expect(server?.lastSocket !== undefined).toBe(expectedStatus === undefined);
     } finally {
       await app.close();
     }

--- a/packages/websockets/src/cloudflare-workers/cloudflare-workers.test.ts
+++ b/packages/websockets/src/cloudflare-workers/cloudflare-workers.test.ts
@@ -383,6 +383,98 @@ describe('@fluojs/websockets/cloudflare-workers', () => {
     }
   });
 
+  it('joins, leaves, broadcasts, and reads rooms through the Worker lifecycle service', async () => {
+    const adapter = new TestWorkerAdapter();
+
+    @WebSocketGateway({ path: '/rooms' })
+    class RoomGateway {
+      @OnMessage('ping')
+      onPing() {}
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [CloudflareWorkersWebSocketModule.forRoot()],
+      providers: [RoomGateway],
+    });
+
+    const app = await bootstrapApplication({ adapter, rootModule: AppModule });
+    const service = await app.container.resolve<CloudflareWorkersWebSocketGatewayLifecycleService>(
+      CloudflareWorkersWebSocketGatewayLifecycleService,
+    );
+
+    try {
+      await app.listen();
+      const server = adapter.getServer();
+      const upgradeResponse = await server?.fetch(new Request('https://worker.test/rooms', {
+        headers: { upgrade: 'websocket' },
+      }));
+      await flushAsyncWork();
+
+      const socket = server?.lastSocket;
+      const socketRegistry = Reflect.get(service, 'socketRegistry') as Map<string, CloudflareWorkerWebSocket>;
+      const socketId = socketRegistry.keys().next().value;
+      expect(upgradeResponse?.status).toBe(200);
+
+      if (!socket || typeof socketId !== 'string') {
+        throw new Error('Expected Worker room test socket registration after websocket upgrade.');
+      }
+
+      service.joinRoom(socketId, 'room-a');
+      service.joinRoom(socketId, 'room-b');
+
+      expect(Array.from(service.getRooms(socketId)).sort()).toEqual(['room-a', 'room-b']);
+
+      service.broadcastToRoom('room-a', 'order.updated', { orderId: 'ord_workers' });
+      service.leaveRoom(socketId, 'room-a');
+      service.broadcastToRoom('room-a', 'order.updated', { orderId: 'ord_after_leave' });
+
+      expect(socket.sentMessages).toEqual([
+        JSON.stringify({ data: { orderId: 'ord_workers' }, event: 'order.updated' }),
+      ]);
+      expect(Array.from(service.getRooms(socketId))).toEqual(['room-b']);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it.each([
+    ['true', (): true => true, 200],
+    ['undefined', (): undefined => undefined, 200],
+    ['no return value', (): void => {}, 200],
+    ['false', (): false => false, 403],
+  ] as const)('maps a Worker guard %s outcome to the documented upgrade decision', async (_outcome, guard, expectedStatus) => {
+    const adapter = new TestWorkerAdapter();
+
+    @WebSocketGateway({ path: '/guard-outcome' })
+    class GuardedGateway {
+      @OnMessage('ping')
+      onPing() {}
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [CloudflareWorkersWebSocketModule.forRoot({ upgrade: { guard } })],
+      providers: [GuardedGateway],
+    });
+
+    const app = await bootstrapApplication({ adapter, rootModule: AppModule });
+    try {
+      await app.listen();
+
+      const server = adapter.getServer();
+      const response = await server?.fetch(new Request('https://worker.test/guard-outcome', {
+        headers: { upgrade: 'websocket' },
+      }));
+      await flushAsyncWork();
+
+      expect(response?.status).toBe(expectedStatus);
+      expect(server?.lastSocket !== undefined).toBe(expectedStatus === 200);
+    } finally {
+      await app.close();
+    }
+  });
+
   it('rejects anonymous upgrade requests before the Worker websocket upgrade completes', async () => {
     const adapter = new TestWorkerAdapter();
 

--- a/packages/websockets/src/decorators.ts
+++ b/packages/websockets/src/decorators.ts
@@ -108,8 +108,8 @@ export function WebSocketGateway(
  *
  * class ChatGateway {
  *   @OnMessage('ping')
- *   handlePing(payload: unknown) {
- *     return payload;
+ *   handlePing(payload: unknown, socket: { send(data: string): void }) {
+ *     socket.send(JSON.stringify({ event: 'pong', data: payload }));
  *   }
  * }
  * ```

--- a/packages/websockets/src/deno/deno.test.ts
+++ b/packages/websockets/src/deno/deno.test.ts
@@ -396,6 +396,59 @@ describe('@fluojs/websockets/deno', () => {
     }
   });
 
+  it('joins, leaves, broadcasts, and reads rooms through the Deno lifecycle service', async () => {
+    const adapter = new TestDenoAdapter();
+
+    @WebSocketGateway({ path: '/rooms' })
+    class RoomGateway {
+      @OnMessage('ping')
+      onPing() {}
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [DenoWebSocketModule.forRoot()],
+      providers: [RoomGateway],
+    });
+
+    const app = await bootstrapApplication({ adapter, rootModule: AppModule });
+    const service = await app.container.resolve<DenoWebSocketGatewayLifecycleService>(DenoWebSocketGatewayLifecycleService);
+
+    try {
+      await app.listen();
+      const server = adapter.getServer();
+      const upgradeResponse = await server?.fetch(new Request('https://runtime.test/rooms', {
+        headers: { upgrade: 'websocket' },
+      }));
+      await flushAsyncWork();
+
+      const socket = server?.lastSocket;
+      const socketRegistry = Reflect.get(service, 'socketRegistry') as Map<string, DenoServerWebSocket>;
+      const socketId = socketRegistry.keys().next().value;
+      expect(upgradeResponse?.status).toBe(200);
+
+      if (!socket || typeof socketId !== 'string') {
+        throw new Error('Expected Deno room test socket registration after websocket upgrade.');
+      }
+
+      service.joinRoom(socketId, 'room-a');
+      service.joinRoom(socketId, 'room-b');
+
+      expect(Array.from(service.getRooms(socketId)).sort()).toEqual(['room-a', 'room-b']);
+
+      service.broadcastToRoom('room-a', 'order.updated', { orderId: 'ord_deno' });
+      service.leaveRoom(socketId, 'room-a');
+      service.broadcastToRoom('room-a', 'order.updated', { orderId: 'ord_after_leave' });
+
+      expect(socket.sentMessages).toEqual([
+        JSON.stringify({ data: { orderId: 'ord_deno' }, event: 'order.updated' }),
+      ]);
+      expect(Array.from(service.getRooms(socketId))).toEqual(['room-b']);
+    } finally {
+      await app.close();
+    }
+  });
+
   it('awaits raw Deno handler return promises before ignoring returned values', async () => {
     const adapter = new TestDenoAdapter();
     const handlerGate = createDeferred<void>();
@@ -460,6 +513,43 @@ describe('@fluojs/websockets/deno', () => {
 
       expect(state.messages).toEqual([{ value: 'ignored' }, { value: 'after' }]);
       expect(socket.sentMessages).toEqual([]);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it.each([
+    ['true', (): true => true, 200],
+    ['undefined', (): undefined => undefined, 200],
+    ['no return value', (): void => {}, 200],
+    ['false', (): false => false, 403],
+  ] as const)('maps a Deno guard %s outcome to the documented upgrade decision', async (_outcome, guard, expectedStatus) => {
+    const adapter = new TestDenoAdapter();
+
+    @WebSocketGateway({ path: '/guard-outcome' })
+    class GuardedGateway {
+      @OnMessage('ping')
+      onPing() {}
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [DenoWebSocketModule.forRoot({ upgrade: { guard } })],
+      providers: [GuardedGateway],
+    });
+
+    const app = await bootstrapApplication({ adapter, rootModule: AppModule });
+    try {
+      await app.listen();
+
+      const server = adapter.getServer();
+      const response = await server?.fetch(new Request('https://runtime.test/guard-outcome', {
+        headers: { upgrade: 'websocket' },
+      }));
+      await flushAsyncWork();
+
+      expect(response?.status).toBe(expectedStatus);
+      expect(server?.lastSocket !== undefined).toBe(expectedStatus === 200);
     } finally {
       await app.close();
     }

--- a/packages/websockets/src/module.test.ts
+++ b/packages/websockets/src/module.test.ts
@@ -164,37 +164,42 @@ function createUpgradeRequest(path: string): string {
 }
 
 async function readUpgradeResponse(port: number, request: string): Promise<string> {
-  return await new Promise<string>((resolve, reject) => {
-    const socket = createConnection({ host: '127.0.0.1', port });
-    const chunks: Buffer[] = [];
-    let settled = false;
+  const socket = createConnection({ host: '127.0.0.1', port });
 
-    const settle = (callback: () => void) => {
-      if (settled) {
-        return;
-      }
+  try {
+    return await new Promise<string>((resolve, reject) => {
+      const chunks: Buffer[] = [];
+      let settled = false;
 
-      settled = true;
-      callback();
-    };
+      const settle = (callback: () => void) => {
+        if (settled) {
+          return;
+        }
 
-    socket.once('connect', () => {
-      socket.write(request);
-    });
-    socket.on('data', (chunk) => {
-      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
-    });
-    socket.once('close', (hadError) => {
-      if (hadError) {
-        return;
-      }
+        settled = true;
+        callback();
+      };
 
-      settle(() => resolve(Buffer.concat(chunks).toString('utf8')));
+      socket.once('connect', () => {
+        socket.write(request);
+      });
+      socket.on('data', (chunk) => {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      });
+      socket.once('close', (hadError) => {
+        if (hadError) {
+          return;
+        }
+
+        settle(() => resolve(Buffer.concat(chunks).toString('utf8')));
+      });
+      socket.once('error', (error) => {
+        settle(() => reject(error));
+      });
     });
-    socket.once('error', (error) => {
-      settle(() => reject(error));
-    });
-  });
+  } finally {
+    socket.destroy();
+  }
 }
 
 function onceCloseDetails(socket: WebSocket): Promise<{ code: number; reason: Buffer }> {
@@ -767,26 +772,32 @@ describe('@fluojs/websockets', () => {
     });
     const state = await app.container.resolve(GatewayState);
 
-    await app.listen();
-    const port = await getApplicationPort(app);
+    try {
+      await app.listen();
+      const port = await getApplicationPort(app);
 
-    const socket = new WebSocket(`ws://127.0.0.1:${String(port)}/chat`);
-    await onceOpen(socket);
-    socket.send(JSON.stringify({ event: 'ping', data: { value: 'hello' } }));
+      const socket = new WebSocket(`ws://127.0.0.1:${String(port)}/chat`);
+      try {
+        await onceOpen(socket);
+        socket.send(JSON.stringify({ event: 'ping', data: { value: 'hello' } }));
 
-    const incoming = await onceMessage(socket);
-    expect(JSON.parse(incoming)).toEqual({ event: 'pong', data: { value: 'hello' } });
+        const incoming = await onceMessage(socket);
+        expect(JSON.parse(incoming)).toEqual({ event: 'pong', data: { value: 'hello' } });
 
-    await closeWebSocket(socket);
+        await closeWebSocket(socket);
 
-    await waitForAssertion(() => {
-      expect(state.disconnectCount).toBe(1);
-    });
+        await waitForAssertion(() => {
+          expect(state.disconnectCount).toBe(1);
+        });
 
-    expect(state.connectCount).toBe(1);
-    expect(state.messages).toEqual([{ value: 'hello' }]);
-
-    await app.close();
+        expect(state.connectCount).toBe(1);
+        expect(state.messages).toEqual([{ value: 'hello' }]);
+      } finally {
+        await closeWebSocket(socket);
+      }
+    } finally {
+      await app.close();
+    }
   });
 
   it('boots an Express app, connects websocket client, handles message, and disconnects', async () => {
@@ -830,26 +841,32 @@ describe('@fluojs/websockets', () => {
     });
     const state = await app.container.resolve(GatewayState);
 
-    await app.listen();
-    const port = await getApplicationPort(app);
+    try {
+      await app.listen();
+      const port = await getApplicationPort(app);
 
-    const socket = new WebSocket(`ws://127.0.0.1:${String(port)}/chat`);
-    await onceOpen(socket);
-    socket.send(JSON.stringify({ event: 'ping', data: { value: 'hello' } }));
+      const socket = new WebSocket(`ws://127.0.0.1:${String(port)}/chat`);
+      try {
+        await onceOpen(socket);
+        socket.send(JSON.stringify({ event: 'ping', data: { value: 'hello' } }));
 
-    const incoming = await onceMessage(socket);
-    expect(JSON.parse(incoming)).toEqual({ event: 'pong', data: { value: 'hello' } });
+        const incoming = await onceMessage(socket);
+        expect(JSON.parse(incoming)).toEqual({ event: 'pong', data: { value: 'hello' } });
 
-    await closeWebSocket(socket);
+        await closeWebSocket(socket);
 
-    await waitForAssertion(() => {
-      expect(state.disconnectCount).toBe(1);
-    });
+        await waitForAssertion(() => {
+          expect(state.disconnectCount).toBe(1);
+        });
 
-    expect(state.connectCount).toBe(1);
-    expect(state.messages).toEqual([{ value: 'hello' }]);
-
-    await app.close();
+        expect(state.connectCount).toBe(1);
+        expect(state.messages).toEqual([{ value: 'hello' }]);
+      } finally {
+        await closeWebSocket(socket);
+      }
+    } finally {
+      await app.close();
+    }
   });
 
   for (const scenario of serverBackedGatewayScenarios) {
@@ -906,36 +923,42 @@ describe('@fluojs/websockets', () => {
         port: 0,
       });
       const state = await app.container.resolve(GatewayState);
-    const service = await app.container.resolve(WebSocketGatewayLifecycleService) as unknown as NodeWebSocketGatewayLifecycleServiceImplementation;
+      const service = await app.container.resolve(WebSocketGatewayLifecycleService) as unknown as NodeWebSocketGatewayLifecycleServiceImplementation;
 
-      await app.listen();
-      const appPort = await getApplicationPort(app);
-      const websocketPort = getOwnedGatewayPort(service);
+      try {
+        await app.listen();
+        const appPort = await getApplicationPort(app);
+        const websocketPort = getOwnedGatewayPort(service);
 
-      const socket = new WebSocket(`ws://127.0.0.1:${String(websocketPort)}/chat`);
-      await onceOpen(socket);
-      socket.send(JSON.stringify({ event: 'ping', data: { value: scenario.name } }));
+        const socket = new WebSocket(`ws://127.0.0.1:${String(websocketPort)}/chat`);
+        try {
+          await onceOpen(socket);
+          socket.send(JSON.stringify({ event: 'ping', data: { value: scenario.name } }));
 
-      const incoming = await onceMessage(socket);
-      expect(JSON.parse(incoming)).toEqual({ event: 'pong', data: { value: scenario.name } });
+          const incoming = await onceMessage(socket);
+          expect(JSON.parse(incoming)).toEqual({ event: 'pong', data: { value: scenario.name } });
 
-      await closeWebSocket(socket);
+          await closeWebSocket(socket);
 
-      await waitForAssertion(() => {
-        expect(state.disconnectCount).toBe(1);
-      });
+          await waitForAssertion(() => {
+            expect(state.disconnectCount).toBe(1);
+          });
 
-      const healthResponse = await fetch(`http://127.0.0.1:${String(appPort)}/health`);
-      expect(healthResponse.status).toBe(200);
-      await expect(healthResponse.json()).resolves.toEqual({ ok: true });
+          const healthResponse = await fetch(`http://127.0.0.1:${String(appPort)}/health`);
+          expect(healthResponse.status).toBe(200);
+          await expect(healthResponse.json()).resolves.toEqual({ ok: true });
 
-      const mainPortResponse = await fetch(`http://127.0.0.1:${String(appPort)}/chat`);
-      expect(mainPortResponse.status).toBe(404);
+          const mainPortResponse = await fetch(`http://127.0.0.1:${String(appPort)}/chat`);
+          expect(mainPortResponse.status).toBe(404);
 
-      expect(state.connectCount).toBe(1);
-      expect(state.messages).toEqual([{ value: scenario.name }]);
-
-      await app.close();
+          expect(state.connectCount).toBe(1);
+          expect(state.messages).toEqual([{ value: scenario.name }]);
+        } finally {
+          await closeWebSocket(socket);
+        }
+      } finally {
+        await app.close();
+      }
 
       expect((Reflect.get(state, 'disconnectCount') as number)).toBe(1);
     });
@@ -998,6 +1021,23 @@ describe('@fluojs/websockets', () => {
     });
 
     await app.close();
+  });
+
+  it.each([
+    ['true', (): true => true, undefined],
+    ['undefined', (): undefined => undefined, undefined],
+    ['no return value', (): void => {}, undefined],
+    ['false', (): false => false, { body: 'WebSocket upgrade rejected.', status: 403 }],
+  ] as const)('maps a Node guard %s outcome to the documented upgrade decision', async (_outcome, guard, expected) => {
+    const service = createTestLifecycleService({ upgrade: { guard } });
+    const resolveUpgradeRejection = Reflect.get(service, 'resolveUpgradeRejection') as (
+      request: IncomingMessage,
+      path: string,
+    ) => Promise<{ body?: string; status: number } | undefined>;
+
+    const rejection = await resolveUpgradeRejection.call(service, { headers: {} } as IncomingMessage, '/guard-outcome');
+
+    expect(rejection).toEqual(expected);
   });
 
   it('rejects anonymous websocket upgrades before the handshake completes', async () => {
@@ -1628,6 +1668,57 @@ describe('@fluojs/websockets', () => {
     expect(startHeartbeatSpy).toHaveBeenCalledWith(30_000, 30_000);
   });
 
+  it('resolves the documented connection, payload, and shutdown defaults', () => {
+    const service = createTestLifecycleService();
+    const resolveMaxConnectionCount = Reflect.get(service, 'resolveMaxConnectionCount') as () => number;
+    const resolveMaxPayloadBytes = Reflect.get(service, 'resolveMaxPayloadBytes') as () => number;
+    const resolveShutdownTimeoutMs = Reflect.get(service, 'resolveShutdownTimeoutMs') as () => number;
+
+    expect(resolveMaxConnectionCount.call(service)).toBe(1_000);
+    expect(resolveMaxPayloadBytes.call(service)).toBe(1_048_576);
+    expect(resolveShutdownTimeoutMs.call(service)).toBe(5_000);
+  });
+
+  it('keeps the documented default of 256 pending messages per socket', () => {
+    const service = createTestLifecycleService();
+    const { socket } = createMockSocket();
+    const state = createTrackedSocketState('socket-default-buffer');
+    const bufferIncomingMessage = Reflect.get(service, 'bufferIncomingMessage') as (
+      state: ReturnType<typeof createTrackedSocketState>,
+      socket: WebSocket,
+      data: Buffer,
+    ) => void;
+
+    for (let index = 0; index <= 256; index += 1) {
+      bufferIncomingMessage.call(service, state, socket, Buffer.from(`message-${String(index)}`));
+    }
+
+    const retainedMessages = (state.bufferedMessages as Buffer[]).slice(state.bufferedMessagesStartIndex);
+
+    expect(retainedMessages).toHaveLength(256);
+    expect(retainedMessages[0]?.toString('utf8')).toBe('message-1');
+    expect(retainedMessages.at(-1)?.toString('utf8')).toBe('message-256');
+  });
+
+  it('drops Node room broadcasts above the documented default 1 MiB backpressure limit', () => {
+    const service = createTestLifecycleService();
+    const atLimit = createMockSocket();
+    const aboveLimit = createMockSocket();
+    const socketRegistry = Reflect.get(service, 'socketRegistry') as Map<string, WebSocket>;
+    (atLimit.socket as unknown as { bufferedAmount: number }).bufferedAmount = 1_048_576;
+    (aboveLimit.socket as unknown as { bufferedAmount: number }).bufferedAmount = 1_048_577;
+    socketRegistry.set('socket-at-limit', atLimit.socket);
+    socketRegistry.set('socket-above-limit', aboveLimit.socket);
+    service.joinRoom('socket-at-limit', 'room-default-backpressure');
+    service.joinRoom('socket-above-limit', 'room-default-backpressure');
+
+    service.broadcastToRoom('room-default-backpressure', 'order.updated', { orderId: 'ord_default' });
+
+    expect(atLimit.send).toHaveBeenCalledWith(JSON.stringify({ data: { orderId: 'ord_default' }, event: 'order.updated' }));
+    expect(aboveLimit.send).not.toHaveBeenCalled();
+    expect(aboveLimit.terminate).not.toHaveBeenCalled();
+  });
+
   it('caps ready-state message queue and drops newest queued messages when saturated', async () => {
     const service = createTestLifecycleService({
       buffer: {
@@ -2004,50 +2095,31 @@ describe('@fluojs/websockets', () => {
       port: 0,
     });
 
-    await app.listen();
-    const port = await getApplicationPort(app);
+    try {
+      await app.listen();
+      const port = await getApplicationPort(app);
 
-    const adapter = await app.container.resolve<HttpApplicationAdapter>(HTTP_APPLICATION_ADAPTER);
-    const server = adapter.getServer?.() as {
-      on(event: 'upgrade', listener: (request: IncomingMessage, socket: Duplex) => void): void;
-    };
-    const delegated = createDeferred<void>();
+      const adapter = await app.container.resolve<HttpApplicationAdapter>(HTTP_APPLICATION_ADAPTER);
+      const server = adapter.getServer?.() as {
+        on(event: 'upgrade', listener: (request: IncomingMessage, socket: Duplex) => void): void;
+      };
+      const delegated = createDeferred<void>();
 
-    server.on('upgrade', (request, socket) => {
-      if (request.url === '/missing') {
-        delegated.resolve();
-        socket.write('HTTP/1.1 426 Upgrade Required\r\nConnection: close\r\nContent-Length: 0\r\n\r\n');
-        socket.end();
-      }
-    });
-
-    const response = await new Promise<string>((resolve, reject) => {
-      const socket = createConnection({ host: '127.0.0.1', port }, () => {
-        socket.write(
-          'GET /missing HTTP/1.1\r\n'
-            + 'Host: 127.0.0.1\r\n'
-            + 'Connection: Upgrade\r\n'
-            + 'Upgrade: websocket\r\n'
-            + 'Sec-WebSocket-Version: 13\r\n'
-            + 'Sec-WebSocket-Key: dGVzdC1rZXktMDAwMDAw\r\n'
-            + '\r\n',
-        );
+      server.on('upgrade', (request, socket) => {
+        if (request.url === '/missing') {
+          delegated.resolve();
+          socket.write('HTTP/1.1 426 Upgrade Required\r\nConnection: close\r\nContent-Length: 0\r\n\r\n');
+          socket.end();
+        }
       });
-      const chunks: Buffer[] = [];
 
-      socket.on('data', (chunk) => {
-        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
-      });
-      socket.on('end', () => {
-        resolve(Buffer.concat(chunks).toString('utf8'));
-      });
-      socket.on('error', reject);
-    });
+      const response = await readUpgradeResponse(port, createUpgradeRequest('/missing'));
 
-    await delegated.promise;
-    expect(response).toContain('HTTP/1.1 426 Upgrade Required');
-
-    await app.close();
+      await delegated.promise;
+      expect(response).toContain('HTTP/1.1 426 Upgrade Required');
+    } finally {
+      await app.close();
+    }
   });
 
   it('rejects unmatched websocket upgrade requests with 404 when no later listener handles them', async () => {
@@ -2068,35 +2140,16 @@ describe('@fluojs/websockets', () => {
       port: 0,
     });
 
-    await app.listen();
-    const port = await getApplicationPort(app);
+    try {
+      await app.listen();
+      const port = await getApplicationPort(app);
 
-    const response = await new Promise<string>((resolve, reject) => {
-      const socket = createConnection({ host: '127.0.0.1', port }, () => {
-        socket.write(
-          'GET /missing HTTP/1.1\r\n'
-            + 'Host: 127.0.0.1\r\n'
-            + 'Connection: Upgrade\r\n'
-            + 'Upgrade: websocket\r\n'
-            + 'Sec-WebSocket-Version: 13\r\n'
-            + 'Sec-WebSocket-Key: dGVzdC1rZXktMDAwMDAw\r\n'
-            + '\r\n',
-        );
-      });
-      const chunks: Buffer[] = [];
+      const response = await readUpgradeResponse(port, createUpgradeRequest('/missing'));
 
-      socket.on('data', (chunk) => {
-        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
-      });
-      socket.on('end', () => {
-        resolve(Buffer.concat(chunks).toString('utf8'));
-      });
-      socket.on('error', reject);
-    });
-
-    expect(response).toContain('HTTP/1.1 404 Not Found');
-
-    await app.close();
+      expect(response).toContain('HTTP/1.1 404 Not Found');
+    } finally {
+      await app.close();
+    }
   });
 
 


### PR DESCRIPTION
## Summary

Harden the existing `@fluojs/websockets` behavioral-contract evidence across Node, Bun, Deno, and Cloudflare Workers without changing runtime behavior.

Linked context: https://github.com/fluojs/fluo/issues/2941

Closes #2941

## Changes

- lock `true`, `undefined`, no-return, and `false` upgrade-guard outcomes across all supported runtimes
- add Bun, Deno, and Workers room join/leave/getRooms/broadcast regression coverage
- lock documented Node/root defaults for connections, payloads, pending buffers, shutdown, heartbeat, and backpressure
- guarantee identified real listener and socket cleanup through `finally`
- correct the public `OnMessage()` TSDoc example to reply with `socket.send(...)`

## Testing

- `pnpm exec vitest run -c vitest.config.ts src/module.test.ts` — 59 passed
- `pnpm exec vitest run -c vitest.config.ts src/bun/bun.test.ts` — 26 passed
- `pnpm exec vitest run -c vitest.config.ts src/deno/deno.test.ts` — 29 passed
- `pnpm exec vitest run -c vitest.config.ts src/cloudflare-workers/cloudflare-workers.test.ts` — 27 passed
- `pnpm --dir packages/websockets test` — 160 passed
- `pnpm build` — passed
- `pnpm typecheck` — passed
- `pnpm lint` — passed; changed-mode public export TSDoc check passed (existing repository warnings/infos remain)
- `pnpm verify:platform-consistency-governance` — passed
- root `pnpm test` — 406 files / 4,748 tests passed; two unrelated 5-second timeouts occurred in `packages/platform-bun/src/published-declaration-surface.test.ts` and `packages/cli/src/commands/typegen-navigation.test.ts`, alongside a Vitest worker RPC timeout
- serial rerun of both unrelated timeout files with `--maxWorkers=1` — 2 files / 8 tests passed

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

No changeset: this is contract-preserving test coverage and a corrective source-TSDoc example only; it changes no runtime behavior, API shape, or published package contents beyond documentation emitted from the existing declaration.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No export shape changed. The existing `OnMessage()` summary and tags remain intact; only the misleading return-value example now matches the documented explicit-send contract.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

No new behavior was introduced. The existing EN/KO README contracts are now directly locked by runtime-specific tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests, such as `createPlatformConformanceHarness(...)` for platform component contracts or `createHttpAdapterPortabilityHarness(...)` for HTTP adapter portability contracts.

No governance or README text changed. Node, Bun, Deno, and Workers regression coverage now backs the already-documented contract.