### PR TITLE
Resolve #2983: Cover rejected React client destinations

### DIFF
--- a/packages/react/src/client-destination-rejection.test.ts
+++ b/packages/react/src/client-destination-rejection.test.ts
@@ -1,0 +1,70 @@
+import { expect, it, vi } from 'vitest';
+
+import {
+  type ClientNavigationEnvironment,
+  createClientNavigationStore,
+} from './client/store.js';
+import { createReactRouteSnapshot, ReactClientNavigationError } from './client.js';
+
+type RejectedNavigationCase = {
+  readonly destination: string;
+  readonly kind: 'cross-origin' | 'non-HTTP(S)';
+  readonly method: 'push' | 'replace';
+};
+
+const rejectedNavigationCases = [
+  {
+    destination: 'https://outside.test/products/sku-84',
+    kind: 'cross-origin',
+    method: 'push',
+  },
+  {
+    destination: 'https://outside.test/products/sku-126',
+    kind: 'cross-origin',
+    method: 'replace',
+  },
+  {
+    destination: 'ftp://example.test/products/sku-84',
+    kind: 'non-HTTP(S)',
+    method: 'push',
+  },
+  {
+    destination: 'ftp://example.test/products/sku-126',
+    kind: 'non-HTTP(S)',
+    method: 'replace',
+  },
+] satisfies readonly RejectedNavigationCase[];
+
+it.each(rejectedNavigationCases)('rejects a $kind $method without invoking browser navigation', ({ destination, method }) => {
+  // Given: a connected client store and observable browser navigation APIs.
+  const assign = vi.fn();
+  const replace = vi.fn();
+  const store = createClientNavigationStore(
+    createReactRouteSnapshot({ url: '/products/sku-42' }),
+  );
+  const environment = {
+    assign,
+    back: vi.fn(),
+    currentHref: () => 'https://example.test/products/sku-42',
+    reload: vi.fn(),
+    replace,
+    subscribe: () => () => undefined,
+  } satisfies ClientNavigationEnvironment;
+  store.connect(environment);
+
+  // When: the router targets an unsupported destination.
+  let thrown: ReactClientNavigationError | undefined;
+  try {
+    store.router[method](destination);
+  } catch (error) {
+    if (!(error instanceof ReactClientNavigationError)) {
+      throw error;
+    }
+    thrown = error;
+  }
+
+  // Then: the stable error is observable before either browser API runs.
+  expect(thrown).toMatchObject({ code: 'unsupported-destination' });
+  expect(assign).not.toHaveBeenCalled();
+  expect(replace).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary

Add the missing regression coverage for the documented stable `@fluojs/react/client` destination-rejection contract.

Linked context: Closes #2983

## Changes

- Add connected-store coverage for cross-origin `push` and `replace` destinations.
- Add connected-store coverage for non-HTTP(S) `push` and `replace` destinations.
- Assert every rejected navigation throws `ReactClientNavigationError` with `unsupported-destination` and calls neither `location.assign` nor `location.replace`.

## Testing

- `pnpm exec biome check packages/react/src/client-destination-rejection.test.ts`
- `pnpm exec vitest run -c vitest.config.ts src/client.test.ts src/client-destination-rejection.test.ts`
- `pnpm --filter @fluojs/react... build`
- `pnpm --filter @fluojs/react typecheck`
- `pnpm --filter @fluojs/react test` — 39 files, 132 tests passed

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

Test-only preservation of an already documented and implemented public contract; no changeset is required.

## Public export documentation

- [x] No public exports changed; source TSDoc and README examples are unaffected.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] No new behavioral contract was introduced; the existing stable client contract remains unchanged.
- [x] Intentional limitations remain explicitly documented.
- [x] The destination-rejection runtime invariant is covered by regression tests.

## Platform consistency governance (SSOT)

- [x] No governance docs or platform contracts changed.
- [x] English/Korean mirrors, discoverability indexes, tooling, and platform harnesses are unaffected.