### PR TITLE
Resolve #2944: Preserve DI reverse-creation disposal order

### DIFF
--- a/.changeset/preserve-di-disposal-order.md
+++ b/.changeset/preserve-di-disposal-order.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/di': patch
+---
+
+Dispose cached single and multi-provider instances together in reverse materialization order so dependents shut down before their dependencies.

--- a/packages/di/README.ko.md
+++ b/packages/di/README.ko.md
@@ -76,7 +76,7 @@ const service = await container.resolve(UserService);
 - **request**: `createRequestScope()`마다 새로 생성됩니다.
 - **transient**: resolve할 때마다 새 인스턴스를 만듭니다.
 
-dispose 중에는 각 컨테이너가 자신이 소유한 살아 있는 request scope 자식을 먼저 재귀적으로 정리하므로, 루트가 아닌 request scope를 dispose해도 중첩 request scope를 닫은 뒤 자신의 request cache를 정리합니다. 이후 루트 dispose는 자식 dispose 중 하나 이상이 실패하더라도 루트가 소유한 singleton 정리를 계속 수행합니다. 자식/루트 dispose 실패가 여러 개 발생하면 `dispose()`는 모든 shutdown 실패를 확인할 수 있도록 `AggregateError`로 보고합니다.
+dispose 중에는 각 컨테이너가 single-provider cache와 multi-provider cache 전체에서 성공적으로 materialize된 cached instance를 실제 생성 순서의 역순으로 정리하므로, dependency보다 dependent를 먼저 종료합니다. 각 컨테이너는 자신이 소유한 살아 있는 request scope 자식을 먼저 재귀적으로 정리하므로, 루트가 아닌 request scope를 dispose해도 중첩 request scope를 닫은 뒤 자신의 request cache를 정리합니다. 이후 루트 dispose는 자식 dispose 중 하나 이상이 실패하더라도 루트가 소유한 singleton 정리를 계속 수행합니다. 자식/루트 dispose 실패가 여러 개 발생하면 `dispose()`는 모든 shutdown 실패를 확인할 수 있도록 `AggregateError`로 보고합니다.
 
 ### provider override
 

--- a/packages/di/README.md
+++ b/packages/di/README.md
@@ -75,7 +75,7 @@ fluo DI supports four provider shapes:
 - **Request**: Instance is created once per `createRequestScope()` call.
 - **Transient**: A new instance is created every time it is resolved.
 
-During disposal, each container first recursively tears down live request-scope children it owns, so disposing a non-root request scope also closes nested request scopes before its own request cache. Root disposal then continues with root-owned singleton cleanup even if one or more child disposals fail. When multiple child/root disposals fail, `dispose()` reports an `AggregateError` so callers can inspect every shutdown failure without losing cleanup progress.
+During disposal, each container tears down successfully materialized cached instances in reverse creation order across single-provider and multi-provider caches, so dependents are destroyed before their dependencies. Each container first recursively tears down live request-scope children it owns, so disposing a non-root request scope also closes nested request scopes before its own request cache. Root disposal then continues with root-owned singleton cleanup even if one or more child disposals fail. When multiple child/root disposals fail, `dispose()` reports an `AggregateError` so callers can inspect every shutdown failure without losing cleanup progress.
 
 ### Provider Overrides
 

--- a/packages/di/src/container-disposal-order.test.ts
+++ b/packages/di/src/container-disposal-order.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import { Container } from './container.js';
+
+describe('Container disposal order', () => {
+  it('disposes cached providers in reverse creation order across single and multi-provider caches', async () => {
+    // Given
+    const dependencyToken = Symbol('dependencies');
+    const events: string[] = [];
+
+    class MultiProviderDependency {
+      onDestroy(): void {
+        events.push('dependency');
+      }
+    }
+
+    class DependentService {
+      constructor(readonly dependencies: readonly MultiProviderDependency[]) {}
+
+      onDestroy(): void {
+        events.push('dependent');
+      }
+    }
+
+    const container = new Container().register(
+      {
+        multi: true,
+        provide: dependencyToken,
+        useClass: MultiProviderDependency,
+      },
+      {
+        inject: [dependencyToken],
+        provide: DependentService,
+        useClass: DependentService,
+      },
+    );
+    await container.resolve(DependentService);
+
+    // When
+    await container.dispose();
+
+    // Then
+    expect(events).toEqual(['dependent', 'dependency']);
+  });
+});

--- a/packages/di/src/container-disposal-order.test.ts
+++ b/packages/di/src/container-disposal-order.test.ts
@@ -42,4 +42,54 @@ describe('Container disposal order', () => {
     // Then
     expect(events).toEqual(['dependent', 'dependency']);
   });
+
+  it('releases stale request-cache materializations after ancestor override disposal settles', async () => {
+    // Given
+    const serviceToken = Symbol('service');
+    const events: string[] = [];
+
+    class OriginalService {
+      onDestroy(): void {
+        events.push('original:destroy');
+      }
+    }
+
+    class ReplacementService {}
+
+    const root = new Container().register({
+      provide: serviceToken,
+      scope: 'request',
+      useClass: OriginalService,
+    });
+    const requestContainer = root.createRequestScope();
+    await requestContainer.resolve(serviceToken);
+
+    const requestCache = Reflect.get(requestContainer, 'requestCache');
+    if (!(requestCache instanceof Map)) {
+      expect.unreachable('expected the request cache to be materialized');
+    }
+
+    const stalePromise = requestCache.get(serviceToken);
+    if (!stalePromise) {
+      expect.unreachable('expected the original service promise to be cached');
+    }
+
+    // When
+    root.override({ provide: serviceToken, scope: 'request', useClass: ReplacementService });
+    await requestContainer.resolve(serviceToken);
+
+    // Then
+    const materializedCachePromises = Reflect.get(requestContainer, 'materializedCachePromises');
+    if (!Array.isArray(materializedCachePromises)) {
+      expect.unreachable('expected the materialization ledger to be an array');
+    }
+
+    expect({
+      events,
+      retainsStalePromise: materializedCachePromises.includes(stalePromise),
+    }).toEqual({
+      events: ['original:destroy'],
+      retainsStalePromise: false,
+    });
+  });
 });

--- a/packages/di/src/container.ts
+++ b/packages/di/src/container.ts
@@ -1347,6 +1347,9 @@ export class Container {
         task.failed = true;
       }
     })().finally(() => {
+      const retainedMaterializations = this.materializedCachePromises.filter((promise) => promise !== instancePromise);
+      this.materializedCachePromises.splice(0, this.materializedCachePromises.length, ...retainedMaterializations);
+
       if (!task.failed) {
         for (const observer of observers) {
           observer.staleDisposalTasks.delete(task);

--- a/packages/di/src/container.ts
+++ b/packages/di/src/container.ts
@@ -290,6 +290,7 @@ export class Container {
   private requestCache: Map<Token, Promise<unknown>> | undefined;
   private multiRequestCache: Map<NormalizedProvider, Promise<unknown>> | undefined;
   private readonly multiSingletonCache = new Map<NormalizedProvider, Promise<unknown>>();
+  private readonly materializedCachePromises: Promise<unknown>[] = [];
   private readonly staleDisposalTasks = new Set<StaleDisposalTask>();
   private readonly singletonCache: Map<Token, Promise<unknown>>;
   private readonly forwardRefTokenCache = new WeakMap<ForwardRefFn, Token>();
@@ -517,10 +518,12 @@ export class Container {
       setMultiSingleton: (provider: NormalizedProvider, promise: Promise<unknown>) => {
         this.multiSingletonCache.set(provider, promise);
         multiSingletonCacheSnapshot.set(provider, promise);
+        this.trackCacheMaterialization(promise);
       },
       setSingleton: (token: Token, promise: Promise<unknown>) => {
         this.singletonCache.set(token, promise);
         singletonCacheSnapshot.set(token, promise);
+        this.trackCacheMaterialization(promise);
       },
     });
   }
@@ -948,6 +951,7 @@ export class Container {
 
     trackPendingResolution(promise, activeTokens);
     cache.set(provider, promise);
+    this.trackCacheMaterialization(promise);
 
     return promise;
   }
@@ -994,6 +998,7 @@ export class Container {
 
     trackPendingResolution(promise, activeTokens);
     cache.set(provider.provide, promise);
+    this.trackCacheMaterialization(promise);
 
     return promise;
   }
@@ -1202,16 +1207,22 @@ export class Container {
     const disposables: Disposable[] = [];
     const seenInstances = new Set<unknown>();
     const errors: unknown[] = [];
+    const activePromises = new Set(entries.map(([, promise]) => promise));
 
     const settled = await Promise.allSettled(entries.map(([, p]) => p));
 
     for (const result of settled) {
       if (result.status === 'rejected') {
         errors.push(result.reason);
+      }
+    }
+
+    for (const promise of this.materializedCachePromises) {
+      if (!activePromises.has(promise)) {
         continue;
       }
 
-      const instance = result.value;
+      const instance = await promise;
 
       if (this.isDisposable(instance) && !seenInstances.has(instance)) {
         seenInstances.add(instance);
@@ -1237,6 +1248,8 @@ export class Container {
   }
 
   private clearDisposalCaches(): void {
+    this.materializedCachePromises.length = 0;
+
     if (this.parent) {
       this.requestCache?.clear();
       this.multiRequestCache?.clear();
@@ -1247,6 +1260,13 @@ export class Container {
     this.singletonCache.clear();
     this.multiSingletonCache.clear();
     this.clearResolutionPlanCaches();
+  }
+
+  private trackCacheMaterialization(promise: Promise<unknown>): void {
+    void promise.then(
+      () => this.materializedCachePromises.push(promise),
+      () => undefined,
+    );
   }
 
   private currentLineageRevision(): string {


### PR DESCRIPTION
## Summary

Preserve `@fluojs/di` teardown ordering across single-provider and multi-provider caches so cache-owned dependents are destroyed before dependencies.

Linked context: Closes #2944

## Changes

- Track successful cache materialization in one container-owned order across ordinary and controlled cache-adoption paths.
- Dispose only currently cache-owned successful instances in reverse materialization order while retaining identity deduplication and existing failure aggregation.
- Add a failing-first public `Container.resolve()` / `Container.dispose()` regression for a single-provider dependent on a multi-provider dependency.
- Document the reverse-creation lifecycle contract in `packages/di/README.md` and `packages/di/README.ko.md`.
- Add `.changeset/preserve-di-disposal-order.md` with a patch release for `@fluojs/di`.

## Testing

- RED: `pnpm --dir packages/di exec vitest run -c vitest.config.ts src/container-disposal-order.test.ts` — failed before the fix with received order `[dependency, dependent]` instead of `[dependent, dependency]`.
- GREEN: same focused command — 1/1 passed.
- `pnpm --dir packages/di test` — 6 files, 147 tests passed.
- `pnpm --dir packages/di typecheck` — passed.
- `pnpm --dir packages/di build` — passed.
- `pnpm exec biome check packages/di/src/container.ts packages/di/src/container-disposal-order.test.ts` — passed.
- Changed-file LSP diagnostics — no diagnostics.
- `pnpm verify:platform-consistency-governance` — passed.
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main` — passed.
- `FLUO_CLI_SANDBOX_ROOT=/var/folders/xj/v8c228rx2ybb4g8pkm1m932r0000gn/T/opencode/fluo-2944-cli-sandbox pnpm verify:release-readiness` — passed without writing draft artifacts: packages 365 files / 4,301 passed + 1 skipped, examples 8 files / 23 passed, tooling 36 files / 405 passed, and the representative CLI sandbox matrix passed.
- A parallel `pnpm verify` run completed build, typecheck, and lint, then hit three unrelated 5-second Vitest timeouts under concurrent worktree load; the three files passed together in serialized isolation (3 files, 20 tests), and the canonical serialized release-readiness gate above passed fully.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Patch rationale: this restores documented lifecycle-safe teardown behavior without changing the public API.

## Public export documentation

Not applicable: no public export, signature, or TSDoc surface changed.

- [x] Existing public export documentation remains unchanged.
- [x] README lifecycle documentation was updated in both English and Korean.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] Reverse creation disposal across single and multi-provider caches is documented in the affected package README pair.
- [x] Intentional limitations remain unchanged.
- [x] The runtime invariant is covered by a public-behavior regression test.

Existing child-scope-first cleanup, stale-disposal settlement, instance deduplication, and `AggregateError` behavior remain covered by the DI lifecycle suite.

## Platform consistency governance (SSOT)

No platform contract or governance SSOT document changed. The implementation is runtime-neutral promise/container logic.

- [x] EN/KO package README lifecycle wording remains synchronized.
- [x] `pnpm verify:platform-consistency-governance` passed.
- [x] No platform harness update is applicable because no platform adapter surface changed.