### PR TITLE
Align Fastify lifecycle helper documentation

### DIFF
--- a/packages/platform-fastify/README.ko.md
+++ b/packages/platform-fastify/README.ko.md
@@ -50,7 +50,7 @@ const app = await fluoFactory.create(AppModule, {
 await app.listen();
 ```
 
-`createFastifyAdapter()`는 기본 port로 `3000`을 사용하며 `process.env.PORT`를 읽지 않습니다. `port`, `maxBodySize`, `retryDelayMs`, `retryLimit`, `shutdownTimeoutMs` 같은 잘못된 explicit numeric option은 adapter setup 중 throw됩니다. `maxBodySize`와 `shutdownTimeoutMs`는 음수가 아닌 정수 byte/time limit이므로 `0`도 유효합니다. `maxBodySize: 0`은 빈 request body만 허용하고, `shutdownTimeoutMs: 0`은 다음 timer turn에 Fastify close가 timeout되도록 요청합니다.
+`createFastifyAdapter()`는 기본 port로 `3000`을 사용하며 `process.env.PORT`를 읽지 않습니다. `port`, `maxBodySize`, `retryDelayMs`, `retryLimit`, `shutdownTimeoutMs` 같은 잘못된 explicit numeric option은 adapter setup 중 throw됩니다. `maxBodySize`와 `shutdownTimeoutMs`는 음수가 아닌 정수 byte/time limit이므로 `0`도 유효합니다. `maxBodySize: 0`은 빈 request body만 허용하고, `shutdownTimeoutMs: 0`은 Fastify close를 즉시 시작합니다. `0`은 대기 시간만 제한하므로 close가 아직 settle되지 않았다면 대기는 다음 timer turn에 timeout될 수 있지만, 기반 Fastify close와 cleanup은 계속 진행됩니다.
 
 ## 주요 패턴
 
@@ -74,10 +74,10 @@ await app.listen();
 
 Adapter를 만들기 전에 certificate는 애플리케이션 configuration 또는 secret-management boundary에서 로드하세요. 이 패키지는 certificate file, `process.env`, `PORT`를 직접 읽지 않습니다. Load balancer, ingress, API gateway가 TLS를 종료한다면 `https`를 설정하지 말고 해당 infrastructure 뒤에서 Fastify adapter를 일반 HTTP로 실행하세요.
 
-`bootstrapFastifyApplication(...)`과 `runFastifyApplication(...)`도 같은 `https`, `host`, `port` option을 받습니다.
+`bootstrapFastifyApplication(...)`과 `runFastifyApplication(...)`도 같은 `https`, `host`, `port` option을 받습니다. `runFastifyApplication(...)`은 shutdown registration이 준비된 shell을 반환하며, caller는 여전히 `listen()`을 호출합니다.
 
 ```typescript
-await runFastifyApplication(AppModule, {
+const app = await runFastifyApplication(AppModule, {
   host: '127.0.0.1',
   https: {
     cert: tlsCertificate,
@@ -85,6 +85,8 @@ await runFastifyApplication(AppModule, {
   },
   port: 3443,
 });
+
+await app.listen();
 ```
 
 ### 멀티파트 및 Raw Body
@@ -189,13 +191,13 @@ fluo의 Fastify 어댑터는 높은 동시성 시나리오에서 raw Node.js 어
 
 `packages/platform-fastify/src/adapter.test.ts`는 문서화된 Fastify 어댑터 계약을 위한 package-local regression target입니다. 이 파일은 공유 `createHttpAdapterPortabilityHarness(...)` 검사를 실행하여 malformed cookie 보존, JSON/text raw-body capture, byte-exact raw-body capture, multipart raw-body 제외, multipart total-size 기본값, SSE framing, response stream drain settlement, host 및 HTTPS startup logging, shutdown signal listener cleanup을 확인합니다.
 
-같은 파일은 Fastify 전용 native route registration과 wildcard fallback, duplicate shape route fallback, concurrent/repeated `listen()` idempotency, shutdown 중 startup retry cancellation, adapter reuse 시 native descriptor refresh, explicit `OPTIONS` route ownership, middleware/guard/interceptor/observer ordering, CORS ownership, global prefix behavior, malformed cookie preservation, response serialization parity, raw-body pre-parsing behavior, zero-valued body/shutdown limit, 대소문자 구분 없는 multipart detection, multipart limit handling도 함께 다룹니다. startup, routing, adapter portability behavior를 변경할 때는 README 예제 포인터를 이 테스트 파일 및 custom adapter book chapter와 맞추어 유지하세요.
+같은 파일은 Fastify 전용 native route registration과 wildcard fallback, duplicate shape route fallback, concurrent/repeated `listen()` idempotency, shutdown 중 startup retry cancellation, adapter reuse 시 native descriptor refresh, explicit `OPTIONS` route ownership, middleware/guard/interceptor/observer ordering, CORS ownership, global prefix behavior, malformed cookie preservation, response serialization parity, raw-body pre-parsing behavior, zero-valued body/shutdown limit, 기반 Fastify close를 계속 in-flight 상태로 두는 close 대기 timeout, 대소문자 구분 없는 multipart detection, multipart limit handling도 함께 다룹니다. startup, routing, adapter portability behavior를 변경할 때는 README 예제 포인터를 이 테스트 파일 및 custom adapter book chapter와 맞추어 유지하세요.
 
 ## 공개 API 개요
 
 - `createFastifyAdapter(options, multipartOptions?)`: Fastify 어댑터를 위한 권장 팩토리입니다. `options`에는 `host`, `port`, Node.js `https` server option 같은 transport startup knob이 포함됩니다. 선택적 두 번째 인자는 직접 어댑터를 생성할 때 `maxFileSize`, `maxFiles`, `maxTotalSize` 같은 multipart 제한을 설정합니다.
 - `bootstrapFastifyApplication(module, options)`: 암시적 리스닝 없이 수행하는 고급 부트스트랩입니다. Host가 bind 전에 앱을 구성해야 할 때 `https`를 포함한 같은 Fastify startup option을 받습니다.
-- `runFastifyApplication(module, options)`: 생명주기 관리를 포함한 빠른 시작 헬퍼이며 같은 `https` startup surface를 제공합니다. timeout/실패 시에는 해당 상태를 로그와 `process.exitCode`로 보고하고, 최종 프로세스 종료는 주변 호스트에 맡깁니다.
+- `runFastifyApplication(module, options)`: shutdown registration과 같은 `https` startup surface가 준비된 bootstrapped application shell을 반환하며, caller는 여전히 `app.listen()`을 호출합니다. Signal 기반 shutdown timeout/실패 시에는 해당 상태를 로그와 `process.exitCode`로 보고하고, 최종 프로세스 종료는 주변 호스트에 맡깁니다.
 - `isFastifyMultipartTooLargeError(error)`: Fastify error shape 전반에서 multipart limit error를 감지합니다.
 - `FastifyHttpApplicationAdapter`: 핵심 어댑터 구현 클래스입니다.
 - Option type: `FastifyAdapterOptions`, `BootstrapFastifyApplicationOptions`, `RunFastifyApplicationOptions`, `CorsInput`, `FastifyApplicationSignal`.

--- a/packages/platform-fastify/README.ko.md
+++ b/packages/platform-fastify/README.ko.md
@@ -74,7 +74,7 @@ await app.listen();
 
 Adapter를 만들기 전에 certificate는 애플리케이션 configuration 또는 secret-management boundary에서 로드하세요. 이 패키지는 certificate file, `process.env`, `PORT`를 직접 읽지 않습니다. Load balancer, ingress, API gateway가 TLS를 종료한다면 `https`를 설정하지 말고 해당 infrastructure 뒤에서 Fastify adapter를 일반 HTTP로 실행하세요.
 
-`bootstrapFastifyApplication(...)`과 `runFastifyApplication(...)`도 같은 `https`, `host`, `port` option을 받습니다. `runFastifyApplication(...)`은 shutdown registration이 준비된 shell을 반환하며, caller는 여전히 `listen()`을 호출합니다.
+`bootstrapFastifyApplication(...)`과 `runFastifyApplication(...)`도 같은 `https`, `host`, `port` option을 받습니다. `runFastifyApplication(...)`은 resolve되기 전에 listening을 시작하고 shutdown registration을 설치한 다음 실행 중인 application shell을 반환합니다.
 
 ```typescript
 const app = await runFastifyApplication(AppModule, {
@@ -85,8 +85,6 @@ const app = await runFastifyApplication(AppModule, {
   },
   port: 3443,
 });
-
-await app.listen();
 ```
 
 ### 멀티파트 및 Raw Body
@@ -197,7 +195,7 @@ fluo의 Fastify 어댑터는 높은 동시성 시나리오에서 raw Node.js 어
 
 - `createFastifyAdapter(options, multipartOptions?)`: Fastify 어댑터를 위한 권장 팩토리입니다. `options`에는 `host`, `port`, Node.js `https` server option 같은 transport startup knob이 포함됩니다. 선택적 두 번째 인자는 직접 어댑터를 생성할 때 `maxFileSize`, `maxFiles`, `maxTotalSize` 같은 multipart 제한을 설정합니다.
 - `bootstrapFastifyApplication(module, options)`: 암시적 리스닝 없이 수행하는 고급 부트스트랩입니다. Host가 bind 전에 앱을 구성해야 할 때 `https`를 포함한 같은 Fastify startup option을 받습니다.
-- `runFastifyApplication(module, options)`: shutdown registration과 같은 `https` startup surface가 준비된 bootstrapped application shell을 반환하며, caller는 여전히 `app.listen()`을 호출합니다. Signal 기반 shutdown timeout/실패 시에는 해당 상태를 로그와 `process.exitCode`로 보고하고, 최종 프로세스 종료는 주변 호스트에 맡깁니다.
+- `runFastifyApplication(module, options)`: Application을 bootstrap하고 listening을 시작한 뒤 shutdown registration을 설치하며, 같은 `https` startup surface를 사용하는 실행 중인 shell을 반환합니다. Signal 기반 shutdown timeout/실패 시에는 해당 상태를 로그와 `process.exitCode`로 보고하고, 최종 프로세스 종료는 주변 호스트에 맡깁니다.
 - `isFastifyMultipartTooLargeError(error)`: Fastify error shape 전반에서 multipart limit error를 감지합니다.
 - `FastifyHttpApplicationAdapter`: 핵심 어댑터 구현 클래스입니다.
 - Option type: `FastifyAdapterOptions`, `BootstrapFastifyApplicationOptions`, `RunFastifyApplicationOptions`, `CorsInput`, `FastifyApplicationSignal`.

--- a/packages/platform-fastify/README.md
+++ b/packages/platform-fastify/README.md
@@ -74,7 +74,7 @@ await app.listen();
 
 Load certificates from your application configuration or secret-management boundary before constructing the adapter; the package does not read certificate files, `process.env`, or `PORT` by itself. If a load balancer, ingress, or API gateway terminates TLS, leave `https` unset and run the Fastify adapter as plain HTTP behind that infrastructure.
 
-`bootstrapFastifyApplication(...)` and `runFastifyApplication(...)` accept the same `https`, `host`, and `port` options. `runFastifyApplication(...)` returns a shell prepared with shutdown registration; the caller still invokes `listen()`:
+`bootstrapFastifyApplication(...)` and `runFastifyApplication(...)` accept the same `https`, `host`, and `port` options. `runFastifyApplication(...)` starts listening before it resolves, installs shutdown registration, and returns the running application shell:
 
 ```typescript
 const app = await runFastifyApplication(AppModule, {
@@ -85,8 +85,6 @@ const app = await runFastifyApplication(AppModule, {
   },
   port: 3443,
 });
-
-await app.listen();
 ```
 
 ### Multipart and Raw Body
@@ -197,7 +195,7 @@ The same file also covers Fastify-specific native route registration with wildca
 
 - `createFastifyAdapter(options, multipartOptions?)`: Recommended factory for the Fastify adapter. `options` includes transport startup knobs such as `host`, `port`, and Node.js `https` server options. The optional second argument configures multipart limits such as `maxFileSize`, `maxFiles`, and `maxTotalSize` for direct adapter construction.
 - `bootstrapFastifyApplication(module, options)`: advanced bootstrap without implicit listening; accepts the same Fastify startup options, including `https`, when the host wants to construct the app before binding it.
-- `runFastifyApplication(module, options)`: Returns a bootstrapped application shell with shutdown registration and the same `https` startup surface; the caller still invokes `app.listen()`. On signal-driven shutdown timeout/failure it reports the condition through logging and `process.exitCode`, while leaving final process termination to the surrounding host.
+- `runFastifyApplication(module, options)`: Bootstraps the application, starts listening, installs shutdown registration, and returns the running shell with the same `https` startup surface. On signal-driven shutdown timeout/failure it reports the condition through logging and `process.exitCode`, while leaving final process termination to the surrounding host.
 - `isFastifyMultipartTooLargeError(error)`: Detects multipart limit errors across Fastify error shapes.
 - `FastifyHttpApplicationAdapter`: The core adapter implementation.
 - Option types: `FastifyAdapterOptions`, `BootstrapFastifyApplicationOptions`, `RunFastifyApplicationOptions`, `CorsInput`, `FastifyApplicationSignal`.

--- a/packages/platform-fastify/README.md
+++ b/packages/platform-fastify/README.md
@@ -50,7 +50,7 @@ const app = await fluoFactory.create(AppModule, {
 await app.listen();
 ```
 
-`createFastifyAdapter()` defaults to port `3000` and does not read `process.env.PORT`; invalid explicit numeric options such as `port`, `maxBodySize`, `retryDelayMs`, `retryLimit`, and `shutdownTimeoutMs` throw during adapter setup. `maxBodySize` and `shutdownTimeoutMs` are non-negative integer byte/time limits, so `0` is valid: `maxBodySize: 0` allows only empty request bodies, and `shutdownTimeoutMs: 0` asks Fastify to close on the next timer turn.
+`createFastifyAdapter()` defaults to port `3000` and does not read `process.env.PORT`; invalid explicit numeric options such as `port`, `maxBodySize`, `retryDelayMs`, `retryLimit`, and `shutdownTimeoutMs` throw during adapter setup. `maxBodySize` and `shutdownTimeoutMs` are non-negative integer byte/time limits, so `0` is valid: `maxBodySize: 0` allows only empty request bodies, and `shutdownTimeoutMs: 0` starts Fastify close immediately. The zero value bounds only the wait: if close has not settled, the wait may time out on the next timer turn while the underlying Fastify close and cleanup continue.
 
 ## Common Patterns
 
@@ -74,10 +74,10 @@ await app.listen();
 
 Load certificates from your application configuration or secret-management boundary before constructing the adapter; the package does not read certificate files, `process.env`, or `PORT` by itself. If a load balancer, ingress, or API gateway terminates TLS, leave `https` unset and run the Fastify adapter as plain HTTP behind that infrastructure.
 
-`bootstrapFastifyApplication(...)` and `runFastifyApplication(...)` accept the same `https`, `host`, and `port` options:
+`bootstrapFastifyApplication(...)` and `runFastifyApplication(...)` accept the same `https`, `host`, and `port` options. `runFastifyApplication(...)` returns a shell prepared with shutdown registration; the caller still invokes `listen()`:
 
 ```typescript
-await runFastifyApplication(AppModule, {
+const app = await runFastifyApplication(AppModule, {
   host: '127.0.0.1',
   https: {
     cert: tlsCertificate,
@@ -85,6 +85,8 @@ await runFastifyApplication(AppModule, {
   },
   port: 3443,
 });
+
+await app.listen();
 ```
 
 ### Multipart and Raw Body
@@ -189,13 +191,13 @@ fluo's Fastify adapter significantly outperforms the raw Node.js adapter in high
 
 `packages/platform-fastify/src/adapter.test.ts` is the package-local regression target for the documented Fastify adapter contract. It runs the shared `createHttpAdapterPortabilityHarness(...)` checks for malformed cookie preservation, JSON/text raw-body capture, byte-exact raw-body capture, multipart raw-body exclusion, multipart total-size defaults, SSE framing, response stream drain settlement, host and HTTPS startup logging, and shutdown signal listener cleanup.
 
-The same file also covers Fastify-specific native route registration with wildcard fallback, duplicate shape route fallback, concurrent and repeated `listen()` idempotency, startup retry cancellation during shutdown, native descriptor refresh on adapter reuse, explicit `OPTIONS` route ownership, middleware/guard/interceptor/observer ordering, CORS ownership, global prefix behavior, malformed cookie preservation, response serialization parity, raw-body pre-parsing behavior, zero-valued body/shutdown limits, case-insensitive multipart detection, and multipart limit handling. Keep README example pointers aligned with that test file and the custom adapter book chapter when changing startup, routing, or adapter portability behavior.
+The same file also covers Fastify-specific native route registration with wildcard fallback, duplicate shape route fallback, concurrent and repeated `listen()` idempotency, startup retry cancellation during shutdown, native descriptor refresh on adapter reuse, explicit `OPTIONS` route ownership, middleware/guard/interceptor/observer ordering, CORS ownership, global prefix behavior, malformed cookie preservation, response serialization parity, raw-body pre-parsing behavior, zero-valued body/shutdown limits, close wait timeouts that leave the underlying Fastify close in flight, case-insensitive multipart detection, and multipart limit handling. Keep README example pointers aligned with that test file and the custom adapter book chapter when changing startup, routing, or adapter portability behavior.
 
 ## Public API Overview
 
 - `createFastifyAdapter(options, multipartOptions?)`: Recommended factory for the Fastify adapter. `options` includes transport startup knobs such as `host`, `port`, and Node.js `https` server options. The optional second argument configures multipart limits such as `maxFileSize`, `maxFiles`, and `maxTotalSize` for direct adapter construction.
 - `bootstrapFastifyApplication(module, options)`: advanced bootstrap without implicit listening; accepts the same Fastify startup options, including `https`, when the host wants to construct the app before binding it.
-- `runFastifyApplication(module, options)`: Quick-start helper with lifecycle management and the same `https` startup surface. On timeout/failure it reports the condition through logging and `process.exitCode`, while leaving final process termination to the surrounding host.
+- `runFastifyApplication(module, options)`: Returns a bootstrapped application shell with shutdown registration and the same `https` startup surface; the caller still invokes `app.listen()`. On signal-driven shutdown timeout/failure it reports the condition through logging and `process.exitCode`, while leaving final process termination to the surrounding host.
 - `isFastifyMultipartTooLargeError(error)`: Detects multipart limit errors across Fastify error shapes.
 - `FastifyHttpApplicationAdapter`: The core adapter implementation.
 - Option types: `FastifyAdapterOptions`, `BootstrapFastifyApplicationOptions`, `RunFastifyApplicationOptions`, `CorsInput`, `FastifyApplicationSignal`.

--- a/packages/platform-fastify/src/adapter.ts
+++ b/packages/platform-fastify/src/adapter.ts
@@ -714,14 +714,14 @@ export async function bootstrapFastifyApplication(
 }
 
 /**
- * Bootstrap and prepare a Fastify-backed application with shutdown registration.
+ * Bootstrap and start a Fastify-backed application with shutdown registration.
  *
- * This helper mirrors the README quick-start path: create the adapter, wire the
- * runtime, and attach signal handling so callers only need to invoke `listen()`.
+ * This helper creates the adapter, wires the runtime, awaits `listen()`, installs
+ * the configured shutdown registration, and only then returns the running application.
  *
  * @param rootModule Root application module compiled by the Fluo runtime.
  * @param options Runtime, adapter, and shutdown registration settings.
- * @returns A bootstrapped application shell ready to listen.
+ * @returns A running application shell after listening succeeds and shutdown registration completes.
  */
 export async function runFastifyApplication(
   rootModule: ModuleType,

--- a/tooling/governance/verify-platform-consistency-governance.mjs
+++ b/tooling/governance/verify-platform-consistency-governance.mjs
@@ -1485,6 +1485,24 @@ function enforceCanonicalRuntimeMatrixReferences() {
     'Korean Fastify README, package-surface, package-chooser, docs/CONTEXT.ko.md, book metadata, and website guidance must keep the Node.js 20+ runtime floor and HTTPS/TLS startup boundary discoverable together.',
   );
   assert(
+    fastifyReadme.includes('`shutdownTimeoutMs: 0` starts Fastify close immediately') &&
+      fastifyReadme.includes('the wait may time out on the next timer turn') &&
+      fastifyReadme.includes('the underlying Fastify close and cleanup continue') &&
+      fastifyReadme.includes('returns a shell prepared with shutdown registration') &&
+      fastifyReadme.includes('the caller still invokes `listen()`') &&
+      fastifyReadme.includes('the caller still invokes `app.listen()`'),
+    'Fastify README must document zero-timeout close ordering and caller-owned listen after run-helper preparation.',
+  );
+  assert(
+    fastifyReadmeKo.includes('`shutdownTimeoutMs: 0`은 Fastify close를 즉시 시작') &&
+      fastifyReadmeKo.includes('대기는 다음 timer turn에 timeout될 수 있지만') &&
+      fastifyReadmeKo.includes('기반 Fastify close와 cleanup은 계속 진행') &&
+      fastifyReadmeKo.includes('shutdown registration이 준비된 shell을 반환') &&
+      fastifyReadmeKo.includes('caller는 여전히 `listen()`을 호출') &&
+      fastifyReadmeKo.includes('caller는 여전히 `app.listen()`을 호출'),
+    'Korean Fastify README must document zero-timeout close ordering and caller-owned listen after run-helper preparation.',
+  );
+  assert(
     platformBunReadme.includes('synchronously creates the fetch bridge') &&
       platformBunReadme.includes('Bun websocket bindings must be configured before `listen()` starts') &&
       platformBunReadme.includes('logging and `process.exitCode`') &&

--- a/tooling/governance/verify-platform-consistency-governance.mjs
+++ b/tooling/governance/verify-platform-consistency-governance.mjs
@@ -1488,19 +1488,19 @@ function enforceCanonicalRuntimeMatrixReferences() {
     fastifyReadme.includes('`shutdownTimeoutMs: 0` starts Fastify close immediately') &&
       fastifyReadme.includes('the wait may time out on the next timer turn') &&
       fastifyReadme.includes('the underlying Fastify close and cleanup continue') &&
-      fastifyReadme.includes('returns a shell prepared with shutdown registration') &&
-      fastifyReadme.includes('the caller still invokes `listen()`') &&
-      fastifyReadme.includes('the caller still invokes `app.listen()`'),
-    'Fastify README must document zero-timeout close ordering and caller-owned listen after run-helper preparation.',
+      fastifyReadme.includes('starts listening before it resolves, installs shutdown registration') &&
+      fastifyReadme.includes('returns the running application shell') &&
+      !fastifyReadme.includes('the caller still invokes'),
+    'Fastify README must document zero-timeout close ordering and run-helper-owned listening.',
   );
   assert(
     fastifyReadmeKo.includes('`shutdownTimeoutMs: 0`은 Fastify close를 즉시 시작') &&
       fastifyReadmeKo.includes('대기는 다음 timer turn에 timeout될 수 있지만') &&
       fastifyReadmeKo.includes('기반 Fastify close와 cleanup은 계속 진행') &&
-      fastifyReadmeKo.includes('shutdown registration이 준비된 shell을 반환') &&
-      fastifyReadmeKo.includes('caller는 여전히 `listen()`을 호출') &&
-      fastifyReadmeKo.includes('caller는 여전히 `app.listen()`을 호출'),
-    'Korean Fastify README must document zero-timeout close ordering and caller-owned listen after run-helper preparation.',
+      fastifyReadmeKo.includes('resolve되기 전에 listening을 시작하고 shutdown registration을 설치') &&
+      fastifyReadmeKo.includes('실행 중인 application shell을 반환') &&
+      !fastifyReadmeKo.includes('caller는 여전히'),
+    'Korean Fastify README must document zero-timeout close ordering and run-helper-owned listening.',
   );
   assert(
     platformBunReadme.includes('synchronously creates the fetch bridge') &&

--- a/tooling/governance/verify-platform-consistency-governance.mjs
+++ b/tooling/governance/verify-platform-consistency-governance.mjs
@@ -1204,6 +1204,7 @@ function enforceCanonicalRuntimeMatrixReferences() {
   const i18nReadmeKo = readFileSync(join(repoRoot, 'packages/i18n/README.ko.md'), 'utf8');
   const drizzleReadme = readFileSync(join(repoRoot, 'packages/drizzle/README.md'), 'utf8');
   const drizzleReadmeKo = readFileSync(join(repoRoot, 'packages/drizzle/README.ko.md'), 'utf8');
+  const fastifyAdapterSource = readFileSync(join(repoRoot, 'packages/platform-fastify/src/adapter.ts'), 'utf8');
   const fastifyReadme = readFileSync(join(repoRoot, 'packages/platform-fastify/README.md'), 'utf8');
   const fastifyReadmeKo = readFileSync(join(repoRoot, 'packages/platform-fastify/README.ko.md'), 'utf8');
   const platformBunReadme = readFileSync(join(repoRoot, 'packages/platform-bun/README.md'), 'utf8');
@@ -1490,8 +1491,13 @@ function enforceCanonicalRuntimeMatrixReferences() {
       fastifyReadme.includes('the underlying Fastify close and cleanup continue') &&
       fastifyReadme.includes('starts listening before it resolves, installs shutdown registration') &&
       fastifyReadme.includes('returns the running application shell') &&
-      !fastifyReadme.includes('the caller still invokes'),
-    'Fastify README must document zero-timeout close ordering and run-helper-owned listening.',
+      !fastifyReadme.includes('the caller still invokes') &&
+      fastifyAdapterSource.includes('awaits `listen()`') &&
+      fastifyAdapterSource.includes('only then returns the running application') &&
+      fastifyAdapterSource.includes('@returns A running application shell after listening succeeds and shutdown registration completes.') &&
+      !fastifyAdapterSource.includes('callers only need to invoke `listen()`') &&
+      !fastifyAdapterSource.includes('ready to listen'),
+    'Fastify README and public TSDoc must document zero-timeout close ordering and run-helper-owned listening.',
   );
   assert(
     fastifyReadmeKo.includes('`shutdownTimeoutMs: 0`은 Fastify close를 즉시 시작') &&

--- a/tooling/governance/verify-platform-consistency-governance.test.ts
+++ b/tooling/governance/verify-platform-consistency-governance.test.ts
@@ -1152,6 +1152,7 @@ describe('repository governance contracts', () => {
     const customAdapterKo = readFileSync(resolve(repoRoot, 'book/advanced/ch13-custom-adapter.ko.md'), 'utf8');
     const runtimeAdaptersGuide = readFileSync(resolve(repoRoot, 'apps/docs/content/docs/guides/runtime-adapters.mdx'), 'utf8');
     const runtimeAdaptersGuideKo = readFileSync(resolve(repoRoot, 'apps/docs/content/docs/guides/runtime-adapters.ko.mdx'), 'utf8');
+    const fastifyAdapterSource = readFileSync(resolve(repoRoot, 'packages/platform-fastify/src/adapter.ts'), 'utf8');
     const fastifyReadme = readFileSync(resolve(repoRoot, 'packages/platform-fastify/README.md'), 'utf8');
     const fastifyReadmeKo = readFileSync(resolve(repoRoot, 'packages/platform-fastify/README.ko.md'), 'utf8');
 
@@ -1204,6 +1205,11 @@ describe('repository governance contracts', () => {
     expect(fastifyReadme).toContain('starts listening before it resolves, installs shutdown registration');
     expect(fastifyReadme).toContain('returns the running application shell');
     expect(fastifyReadme).not.toContain('the caller still invokes');
+    expect(fastifyAdapterSource).toContain('awaits `listen()`');
+    expect(fastifyAdapterSource).toContain('only then returns the running application');
+    expect(fastifyAdapterSource).toContain('@returns A running application shell after listening succeeds and shutdown registration completes.');
+    expect(fastifyAdapterSource).not.toContain('callers only need to invoke `listen()`');
+    expect(fastifyAdapterSource).not.toContain('ready to listen');
 
     expect(fastifyReadmeKo).toContain('`shutdownTimeoutMs: 0`은 Fastify close를 즉시 시작');
     expect(fastifyReadmeKo).toContain('대기는 다음 timer turn에 timeout될 수 있지만');

--- a/tooling/governance/verify-platform-consistency-governance.test.ts
+++ b/tooling/governance/verify-platform-consistency-governance.test.ts
@@ -1197,6 +1197,20 @@ describe('repository governance contracts', () => {
     expect(runtimeAdaptersGuideKo).toContain('infrastructure boundary 뒤에서 Fastify를 일반 HTTP로 실행');
     expect(docsContext).toContain('apps/docs/content/docs/guides/runtime-adapters.mdx');
     expect(docsContextKo).toContain('apps/docs/content/docs/guides/runtime-adapters.ko.mdx');
+
+    expect(fastifyReadme).toContain('`shutdownTimeoutMs: 0` starts Fastify close immediately');
+    expect(fastifyReadme).toContain('the wait may time out on the next timer turn');
+    expect(fastifyReadme).toContain('the underlying Fastify close and cleanup continue');
+    expect(fastifyReadme).toContain('returns a shell prepared with shutdown registration');
+    expect(fastifyReadme).toContain('the caller still invokes `listen()`');
+    expect(fastifyReadme).toContain('the caller still invokes `app.listen()`');
+
+    expect(fastifyReadmeKo).toContain('`shutdownTimeoutMs: 0`은 Fastify close를 즉시 시작');
+    expect(fastifyReadmeKo).toContain('대기는 다음 timer turn에 timeout될 수 있지만');
+    expect(fastifyReadmeKo).toContain('기반 Fastify close와 cleanup은 계속 진행');
+    expect(fastifyReadmeKo).toContain('shutdown registration이 준비된 shell을 반환');
+    expect(fastifyReadmeKo).toContain('caller는 여전히 `listen()`을 호출');
+    expect(fastifyReadmeKo).toContain('caller는 여전히 `app.listen()`을 호출');
   });
 
   it('keeps Throttler guard activation and backing-store clock docs discoverable across governed docs', () => {

--- a/tooling/governance/verify-platform-consistency-governance.test.ts
+++ b/tooling/governance/verify-platform-consistency-governance.test.ts
@@ -1201,16 +1201,16 @@ describe('repository governance contracts', () => {
     expect(fastifyReadme).toContain('`shutdownTimeoutMs: 0` starts Fastify close immediately');
     expect(fastifyReadme).toContain('the wait may time out on the next timer turn');
     expect(fastifyReadme).toContain('the underlying Fastify close and cleanup continue');
-    expect(fastifyReadme).toContain('returns a shell prepared with shutdown registration');
-    expect(fastifyReadme).toContain('the caller still invokes `listen()`');
-    expect(fastifyReadme).toContain('the caller still invokes `app.listen()`');
+    expect(fastifyReadme).toContain('starts listening before it resolves, installs shutdown registration');
+    expect(fastifyReadme).toContain('returns the running application shell');
+    expect(fastifyReadme).not.toContain('the caller still invokes');
 
     expect(fastifyReadmeKo).toContain('`shutdownTimeoutMs: 0`은 Fastify close를 즉시 시작');
     expect(fastifyReadmeKo).toContain('대기는 다음 timer turn에 timeout될 수 있지만');
     expect(fastifyReadmeKo).toContain('기반 Fastify close와 cleanup은 계속 진행');
-    expect(fastifyReadmeKo).toContain('shutdown registration이 준비된 shell을 반환');
-    expect(fastifyReadmeKo).toContain('caller는 여전히 `listen()`을 호출');
-    expect(fastifyReadmeKo).toContain('caller는 여전히 `app.listen()`을 호출');
+    expect(fastifyReadmeKo).toContain('resolve되기 전에 listening을 시작하고 shutdown registration을 설치');
+    expect(fastifyReadmeKo).toContain('실행 중인 application shell을 반환');
+    expect(fastifyReadmeKo).not.toContain('caller는 여전히');
   });
 
   it('keeps Throttler guard activation and backing-store clock docs discoverable across governed docs', () => {


### PR DESCRIPTION
## Summary
- clarify shutdownTimeoutMs: 0 lifecycle semantics in EN/KO docs
- document that runFastifyApplication returns after listening and shutdown registration
- align public TSDoc and governance regression evidence with helper-owned listening

## Release impact
- docs, TSDoc, and governance-only correction
- no runtime or public API behavior change
- no changeset required

## Public export documentation
- updated the public runFastifyApplication TSDoc

## Behavioral contract
- EN/KO README, TSDoc, implementation, and executable Fastify tests now agree on listen ownership

## Platform consistency governance
- governance rejects stale caller-owned listen claims in README and source TSDoc

## Verification
- docs verification and production build passed
- focused Fastify/governance tests passed
- public-export TSDoc verifier, typecheck, Biome, and diagnostics passed

Closes #2965