### PR TITLE
Resolve #2942: cover Socket.IO no-ACK rejection and cleanup paths

### DIFF
--- a/packages/socket.io/src/module.test.ts
+++ b/packages/socket.io/src/module.test.ts
@@ -1303,9 +1303,7 @@ describe('@fluojs/socket.io', () => {
     }
   });
 
-  it('rejects guarded message events without invoking gateway handlers', async () => {
-    const messageHandled = createDeferred<void>();
-
+  it('rejects guarded message events without invoking handlers or emitting implicit client errors', async () => {
     class GatewayState {
       messages: unknown[] = [];
     }
@@ -1316,9 +1314,14 @@ describe('@fluojs/socket.io', () => {
       constructor(private readonly state: GatewayState) {}
 
       @OnMessage('ping')
-      onPing(payload: unknown) {
+      onPing(
+        payload: unknown,
+        _socket: Socket,
+        _request: SocketIoHandshakeRequest,
+        acknowledgement?: (response: unknown) => void,
+      ) {
         this.state.messages.push(payload);
-        messageHandled.resolve();
+        acknowledgement?.({ accepted: true });
       }
     }
 
@@ -1375,10 +1378,17 @@ describe('@fluojs/socket.io', () => {
       expect(falseRejectedAck).toEqual({ data: undefined, error: 'Socket.IO message rejected.' });
       expect(state.messages).toEqual([]);
 
-      activeSocket.emit('ping', 'allowed');
-      await messageHandled.promise;
-      expect(state.messages).toEqual(['allowed']);
+      const clientErrors: unknown[] = [];
+      activeSocket.on('error', (error: unknown) => clientErrors.push(error));
 
+      activeSocket.emit('ping', 'blocked');
+      const allowedAck = await new Promise<unknown>((resolve) => {
+        activeSocket.emit('ping', 'allowed', (response: unknown) => resolve(response));
+      });
+
+      expect(allowedAck).toEqual({ accepted: true });
+      expect(state.messages).toEqual(['allowed']);
+      expect(clientErrors).toEqual([]);
 
       const disconnected = new Promise((resolve) => activeSocket.once('disconnect', resolve));
       const disconnectAck = await new Promise<unknown>((resolve) => {
@@ -1435,29 +1445,34 @@ describe('@fluojs/socket.io', () => {
       providers: [GatewayState, GuardedGateway],
     });
 
-    const errorLog = vi.spyOn(console, 'error').mockImplementation((message: unknown, error?: unknown) => {
-      loggerEvents.push(`${String(message)}:${error instanceof Error ? error.message : 'none'}`);
-      if (stripAnsi(String(message)).includes('[SocketIoLifecycleService] Socket.IO message guard for event ping on socket')) {
-        errorLogged.resolve();
-      }
-    });
     const { adapter, app } = await createNodejsSocketIoApplication(AppModule);
-    const state = await app.container.resolve<GatewayState>(GatewayState);
-
-    await app.listen();
-    const port = getBoundPortFromAdapter(adapter);
-    process.on('unhandledRejection', onUnhandledRejection);
-
-    const socket = createClient(`http://127.0.0.1:${String(port)}/async-message-guard`, {
-      reconnection: false,
-      transports: ['websocket'],
-    });
+    let restoreErrorLog: (() => void) | undefined;
+    let socket: ClientSocket | undefined;
 
     try {
-      await onceConnected(socket);
+      const state = await app.container.resolve<GatewayState>(GatewayState);
+      const errorLog = vi.spyOn(console, 'error');
+      restoreErrorLog = () => errorLog.mockRestore();
+      errorLog.mockImplementation((message: unknown, error?: unknown) => {
+        loggerEvents.push(`${String(message)}:${error instanceof Error ? error.message : 'none'}`);
+        if (stripAnsi(String(message)).includes('[SocketIoLifecycleService] Socket.IO message guard for event ping on socket')) {
+          errorLogged.resolve();
+        }
+      });
+
+      await app.listen();
+      const port = getBoundPortFromAdapter(adapter);
+      process.on('unhandledRejection', onUnhandledRejection);
+
+      const activeSocket = createClient(`http://127.0.0.1:${String(port)}/async-message-guard`, {
+        reconnection: false,
+        transports: ['websocket'],
+      });
+      socket = activeSocket;
+      await onceConnected(activeSocket);
 
       const rejectedAck = await new Promise<unknown>((resolve) => {
-        socket.emit('ping', 'blocked', (response: unknown) => resolve(response));
+        activeSocket.emit('ping', 'blocked', (response: unknown) => resolve(response));
       });
 
       expect(rejectedAck).toEqual({ data: { code: 'AUTH_REQUIRED' }, error: 'Forbidden event.' });
@@ -1471,10 +1486,19 @@ describe('@fluojs/socket.io', () => {
       ).toBe(true);
       expect(loggerEvents.some((event) => event.includes('Forbidden event.'))).toBe(true);
     } finally {
-      errorLog.mockRestore();
-      process.off('unhandledRejection', onUnhandledRejection);
-      socket.close();
-      await app.close();
+      try {
+        restoreErrorLog?.();
+      } finally {
+        try {
+          process.off('unhandledRejection', onUnhandledRejection);
+        } finally {
+          try {
+            socket?.close();
+          } finally {
+            await app.close();
+          }
+        }
+      }
     }
   });
 


### PR DESCRIPTION
## Summary

`@fluojs/socket.io`의 문서화된 no-ACK message-guard rejection 계약을 실행 가능한 회귀 테스트로 고정하고, async guard 테스트의 전역/서버 리소스 정리를 setup 초기 단계부터 보장합니다.

Linked context: Closes #2942

## Changes

- ACK callback 없이 거부된 message가 gateway handler를 호출하지 않고 implicit client `error` event도 emit하지 않음을 검증합니다.
- 후속 explicit ACK를 synchronization barrier로 사용해 negative client-event assertion을 결정적으로 확인합니다.
- async message-guard 테스트의 cleanup scope를 app 생성 직후 시작합니다.
- console spy, process listener, 조건부 socket, app cleanup을 중첩 `finally`로 보호합니다.

## Testing

- `pnpm exec biome check packages/socket.io/src/module.test.ts` — passed
- `pnpm --dir packages/socket.io typecheck` — passed after fresh-worktree workspace build
- `pnpm --dir packages/socket.io test` — 6 files, 70 tests passed
- `pnpm build` — passed
- `pnpm verify:platform-consistency-governance` — passed
- `pnpm verify` — 408 files passed; 4,750 tests passed, 1 skipped
- Regression sensitivity check — a temporary implicit client `error` emit made the targeted assertion fail; reverting the mutation restored green.

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

No changeset: test-only contract hardening입니다. Runtime behavior, public API, published package contents, release metadata는 변경하지 않습니다.

## Public export documentation

해당 없음 — public export 또는 package source API를 변경하지 않았습니다.

- [x] Changed public exports 없음
- [x] Source TSDoc 변경 불필요
- [x] README example 변경 불필요

## Behavioral contract

- [x] 문서화된 behavioral contract를 제거하거나 변경하지 않았습니다.
- [x] 기존 no-implicit-error contract를 실제 Socket.IO client 경계의 regression test로 고정했습니다.
- [x] Intentional limitation과 runtime behavior는 그대로 유지됩니다.
- [x] Async guard rejection의 cleanup invariant를 강화했습니다.

## Platform consistency governance (SSOT)

- [x] SSOT 문서와 EN/KO mirror를 변경하지 않았습니다.
- [x] 새로운 platform alignment/conformance claim을 추가하지 않았습니다.
- [x] 기존 Node-backed Socket.IO integration test seam만 사용했습니다.