### PR TITLE
Resolve #2949: Cover i18n ICU missing-message hook contract

### DIFF
--- a/packages/i18n/src/icu.test.ts
+++ b/packages/i18n/src/icu.test.ts
@@ -102,6 +102,27 @@ describe('@fluojs/i18n/icu MessageFormat subpath', () => {
     ).toBe('2 fallback items');
   });
 
+  it('formats missing-message ICU patterns with requested values and locale', () => {
+    // Given
+    const service = createIcuI18n({
+      defaultLocale: 'en',
+      missingMessage: ({ locale }) =>
+        locale === 'ar'
+          ? '{count, plural, zero {No notifications for {name}} one {One notification for {name}} other {# notifications for {name}}}'
+          : undefined,
+      supportedLocales: ['en', 'ar'],
+    });
+
+    // When
+    const message = service.translate('notifications', {
+      locale: 'ar',
+      values: { count: 0, name: 'Mina' },
+    });
+
+    // Then
+    expect(message).toBe('No notifications for Mina');
+  });
+
   it('formats fallback catalog messages with the locale that supplied the message', () => {
     const service = createIcuI18n({
       catalogs: {


### PR DESCRIPTION
## Summary

Add executable regression evidence for the documented `@fluojs/i18n/icu` contract that preserves the core `missingMessage` hook.

Linked context: Closes #2949

## Changes

- Add an absent-key ICU test whose core `missingMessage` hook returns an ICU plural pattern.
- Prove requested values are substituted and the requested `ar` locale selects the ICU `zero` plural branch.
- Keep the final change test-only; production source, docs, examples, and package metadata are unchanged.

## Testing

- RED: with a deliberate temporary regression that forced the default locale, `pnpm exec vitest run -c vitest.config.ts src/icu.test.ts` failed only the new assertion (`0 notifications for Mina` instead of `No notifications for Mina`; 8 passed, 1 failed). The mutation was reverted before commit.
- GREEN: `pnpm exec vitest run -c vitest.config.ts src/icu.test.ts` — 9 passed.
- `pnpm --filter @fluojs/i18n test` — 10 files, 98 tests passed.
- `pnpm --filter "@fluojs/i18n..." build && pnpm --filter @fluojs/i18n typecheck` — passed.
- Changed-file LSP diagnostics — no diagnostics.
- `pnpm verify` — build, typecheck, lint, and changed-mode public-export TSDoc checks passed; the root test phase passed 404 files / 4,749 tests and had 3 unrelated failures (CLI timeout, GraphQL SSE timing, platform-bun declaration resolution). Each failed file passed immediately in an isolated rerun: CLI 222/222, GraphQL 1/1, platform-bun 1/1.

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact. This is test-only contract coverage, so no changeset is included.

## Public export documentation

- [x] No public exports or source TSDoc changed; this section is not applicable.

## Behavioral contract

- [x] No documented behavioral contracts were removed or changed.
- [x] No new behavioral contract was introduced; the existing README guarantee is now covered by regression evidence.
- [x] Intentional limitations remain unchanged.
- [x] The documented ICU missing-message invariant is covered by the new test.

## Platform consistency governance (SSOT)

- [x] No governance docs, platform contracts, or EN/KO mirrors changed.
- [x] Platform harness evidence is not applicable to this package-local test-only change.