### PR TITLE
Resolve #2967: Add Workers WebSocket conformance coverage

### DIFF
--- a/packages/platform-cloudflare-workers/package.json
+++ b/packages/platform-cloudflare-workers/package.json
@@ -44,6 +44,7 @@
     "@fluojs/runtime": "workspace:^"
   },
   "devDependencies": {
+    "@fluojs/testing": "workspace:^",
     "vitest": "^3.2.4"
   }
 }

--- a/packages/platform-cloudflare-workers/src/websocket-conformance.test.ts
+++ b/packages/platform-cloudflare-workers/src/websocket-conformance.test.ts
@@ -1,0 +1,16 @@
+import { createFetchStyleWebSocketConformanceHarness } from '@fluojs/testing/fetch-style-websocket-conformance';
+import { expect, it } from 'vitest';
+
+import { createCloudflareWorkerAdapter } from './adapter.js';
+
+it('reports the supported fetch-style websocket contract through the package conformance harness', () => {
+  const harness = createFetchStyleWebSocketConformanceHarness({
+    createAdapter: () => createCloudflareWorkerAdapter(),
+    expectedReason:
+      'Cloudflare Workers exposes WebSocketPair isolate-local request-upgrade hosting. Use @fluojs/websockets/cloudflare-workers for the official raw websocket binding.',
+    expectedSupport: 'supported',
+    name: 'cloudflare-workers',
+  });
+
+  expect(() => harness.assertExposesRawWebSocketExpansionContract()).not.toThrow();
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -785,6 +785,9 @@ importers:
         specifier: workspace:^
         version: link:../runtime
     devDependencies:
+      '@fluojs/testing':
+        specifier: workspace:^
+        version: link:../testing
       vitest:
         specifier: ^3.2.4
         version: 3.2.7(@types/debug@4.1.13)(@types/node@22.19.15)(happy-dom@20.9.0)(tsx@4.23.1)


### PR DESCRIPTION
## Summary

Add the required package-local fetch-style WebSocket conformance harness for the Cloudflare Workers adapter.

Closes #2967

## Changes

- Instantiate `createFetchStyleWebSocketConformanceHarness(...)` against the real Workers adapter.
- Add the package-local `@fluojs/testing` development dependency and lockfile importer entry.
- Preserve existing adapter and lifecycle tests without runtime changes.

## Testing

- Focused Workers tests — 3 files, 31 tests passed.
- Full package tests — 5 files, 37 tests passed.
- `pnpm --filter @fluojs/platform-cloudflare-workers typecheck` — passed.
- `pnpm --filter @fluojs/platform-cloudflare-workers build` — passed.
- `pnpm verify:platform-consistency-governance` — passed.
- Changed-file Biome and `git diff --check` — passed.

## Release impact

No changeset: test code and a development-only workspace dependency changed; consumer-visible API, runtime behavior, and published package contents are unchanged.

## Public export documentation

Not applicable: no public export changed.

## Behavioral contract

The new harness makes the existing fetch-style WebSocket capability and upgrade contract executable without changing behavior.

## Platform consistency governance (SSOT)

The existing MUST-level platform conformance requirement is now covered against the real Workers adapter; governance verification passed.

- Conformance test evidence: [packages/platform-cloudflare-workers/src/websocket-conformance.test.ts](https://github.com/fluojs/fluo/blob/383461556a576eb583683a3905f6c508aa4f7b43/packages/platform-cloudflare-workers/src/websocket-conformance.test.ts#L1-L16)