### PR TITLE
Resolve #2941: lock WebSocket runtime contracts and cleanup paths

### DIFF
--- a/packages/websockets/src/bun/bun.test.ts
+++ b/packages/websockets/src/bun/bun.test.ts
@@ -16,6 +16,7 @@ import {
   type BunWebSocketMessage,
   BunWebSocketModule,
   type BunWebSocketUpgradeHost,
+  type WebSocketUpgradeGuard,
 } from './bun.js';
 
 type MockSocket = BunServerWebSocket<unknown> & {
@@ -27,6 +28,11 @@ const WEBSOCKET_CLOSED_READY_STATE = 3;
 const WEBSOCKET_OPEN_READY_STATE = 1;
 const BUN_WEBSOCKET_CAPABILITY_REASON =
   'Bun exposes Bun.serve() + server.upgrade() request-upgrade hosting. Use @fluojs/websockets/bun for the official raw websocket binding.';
+const allowedBunUpgradeGuardOutcomes = [
+  ['true', () => true],
+  ['undefined', () => undefined],
+  ['no return value', () => {}],
+] as const satisfies readonly (readonly [string, WebSocketUpgradeGuard])[];
 
 class TestBunAdapter implements HttpApplicationAdapter, BunWebSocketBindingHost {
   private binding?: BunWebSocketBinding<unknown>;
@@ -325,25 +331,35 @@ describe('@fluojs/websockets/bun', () => {
     }
   });
 
-  it('joins, leaves, broadcasts, and reads rooms through the Bun lifecycle service', async () => {
+  it('manages room membership and broadcasts through the Bun lifecycle service', async () => {
     const adapter = new TestBunAdapter();
 
+    class GatewayState {
+      socketId?: string;
+    }
+
+    @Inject(GatewayState)
     @WebSocketGateway({ path: '/rooms' })
     class RoomGateway {
-      @OnMessage('ping')
-      onPing() {}
+      constructor(private readonly state: GatewayState) {}
+
+      @OnConnect()
+      onConnect(_socket: BunServerWebSocket, _request: Request, socketId: string) {
+        this.state.socketId = socketId;
+      }
     }
 
     class AppModule {}
     defineModule(AppModule, {
       imports: [BunWebSocketModule.forRoot()],
-      providers: [RoomGateway],
+      providers: [GatewayState, RoomGateway],
     });
 
     const app = await bootstrapApplication({ adapter, rootModule: AppModule });
-    const service = await app.container.resolve<BunWebSocketGatewayLifecycleService>(BunWebSocketGatewayLifecycleService);
 
     try {
+      const state = await app.container.resolve(GatewayState);
+      const rooms = await app.container.resolve(BunWebSocketGatewayLifecycleService);
       await app.listen();
       const server = adapter.getServer();
       const upgradeResponse = await server?.fetch(new Request('http://127.0.0.1:3000/rooms', {
@@ -352,27 +368,23 @@ describe('@fluojs/websockets/bun', () => {
       await flushAsyncWork();
 
       const socket = server?.lastSocket;
-      const socketRegistry = Reflect.get(service, 'socketRegistry') as Map<string, BunServerWebSocket>;
-      const socketId = socketRegistry.keys().next().value;
       expect(upgradeResponse).toBeUndefined();
-
-      if (!socket || typeof socketId !== 'string') {
-        throw new Error('Expected Bun room test socket registration after websocket upgrade.');
+      const socketId = state.socketId;
+      if (!socket || !socketId) {
+        throw new Error('Expected Bun room test socket and identifier after websocket upgrade.');
       }
 
-      service.joinRoom(socketId, 'room-a');
-      service.joinRoom(socketId, 'room-b');
+      rooms.joinRoom(socketId, 'room-a');
+      rooms.joinRoom(socketId, 'room-b');
+      expect([...rooms.getRooms(socketId)].sort()).toEqual(['room-a', 'room-b']);
 
-      expect(Array.from(service.getRooms(socketId)).sort()).toEqual(['room-a', 'room-b']);
+      rooms.broadcastToRoom('room-a', 'order.updated', { orderId: 'ord_1' });
+      expect(socket.sentMessages).toEqual(['{"data":{"orderId":"ord_1"},"event":"order.updated"}']);
 
-      service.broadcastToRoom('room-a', 'order.updated', { orderId: 'ord_bun' });
-      service.leaveRoom(socketId, 'room-a');
-      service.broadcastToRoom('room-a', 'order.updated', { orderId: 'ord_after_leave' });
-
-      expect(socket.sentMessages).toEqual([
-        JSON.stringify({ data: { orderId: 'ord_bun' }, event: 'order.updated' }),
-      ]);
-      expect(Array.from(service.getRooms(socketId))).toEqual(['room-b']);
+      rooms.leaveRoom(socketId, 'room-a');
+      rooms.broadcastToRoom('room-a', 'order.updated', { orderId: 'ord_2' });
+      expect(socket.sentMessages).toHaveLength(1);
+      expect([...rooms.getRooms(socketId)]).toEqual(['room-b']);
     } finally {
       await app.close();
     }
@@ -447,15 +459,43 @@ describe('@fluojs/websockets/bun', () => {
     }
   });
 
-  it.each([
-    ['true', (): true => true, undefined],
-    ['undefined', (): undefined => undefined, undefined],
-    ['no return value', (): void => {}, undefined],
-    ['false', (): false => false, 403],
-  ] as const)('maps a Bun guard %s outcome to the documented upgrade decision', async (_outcome, guard, expectedStatus) => {
+  it.each(allowedBunUpgradeGuardOutcomes)(
+    'allows Bun upgrades when the guard returns %s',
+    async (_label, guard) => {
+      const adapter = new TestBunAdapter();
+
+      @WebSocketGateway({ path: '/guard-outcome' })
+      class GuardedGateway {
+        @OnMessage('ping')
+        onPing() {}
+      }
+
+      class AppModule {}
+      defineModule(AppModule, {
+        imports: [BunWebSocketModule.forRoot({ upgrade: { guard } })],
+        providers: [GuardedGateway],
+      });
+
+      const app = await bootstrapApplication({ adapter, rootModule: AppModule });
+      try {
+        await app.listen();
+
+        const response = await adapter.getServer()?.fetch(new Request('http://127.0.0.1:3000/guard-outcome', {
+          headers: { upgrade: 'websocket' },
+        }));
+
+        expect(response).toBeUndefined();
+        expect(adapter.getServer()?.lastSocket).toBeDefined();
+      } finally {
+        await app.close();
+      }
+    },
+  );
+
+  it('rejects Bun upgrades when the guard returns false', async () => {
     const adapter = new TestBunAdapter();
 
-    @WebSocketGateway({ path: '/guard-outcome' })
+    @WebSocketGateway({ path: '/false-guard' })
     class GuardedGateway {
       @OnMessage('ping')
       onPing() {}
@@ -463,7 +503,7 @@ describe('@fluojs/websockets/bun', () => {
 
     class AppModule {}
     defineModule(AppModule, {
-      imports: [BunWebSocketModule.forRoot({ upgrade: { guard } })],
+      imports: [BunWebSocketModule.forRoot({ upgrade: { guard: () => false } })],
       providers: [GuardedGateway],
     });
 
@@ -471,14 +511,12 @@ describe('@fluojs/websockets/bun', () => {
     try {
       await app.listen();
 
-      const server = adapter.getServer();
-      const response = await server?.fetch(new Request('http://127.0.0.1:3000/guard-outcome', {
+      const response = await adapter.getServer()?.fetch(new Request('http://127.0.0.1:3000/false-guard', {
         headers: { upgrade: 'websocket' },
       }));
-      await flushAsyncWork();
 
-      expect(response?.status).toBe(expectedStatus);
-      expect(server?.lastSocket !== undefined).toBe(expectedStatus === undefined);
+      expect(response?.status).toBe(403);
+      expect(await response?.text()).toBe('WebSocket upgrade rejected.');
     } finally {
       await app.close();
     }

--- a/packages/websockets/src/cloudflare-workers/cloudflare-workers.test.ts
+++ b/packages/websockets/src/cloudflare-workers/cloudflare-workers.test.ts
@@ -20,6 +20,7 @@ import {
   type CloudflareWorkerWebSocketBindingHost,
   type CloudflareWorkerWebSocketMessage,
   type CloudflareWorkerWebSocketUpgradeResult,
+  type WebSocketUpgradeGuard,
 } from './cloudflare-workers.js';
 
 type MockSocketListenerMap = {
@@ -32,6 +33,11 @@ const WEBSOCKET_OPEN_READY_STATE = 1;
 const WEBSOCKET_CLOSED_READY_STATE = 3;
 const CLOUDFLARE_WORKERS_WEBSOCKET_CAPABILITY_REASON =
   'Cloudflare Workers exposes WebSocketPair isolate-local request-upgrade hosting. Use @fluojs/websockets/cloudflare-workers for the official raw websocket binding.';
+const allowedWorkerUpgradeGuardOutcomes = [
+  ['true', () => true],
+  ['undefined', () => undefined],
+  ['no return value', () => {}],
+] as const satisfies readonly (readonly [string, WebSocketUpgradeGuard])[];
 
 class MockWorkerSocket implements CloudflareWorkerWebSocket {
   readonly #listeners: MockSocketListenerMap = {
@@ -383,27 +389,98 @@ describe('@fluojs/websockets/cloudflare-workers', () => {
     }
   });
 
-  it('joins, leaves, broadcasts, and reads rooms through the Worker lifecycle service', async () => {
+  it.each(allowedWorkerUpgradeGuardOutcomes)(
+    'allows Worker upgrades when the guard returns %s',
+    async (_label, guard) => {
+      const adapter = new TestWorkerAdapter();
+
+      @WebSocketGateway({ path: '/guard-outcome' })
+      class GuardedGateway {
+        @OnMessage('ping')
+        onPing() {}
+      }
+
+      class AppModule {}
+      defineModule(AppModule, {
+        imports: [CloudflareWorkersWebSocketModule.forRoot({ upgrade: { guard } })],
+        providers: [GuardedGateway],
+      });
+
+      const app = await bootstrapApplication({ adapter, rootModule: AppModule });
+      try {
+        await app.listen();
+
+        const response = await adapter.getServer()?.fetch(new Request('https://worker.test/guard-outcome', {
+          headers: { upgrade: 'websocket' },
+        }));
+
+        expect(response?.status).toBe(200);
+        expect(adapter.getServer()?.lastSocket).toBeDefined();
+      } finally {
+        await app.close();
+      }
+    },
+  );
+
+  it('rejects Worker upgrades when the guard returns false', async () => {
     const adapter = new TestWorkerAdapter();
 
-    @WebSocketGateway({ path: '/rooms' })
-    class RoomGateway {
+    @WebSocketGateway({ path: '/false-guard' })
+    class GuardedGateway {
       @OnMessage('ping')
       onPing() {}
     }
 
     class AppModule {}
     defineModule(AppModule, {
-      imports: [CloudflareWorkersWebSocketModule.forRoot()],
-      providers: [RoomGateway],
+      imports: [CloudflareWorkersWebSocketModule.forRoot({ upgrade: { guard: () => false } })],
+      providers: [GuardedGateway],
     });
 
     const app = await bootstrapApplication({ adapter, rootModule: AppModule });
-    const service = await app.container.resolve<CloudflareWorkersWebSocketGatewayLifecycleService>(
-      CloudflareWorkersWebSocketGatewayLifecycleService,
-    );
+    try {
+      await app.listen();
+
+      const response = await adapter.getServer()?.fetch(new Request('https://worker.test/false-guard', {
+        headers: { upgrade: 'websocket' },
+      }));
+
+      expect(response?.status).toBe(403);
+      expect(await response?.text()).toBe('WebSocket upgrade rejected.');
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('manages room membership and broadcasts through the Worker lifecycle service', async () => {
+    const adapter = new TestWorkerAdapter();
+
+    class GatewayState {
+      socketId?: string;
+    }
+
+    @Inject(GatewayState)
+    @WebSocketGateway({ path: '/rooms' })
+    class RoomGateway {
+      constructor(private readonly state: GatewayState) {}
+
+      @OnConnect()
+      onConnect(_socket: CloudflareWorkerWebSocket, _request: Request, socketId: string) {
+        this.state.socketId = socketId;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [CloudflareWorkersWebSocketModule.forRoot()],
+      providers: [GatewayState, RoomGateway],
+    });
+
+    const app = await bootstrapApplication({ adapter, rootModule: AppModule });
 
     try {
+      const state = await app.container.resolve(GatewayState);
+      const rooms = await app.container.resolve(CloudflareWorkersWebSocketGatewayLifecycleService);
       await app.listen();
       const server = adapter.getServer();
       const upgradeResponse = await server?.fetch(new Request('https://worker.test/rooms', {
@@ -412,64 +489,23 @@ describe('@fluojs/websockets/cloudflare-workers', () => {
       await flushAsyncWork();
 
       const socket = server?.lastSocket;
-      const socketRegistry = Reflect.get(service, 'socketRegistry') as Map<string, CloudflareWorkerWebSocket>;
-      const socketId = socketRegistry.keys().next().value;
+      const socketId = state.socketId;
       expect(upgradeResponse?.status).toBe(200);
-
-      if (!socket || typeof socketId !== 'string') {
-        throw new Error('Expected Worker room test socket registration after websocket upgrade.');
+      if (!socket || !socketId) {
+        throw new Error('Expected Worker room test socket and identifier after websocket upgrade.');
       }
 
-      service.joinRoom(socketId, 'room-a');
-      service.joinRoom(socketId, 'room-b');
+      rooms.joinRoom(socketId, 'room-a');
+      rooms.joinRoom(socketId, 'room-b');
+      expect([...rooms.getRooms(socketId)].sort()).toEqual(['room-a', 'room-b']);
 
-      expect(Array.from(service.getRooms(socketId)).sort()).toEqual(['room-a', 'room-b']);
+      rooms.broadcastToRoom('room-a', 'order.updated', { orderId: 'ord_1' });
+      expect(socket.sentMessages).toEqual(['{"data":{"orderId":"ord_1"},"event":"order.updated"}']);
 
-      service.broadcastToRoom('room-a', 'order.updated', { orderId: 'ord_workers' });
-      service.leaveRoom(socketId, 'room-a');
-      service.broadcastToRoom('room-a', 'order.updated', { orderId: 'ord_after_leave' });
-
-      expect(socket.sentMessages).toEqual([
-        JSON.stringify({ data: { orderId: 'ord_workers' }, event: 'order.updated' }),
-      ]);
-      expect(Array.from(service.getRooms(socketId))).toEqual(['room-b']);
-    } finally {
-      await app.close();
-    }
-  });
-
-  it.each([
-    ['true', (): true => true, 200],
-    ['undefined', (): undefined => undefined, 200],
-    ['no return value', (): void => {}, 200],
-    ['false', (): false => false, 403],
-  ] as const)('maps a Worker guard %s outcome to the documented upgrade decision', async (_outcome, guard, expectedStatus) => {
-    const adapter = new TestWorkerAdapter();
-
-    @WebSocketGateway({ path: '/guard-outcome' })
-    class GuardedGateway {
-      @OnMessage('ping')
-      onPing() {}
-    }
-
-    class AppModule {}
-    defineModule(AppModule, {
-      imports: [CloudflareWorkersWebSocketModule.forRoot({ upgrade: { guard } })],
-      providers: [GuardedGateway],
-    });
-
-    const app = await bootstrapApplication({ adapter, rootModule: AppModule });
-    try {
-      await app.listen();
-
-      const server = adapter.getServer();
-      const response = await server?.fetch(new Request('https://worker.test/guard-outcome', {
-        headers: { upgrade: 'websocket' },
-      }));
-      await flushAsyncWork();
-
-      expect(response?.status).toBe(expectedStatus);
-      expect(server?.lastSocket !== undefined).toBe(expectedStatus === 200);
+      rooms.leaveRoom(socketId, 'room-a');
+      rooms.broadcastToRoom('room-a', 'order.updated', { orderId: 'ord_2' });
+      expect(socket.sentMessages).toHaveLength(1);
+      expect([...rooms.getRooms(socketId)]).toEqual(['room-b']);
     } finally {
       await app.close();
     }

--- a/packages/websockets/src/decorators.ts
+++ b/packages/websockets/src/decorators.ts
@@ -102,6 +102,9 @@ export function WebSocketGateway(
  * @param event Optional event name filter. When omitted, the runtime treats the handler as a generic message listener.
  * @returns A method decorator that records message-handler metadata for the gateway.
  *
+ * @remarks
+ * Handler return values are awaited and then ignored. Send replies explicitly through the runtime socket argument.
+ *
  * @example
  * ```ts
  * import { OnMessage } from '@fluojs/websockets';

--- a/packages/websockets/src/deno/deno.test.ts
+++ b/packages/websockets/src/deno/deno.test.ts
@@ -15,6 +15,7 @@ import {
   type DenoWebSocketMessage,
   DenoWebSocketModule,
   type DenoWebSocketUpgradeResult,
+  type WebSocketUpgradeGuard,
 } from './deno.js';
 
 type MockDenoSocketListenerMap = {
@@ -27,6 +28,11 @@ const WEBSOCKET_OPEN_READY_STATE = 1;
 const WEBSOCKET_CLOSED_READY_STATE = 3;
 const DENO_WEBSOCKET_CAPABILITY_REASON =
   'Deno exposes Deno.upgradeWebSocket(request) request-upgrade hosting. Use @fluojs/websockets/deno for the official raw websocket binding.';
+const allowedDenoUpgradeGuardOutcomes = [
+  ['true', () => true],
+  ['undefined', () => undefined],
+  ['no return value', () => {}],
+] as const satisfies readonly (readonly [string, WebSocketUpgradeGuard])[];
 
 class MockDenoSocket implements DenoServerWebSocket {
   readonly #listeners: MockDenoSocketListenerMap = {
@@ -396,25 +402,35 @@ describe('@fluojs/websockets/deno', () => {
     }
   });
 
-  it('joins, leaves, broadcasts, and reads rooms through the Deno lifecycle service', async () => {
+  it('manages room membership and broadcasts through the Deno lifecycle service', async () => {
     const adapter = new TestDenoAdapter();
 
+    class GatewayState {
+      socketId?: string;
+    }
+
+    @Inject(GatewayState)
     @WebSocketGateway({ path: '/rooms' })
     class RoomGateway {
-      @OnMessage('ping')
-      onPing() {}
+      constructor(private readonly state: GatewayState) {}
+
+      @OnConnect()
+      onConnect(_socket: DenoServerWebSocket, _request: Request, socketId: string) {
+        this.state.socketId = socketId;
+      }
     }
 
     class AppModule {}
     defineModule(AppModule, {
       imports: [DenoWebSocketModule.forRoot()],
-      providers: [RoomGateway],
+      providers: [GatewayState, RoomGateway],
     });
 
     const app = await bootstrapApplication({ adapter, rootModule: AppModule });
-    const service = await app.container.resolve<DenoWebSocketGatewayLifecycleService>(DenoWebSocketGatewayLifecycleService);
 
     try {
+      const state = await app.container.resolve(GatewayState);
+      const rooms = await app.container.resolve(DenoWebSocketGatewayLifecycleService);
       await app.listen();
       const server = adapter.getServer();
       const upgradeResponse = await server?.fetch(new Request('https://runtime.test/rooms', {
@@ -423,27 +439,23 @@ describe('@fluojs/websockets/deno', () => {
       await flushAsyncWork();
 
       const socket = server?.lastSocket;
-      const socketRegistry = Reflect.get(service, 'socketRegistry') as Map<string, DenoServerWebSocket>;
-      const socketId = socketRegistry.keys().next().value;
       expect(upgradeResponse?.status).toBe(200);
-
-      if (!socket || typeof socketId !== 'string') {
-        throw new Error('Expected Deno room test socket registration after websocket upgrade.');
+      const socketId = state.socketId;
+      if (!socket || !socketId) {
+        throw new Error('Expected Deno room test socket and identifier after websocket upgrade.');
       }
 
-      service.joinRoom(socketId, 'room-a');
-      service.joinRoom(socketId, 'room-b');
+      rooms.joinRoom(socketId, 'room-a');
+      rooms.joinRoom(socketId, 'room-b');
+      expect([...rooms.getRooms(socketId)].sort()).toEqual(['room-a', 'room-b']);
 
-      expect(Array.from(service.getRooms(socketId)).sort()).toEqual(['room-a', 'room-b']);
+      rooms.broadcastToRoom('room-a', 'order.updated', { orderId: 'ord_1' });
+      expect(socket.sentMessages).toEqual(['{"data":{"orderId":"ord_1"},"event":"order.updated"}']);
 
-      service.broadcastToRoom('room-a', 'order.updated', { orderId: 'ord_deno' });
-      service.leaveRoom(socketId, 'room-a');
-      service.broadcastToRoom('room-a', 'order.updated', { orderId: 'ord_after_leave' });
-
-      expect(socket.sentMessages).toEqual([
-        JSON.stringify({ data: { orderId: 'ord_deno' }, event: 'order.updated' }),
-      ]);
-      expect(Array.from(service.getRooms(socketId))).toEqual(['room-b']);
+      rooms.leaveRoom(socketId, 'room-a');
+      rooms.broadcastToRoom('room-a', 'order.updated', { orderId: 'ord_2' });
+      expect(socket.sentMessages).toHaveLength(1);
+      expect([...rooms.getRooms(socketId)]).toEqual(['room-b']);
     } finally {
       await app.close();
     }
@@ -518,15 +530,43 @@ describe('@fluojs/websockets/deno', () => {
     }
   });
 
-  it.each([
-    ['true', (): true => true, 200],
-    ['undefined', (): undefined => undefined, 200],
-    ['no return value', (): void => {}, 200],
-    ['false', (): false => false, 403],
-  ] as const)('maps a Deno guard %s outcome to the documented upgrade decision', async (_outcome, guard, expectedStatus) => {
+  it.each(allowedDenoUpgradeGuardOutcomes)(
+    'allows Deno upgrades when the guard returns %s',
+    async (_label, guard) => {
+      const adapter = new TestDenoAdapter();
+
+      @WebSocketGateway({ path: '/guard-outcome' })
+      class GuardedGateway {
+        @OnMessage('ping')
+        onPing() {}
+      }
+
+      class AppModule {}
+      defineModule(AppModule, {
+        imports: [DenoWebSocketModule.forRoot({ upgrade: { guard } })],
+        providers: [GuardedGateway],
+      });
+
+      const app = await bootstrapApplication({ adapter, rootModule: AppModule });
+      try {
+        await app.listen();
+
+        const response = await adapter.getServer()?.fetch(new Request('https://runtime.test/guard-outcome', {
+          headers: { upgrade: 'websocket' },
+        }));
+
+        expect(response?.status).toBe(200);
+        expect(adapter.getServer()?.lastSocket).toBeDefined();
+      } finally {
+        await app.close();
+      }
+    },
+  );
+
+  it('rejects Deno upgrades when the guard returns false', async () => {
     const adapter = new TestDenoAdapter();
 
-    @WebSocketGateway({ path: '/guard-outcome' })
+    @WebSocketGateway({ path: '/false-guard' })
     class GuardedGateway {
       @OnMessage('ping')
       onPing() {}
@@ -534,7 +574,7 @@ describe('@fluojs/websockets/deno', () => {
 
     class AppModule {}
     defineModule(AppModule, {
-      imports: [DenoWebSocketModule.forRoot({ upgrade: { guard } })],
+      imports: [DenoWebSocketModule.forRoot({ upgrade: { guard: () => false } })],
       providers: [GuardedGateway],
     });
 
@@ -542,14 +582,12 @@ describe('@fluojs/websockets/deno', () => {
     try {
       await app.listen();
 
-      const server = adapter.getServer();
-      const response = await server?.fetch(new Request('https://runtime.test/guard-outcome', {
+      const response = await adapter.getServer()?.fetch(new Request('https://runtime.test/false-guard', {
         headers: { upgrade: 'websocket' },
       }));
-      await flushAsyncWork();
 
-      expect(response?.status).toBe(expectedStatus);
-      expect(server?.lastSocket !== undefined).toBe(expectedStatus === 200);
+      expect(response?.status).toBe(403);
+      expect(await response?.text()).toBe('WebSocket upgrade rejected.');
     } finally {
       await app.close();
     }

--- a/packages/websockets/src/module.test.ts
+++ b/packages/websockets/src/module.test.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from 'node:events';
 import type { IncomingMessage } from 'node:http';
 import { type AddressInfo, createConnection } from 'node:net';
 import type { Duplex } from 'node:stream';
@@ -30,7 +31,7 @@ import {
 import { WebSocketModule } from './module.js';
 import { NodeWebSocketGatewayLifecycleServiceImplementation } from './node/node-service.js';
 import { NodeWebSocketGatewayLifecycleService } from './node/node-service-token.js';
-import type { WebSocketModuleOptions } from './node/node-types.js';
+import type { WebSocketModuleOptions, WebSocketUpgradeGuard } from './node/node-types.js';
 import { WebSocketGatewayLifecycleService } from './service.js';
 
 function createLogger(events: string[]): ApplicationLogger {
@@ -239,6 +240,12 @@ const serverBackedGatewayScenarios: readonly ServerBackedGatewayScenario[] = [
   },
 ];
 
+const allowedNodeUpgradeGuardOutcomes = [
+  ['true', () => true],
+  ['undefined', () => undefined],
+  ['no return value', () => {}],
+] as const satisfies readonly (readonly [string, WebSocketUpgradeGuard])[];
+
 function createDeferred<T = void>() {
   let resolve!: (value: T | PromiseLike<T>) => void;
   let reject!: (reason?: unknown) => void;
@@ -279,7 +286,7 @@ type MockSocketListeners = {
   pong?: () => void;
 };
 
-function createMockSocket(): {
+function createMockSocket(bufferedAmount = 0): {
   emitClose: (code?: number, reason?: Buffer) => void;
   emitError: (error: Error) => void;
   emitPong: () => void;
@@ -312,7 +319,7 @@ function createMockSocket(): {
     ping,
     readyState: WebSocket.OPEN,
     send,
-    bufferedAmount: 0,
+    bufferedAmount,
     terminate,
   } as unknown as WebSocket;
 
@@ -775,8 +782,8 @@ describe('@fluojs/websockets', () => {
     try {
       await app.listen();
       const port = await getApplicationPort(app);
-
       const socket = new WebSocket(`ws://127.0.0.1:${String(port)}/chat`);
+
       try {
         await onceOpen(socket);
         socket.send(JSON.stringify({ event: 'ping', data: { value: 'hello' } }));
@@ -785,7 +792,6 @@ describe('@fluojs/websockets', () => {
         expect(JSON.parse(incoming)).toEqual({ event: 'pong', data: { value: 'hello' } });
 
         await closeWebSocket(socket);
-
         await waitForAssertion(() => {
           expect(state.disconnectCount).toBe(1);
         });
@@ -844,8 +850,8 @@ describe('@fluojs/websockets', () => {
     try {
       await app.listen();
       const port = await getApplicationPort(app);
-
       const socket = new WebSocket(`ws://127.0.0.1:${String(port)}/chat`);
+
       try {
         await onceOpen(socket);
         socket.send(JSON.stringify({ event: 'ping', data: { value: 'hello' } }));
@@ -854,7 +860,6 @@ describe('@fluojs/websockets', () => {
         expect(JSON.parse(incoming)).toEqual({ event: 'pong', data: { value: 'hello' } });
 
         await closeWebSocket(socket);
-
         await waitForAssertion(() => {
           expect(state.disconnectCount).toBe(1);
         });
@@ -923,14 +928,17 @@ describe('@fluojs/websockets', () => {
         port: 0,
       });
       const state = await app.container.resolve(GatewayState);
-      const service = await app.container.resolve(WebSocketGatewayLifecycleService) as unknown as NodeWebSocketGatewayLifecycleServiceImplementation;
+      const service = await app.container.resolve(WebSocketGatewayLifecycleService);
+      if (!(service instanceof NodeWebSocketGatewayLifecycleServiceImplementation)) {
+        throw new Error('Expected the root websocket lifecycle token to resolve the Node implementation.');
+      }
 
       try {
         await app.listen();
         const appPort = await getApplicationPort(app);
         const websocketPort = getOwnedGatewayPort(service);
-
         const socket = new WebSocket(`ws://127.0.0.1:${String(websocketPort)}/chat`);
+
         try {
           await onceOpen(socket);
           socket.send(JSON.stringify({ event: 'ping', data: { value: scenario.name } }));
@@ -939,7 +947,6 @@ describe('@fluojs/websockets', () => {
           expect(JSON.parse(incoming)).toEqual({ event: 'pong', data: { value: scenario.name } });
 
           await closeWebSocket(socket);
-
           await waitForAssertion(() => {
             expect(state.disconnectCount).toBe(1);
           });
@@ -960,7 +967,7 @@ describe('@fluojs/websockets', () => {
         await app.close();
       }
 
-      expect((Reflect.get(state, 'disconnectCount') as number)).toBe(1);
+      expect(state.disconnectCount).toBe(1);
     });
   }
 
@@ -1023,21 +1030,77 @@ describe('@fluojs/websockets', () => {
     await app.close();
   });
 
-  it.each([
-    ['true', (): true => true, undefined],
-    ['undefined', (): undefined => undefined, undefined],
-    ['no return value', (): void => {}, undefined],
-    ['false', (): false => false, { body: 'WebSocket upgrade rejected.', status: 403 }],
-  ] as const)('maps a Node guard %s outcome to the documented upgrade decision', async (_outcome, guard, expected) => {
-    const service = createTestLifecycleService({ upgrade: { guard } });
-    const resolveUpgradeRejection = Reflect.get(service, 'resolveUpgradeRejection') as (
-      request: IncomingMessage,
-      path: string,
-    ) => Promise<{ body?: string; status: number } | undefined>;
+  it.each(allowedNodeUpgradeGuardOutcomes)(
+    'allows websocket upgrades when the Node guard returns %s',
+    async (_label, guard) => {
+      @WebSocketGateway({ path: '/guard-outcome' })
+      class GuardedGateway {
+        @OnMessage('ping')
+        onPing() {}
+      }
 
-    const rejection = await resolveUpgradeRejection.call(service, { headers: {} } as IncomingMessage, '/guard-outcome');
+      class AppModule {}
+      defineModule(AppModule, {
+        imports: [WebSocketModule.forRoot({ upgrade: { guard } })],
+        providers: [GuardedGateway],
+      });
 
-    expect(rejection).toEqual(expected);
+      const app = await bootstrapNodeApplication(AppModule, {
+        cors: false,
+        port: 0,
+      });
+
+      try {
+        await app.listen();
+        const port = await getApplicationPort(app);
+        const socket = new WebSocket(`ws://127.0.0.1:${String(port)}/guard-outcome`);
+
+        try {
+          await onceOpen(socket);
+          expect(socket.readyState).toBe(WebSocket.OPEN);
+        } finally {
+          await closeWebSocket(socket);
+        }
+      } finally {
+        await app.close();
+      }
+    },
+  );
+
+  it('rejects websocket upgrades when the Node guard returns false', async () => {
+    @WebSocketGateway({ path: '/false-guard' })
+    class GuardedGateway {
+      @OnMessage('ping')
+      onPing() {}
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [WebSocketModule.forRoot({
+        upgrade: {
+          guard() {
+            return false;
+          },
+        },
+      })],
+      providers: [GuardedGateway],
+    });
+
+    const app = await bootstrapNodeApplication(AppModule, {
+      cors: false,
+      port: 0,
+    });
+
+    try {
+      await app.listen();
+      const port = await getApplicationPort(app);
+      const response = await readUpgradeResponse(port, createUpgradeRequest('/false-guard'));
+
+      expect(response).toContain('HTTP/1.1 403 Forbidden');
+      expect(response).toContain('WebSocket upgrade rejected.');
+    } finally {
+      await app.close();
+    }
   });
 
   it('rejects anonymous websocket upgrades before the handshake completes', async () => {
@@ -1670,53 +1733,76 @@ describe('@fluojs/websockets', () => {
 
   it('resolves the documented connection, payload, and shutdown defaults', () => {
     const service = createTestLifecycleService();
-    const resolveMaxConnectionCount = Reflect.get(service, 'resolveMaxConnectionCount') as () => number;
-    const resolveMaxPayloadBytes = Reflect.get(service, 'resolveMaxPayloadBytes') as () => number;
-    const resolveShutdownTimeoutMs = Reflect.get(service, 'resolveShutdownTimeoutMs') as () => number;
+    const resolveMaxConnectionCount = Reflect.get(service, 'resolveMaxConnectionCount');
+    const resolveMaxPayloadBytes = Reflect.get(service, 'resolveMaxPayloadBytes');
+    const resolveShutdownTimeoutMs = Reflect.get(service, 'resolveShutdownTimeoutMs');
 
-    expect(resolveMaxConnectionCount.call(service)).toBe(1_000);
-    expect(resolveMaxPayloadBytes.call(service)).toBe(1_048_576);
-    expect(resolveShutdownTimeoutMs.call(service)).toBe(5_000);
-  });
-
-  it('keeps the documented default of 256 pending messages per socket', () => {
-    const service = createTestLifecycleService();
-    const { socket } = createMockSocket();
-    const state = createTrackedSocketState('socket-default-buffer');
-    const bufferIncomingMessage = Reflect.get(service, 'bufferIncomingMessage') as (
-      state: ReturnType<typeof createTrackedSocketState>,
-      socket: WebSocket,
-      data: Buffer,
-    ) => void;
-
-    for (let index = 0; index <= 256; index += 1) {
-      bufferIncomingMessage.call(service, state, socket, Buffer.from(`message-${String(index)}`));
+    if (
+      typeof resolveMaxConnectionCount !== 'function'
+      || typeof resolveMaxPayloadBytes !== 'function'
+      || typeof resolveShutdownTimeoutMs !== 'function'
+    ) {
+      throw new Error('Expected Node websocket default resolvers to be available.');
     }
 
-    const retainedMessages = (state.bufferedMessages as Buffer[]).slice(state.bufferedMessagesStartIndex);
-
-    expect(retainedMessages).toHaveLength(256);
-    expect(retainedMessages[0]?.toString('utf8')).toBe('message-1');
-    expect(retainedMessages.at(-1)?.toString('utf8')).toBe('message-256');
+    expect(Reflect.apply(resolveMaxConnectionCount, service, [])).toBe(1_000);
+    expect(Reflect.apply(resolveMaxPayloadBytes, service, [])).toBe(1_048_576);
+    expect(Reflect.apply(resolveShutdownTimeoutMs, service, [])).toBe(5_000);
   });
 
-  it('drops Node room broadcasts above the documented default 1 MiB backpressure limit', () => {
+  it('uses the documented default pending-message capacity and drop-oldest policy', () => {
     const service = createTestLifecycleService();
-    const atLimit = createMockSocket();
-    const aboveLimit = createMockSocket();
-    const socketRegistry = Reflect.get(service, 'socketRegistry') as Map<string, WebSocket>;
-    (atLimit.socket as unknown as { bufferedAmount: number }).bufferedAmount = 1_048_576;
-    (aboveLimit.socket as unknown as { bufferedAmount: number }).bufferedAmount = 1_048_577;
-    socketRegistry.set('socket-at-limit', atLimit.socket);
-    socketRegistry.set('socket-above-limit', aboveLimit.socket);
-    service.joinRoom('socket-at-limit', 'room-default-backpressure');
-    service.joinRoom('socket-above-limit', 'room-default-backpressure');
+    const { socket, terminate } = createMockSocket();
+    const enqueueMessageDispatch = Reflect.get(service, 'enqueueMessageDispatch');
+    if (typeof enqueueMessageDispatch !== 'function') {
+      throw new Error('Expected the Node websocket message queue dispatcher to be available.');
+    }
 
-    service.broadcastToRoom('room-default-backpressure', 'order.updated', { orderId: 'ord_default' });
+    const state = {
+      enqueuedMessageCount: 255,
+      handlerQueue: Promise.resolve(),
+      processingMessageQueue: true,
+      queuedMessages: Array.from({ length: 255 }, (_value, index) => `queued-${String(index)}`),
+      queuedMessagesStartIndex: 0,
+      resolved: [],
+      socketId: 'socket-default-buffer',
+    };
 
-    expect(atLimit.send).toHaveBeenCalledWith(JSON.stringify({ data: { orderId: 'ord_default' }, event: 'order.updated' }));
-    expect(aboveLimit.send).not.toHaveBeenCalled();
-    expect(aboveLimit.terminate).not.toHaveBeenCalled();
+    Reflect.apply(enqueueMessageDispatch, service, [state, socket, {}, 'latest']);
+
+    const messagesAtCapacity = state.queuedMessages.slice(state.queuedMessagesStartIndex);
+    expect(messagesAtCapacity).toHaveLength(256);
+    expect(messagesAtCapacity[0]).toBe('queued-0');
+    expect(messagesAtCapacity.at(-1)).toBe('latest');
+
+    Reflect.apply(enqueueMessageDispatch, service, [state, socket, {}, 'overflow']);
+
+    const messagesAfterOverflow = state.queuedMessages.slice(state.queuedMessagesStartIndex);
+    expect(messagesAfterOverflow).toHaveLength(256);
+    expect(messagesAfterOverflow[0]).toBe('queued-1');
+    expect(messagesAfterOverflow.at(-1)).toBe('overflow');
+    expect(terminate).not.toHaveBeenCalled();
+  });
+
+  it('uses the documented Node backpressure threshold and drop policy', () => {
+    const service = createTestLifecycleService();
+    const atThreshold = createMockSocket(1_048_576);
+    const overThreshold = createMockSocket(1_048_577);
+    const socketRegistry = Reflect.get(service, 'socketRegistry');
+    if (!(socketRegistry instanceof Map)) {
+      throw new Error('Expected the Node websocket socket registry to be available.');
+    }
+
+    socketRegistry.set('socket-at-threshold', atThreshold.socket);
+    socketRegistry.set('socket-over-threshold', overThreshold.socket);
+    service.joinRoom('socket-at-threshold', 'room-default-backpressure');
+    service.joinRoom('socket-over-threshold', 'room-default-backpressure');
+
+    service.broadcastToRoom('room-default-backpressure', 'order.updated', { orderId: 'ord_1' });
+
+    expect(atThreshold.send).toHaveBeenCalledWith('{"data":{"orderId":"ord_1"},"event":"order.updated"}');
+    expect(overThreshold.send).not.toHaveBeenCalled();
+    expect(overThreshold.terminate).not.toHaveBeenCalled();
   });
 
   it('caps ready-state message queue and drops newest queued messages when saturated', async () => {
@@ -2098,14 +2184,14 @@ describe('@fluojs/websockets', () => {
     try {
       await app.listen();
       const port = await getApplicationPort(app);
-
       const adapter = await app.container.resolve<HttpApplicationAdapter>(HTTP_APPLICATION_ADAPTER);
-      const server = adapter.getServer?.() as {
-        on(event: 'upgrade', listener: (request: IncomingMessage, socket: Duplex) => void): void;
-      };
-      const delegated = createDeferred<void>();
+      const server = adapter.getServer?.();
+      if (!(server instanceof EventEmitter)) {
+        throw new Error('Expected the Node websocket test adapter to expose an upgrade event server.');
+      }
 
-      server.on('upgrade', (request, socket) => {
+      const delegated = createDeferred<void>();
+      server.on('upgrade', (request: IncomingMessage, socket: Duplex) => {
         if (request.url === '/missing') {
           delegated.resolve();
           socket.write('HTTP/1.1 426 Upgrade Required\r\nConnection: close\r\nContent-Length: 0\r\n\r\n');
@@ -2143,7 +2229,6 @@ describe('@fluojs/websockets', () => {
     try {
       await app.listen();
       const port = await getApplicationPort(app);
-
       const response = await readUpgradeResponse(port, createUpgradeRequest('/missing'));
 
       expect(response).toContain('HTTP/1.1 404 Not Found');


### PR DESCRIPTION
## Summary

Lock the published WebSocket guard, room, default-limit, and cleanup contracts with direct regression evidence, and align the public `OnMessage()` TSDoc example with the existing explicit-send behavior.

Linked context: Closes #2941

## Changes

- cover `true`, `undefined`, no-return, and `false` upgrade guard outcomes across Node, Bun, Deno, and Cloudflare Workers
- cover fetch-runtime room join/leave/snapshot/broadcast behavior
- lock documented Node connection, payload, buffer, shutdown, and backpressure defaults
- guarantee real listener/socket teardown through `finally`
- replace the `OnMessage()` return-value example with explicit `socket.send(...)` guidance

## Testing

- `pnpm --filter @fluojs/websockets test` — 8 files, 160 tests passed
- `pnpm --filter @fluojs/websockets typecheck` — passed
- `pnpm --dir packages/websockets build` — passed
- `pnpm lint` — passed with pre-existing repository warnings/infos only
- `pnpm verify:public-export-tsdoc` — passed
- `pnpm verify:platform-consistency-governance` — passed
- changed-file LSP diagnostics — no errors or warnings
- `git diff --check origin/main..HEAD` — passed
- full `pnpm test` encountered one unrelated CLI update-decline timeout; the isolated CLI test passed on rerun

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

The diff is test-only plus source TSDoc guidance. Runtime behavior, public API shape, package contents, and consumer behavior are unchanged, so no changeset is included.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

`OnMessage()` keeps its existing summary, parameter, and return documentation; its example and remarks now match the canonical README contract.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

No new behavior is introduced. The added tests protect contracts already documented in `packages/websockets/README.md`.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests.

No governed docs or package README files changed. Existing EN/KO surfaces already agree; runtime-specific regression tests provide the added evidence.
