### PR TITLE
Resolve #2981: Correct React metadata descriptor identity docs

### DIFF
--- a/docs/CONTEXT.ko.md
+++ b/docs/CONTEXT.ko.md
@@ -189,8 +189,10 @@ post-shell recoverable error는 기존 owner와 phase를 유지합니다.
 
 후속 [React page render policy decision](./architecture/react-page-render-policies.ko.md)은 synchronous
 request-aware `@PageMetadata(...)` factory와 bounded title/meta/link resolution, ordinary React element
-creation을 채택합니다. Factory는 active request, optional request id, request-scope container를 받지만
-response authority는 받지 않으며 matched application renderer만 이를 consume합니다. Generic page error
+creation을 채택합니다. `<meta>` identity는 존재하는 `name` 또는 `property` attribute와 그 값으로 정하며
+`content`는 identity에 포함하지 않으므로, 같은 identity의 later descriptor가 earlier descriptor를
+대체합니다. Factory는 active request, optional request id, request-scope container를 받지만 response
+authority는 받지 않으며 matched application renderer만 이를 consume합니다. Generic page error
 presentation과 page-local not-found presentation은 거부한다. 후속 HTTP-owned application seam은 HTTP
 classification 이후에만 optional React-produced document를 선택할 수 있으므로 unmatched request,
 handler-thrown `NotFoundException`, SSR diagnostic phase, Vite asset discovery, inline serialization은 기존

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -190,12 +190,14 @@ post-shell recoverable errors retain their existing owners and phases.
 
 The follow-up [React page render policy decision](./architecture/react-page-render-policies.md)
 accepts synchronous request-aware `@PageMetadata(...)` factories plus bounded title/meta/link
-resolution and ordinary React element creation. Factories receive the active request, optional
-request id, and request-scope container but no response authority; only the matched application
-renderer consumes them. Generic page error presentation and page-local not-found presentation are
-rejected. The later HTTP-owned application seam may select an optional React-produced document only
-after HTTP classification, so unmatched requests, handler-thrown `NotFoundException`, SSR diagnostic
-phases, Vite asset discovery, and inline serialization keep their existing owners and boundaries.
+resolution and ordinary React element creation. `<meta>` identity uses the present `name` or
+`property` attribute and its value; `content` is not part of identity, so a later matching descriptor
+replaces the earlier descriptor. Factories receive the active request, optional request id, and
+request-scope container but no response authority; only the matched application renderer consumes
+them. Generic page error presentation and page-local not-found presentation are rejected. The later
+HTTP-owned application seam may select an optional React-produced document only after HTTP
+classification, so unmatched requests, handler-thrown `NotFoundException`, SSR diagnostic phases,
+Vite asset discovery, and inline serialization keep their existing owners and boundaries.
 
 ## React RSC Graduation Gate
 

--- a/docs/architecture/react-page-render-policies.ko.md
+++ b/docs/architecture/react-page-render-policies.ko.md
@@ -56,7 +56,8 @@ duplicate는 `react-render-policy-duplicate-page-metadata`를 가진 bootstrap e
 Resolve된 값은 deterministic하게 compose한다.
 
 - 가장 가까운 non-`undefined` `title`이 우선한다.
-- `<meta>` identity는 `name`과 그 값 또는 `property`와 그 값이다.
+- `<meta>` identity는 존재하는 identity attribute(`name` 또는 `property`)와 해당 attribute의 값으로
+  구성하며, `content`는 identity에 포함하지 않는다.
 - `<link>` identity는 정확한 `rel`과 `href` pair다.
 - 같은 identity의 later descriptor는 earlier descriptor를 대체하고 later declaration 위치를 차지한다.
 - 관련 없는 descriptor는 factory 및 array order를 유지한다.

--- a/docs/architecture/react-page-render-policies.md
+++ b/docs/architecture/react-page-render-policies.md
@@ -56,7 +56,8 @@ inheritance or class/method sites intentionally compose.
 Resolved values compose deterministically:
 
 - the nearest non-`undefined` `title` wins;
-- `<meta>` identity is `name` plus its value or `property` plus its value;
+- `<meta>` identity is the present identity attribute (`name` or `property`) plus that attribute's
+  value; `content` is not part of identity;
 - `<link>` identity is the exact `rel` plus `href` pair;
 - a later descriptor with the same identity replaces the earlier descriptor and occupies the later
   declaration position;

--- a/tooling/governance/verify-platform-consistency-governance.d.mts
+++ b/tooling/governance/verify-platform-consistency-governance.d.mts
@@ -30,6 +30,7 @@ export function enforceNoNodeGlobalBufferInDenoAndCloudflareWorkerServices(
 ): void;
 export function enforceReactClientSubpathContract(): void;
 export function enforceReactPageCatalogContract(readText?: (relativePath: string) => string): void;
+export function enforceReactPageMetadataIdentityContract(): void;
 export function enforceReactRscGraduationEvidenceUpdates(
   changedFiles: readonly string[],
   readText?: (relativePath: string) => string,

--- a/tooling/governance/verify-platform-consistency-governance.mjs
+++ b/tooling/governance/verify-platform-consistency-governance.mjs
@@ -1988,6 +1988,40 @@ export function enforceReactClientSubpathContract() {
   );
 }
 
+export function enforceReactPageMetadataIdentityContract() {
+  const metadataSource = read('packages/react/src/page-metadata.ts');
+  const metadataTest = read('packages/react/src/page-metadata.test.ts');
+  const englishReadme = read('packages/react/README.md');
+  const koreanReadme = read('packages/react/README.ko.md');
+  const englishDecision = read('docs/architecture/react-page-render-policies.md');
+  const koreanDecision = read('docs/architecture/react-page-render-policies.ko.md');
+  const englishContext = read('docs/CONTEXT.md');
+  const koreanContext = read('docs/CONTEXT.ko.md');
+
+  assert(
+    metadataSource.includes("JSON.stringify(['name', meta.name])") &&
+      metadataSource.includes("JSON.stringify(['property', meta.property])"),
+    'React page metadata source must identify meta descriptors by the present name or property value without content.',
+  );
+  assert(
+    metadataTest.includes("{ content: 'base', name: 'description' }") &&
+      metadataTest.includes("{ content: 'base method', name: 'description' }"),
+    'React page metadata tests must cover later content replacing an earlier descriptor with the same name identity.',
+  );
+  assert(
+    englishReadme.includes('same `name` or `property`') &&
+      englishDecision.includes('`content` is not part of identity') &&
+      englishContext.includes('`content` is not part of identity'),
+    'English React metadata docs must identify meta descriptors by name or property and exclude content from identity.',
+  );
+  assert(
+    koreanReadme.includes('같은 `name` 또는 `property` identity') &&
+      koreanDecision.includes('`content`는 identity에 포함하지 않는다') &&
+      koreanContext.includes('`content`는 identity에 포함하지 않으므로'),
+    'Korean React metadata docs must identify meta descriptors by name or property and exclude content from identity.',
+  );
+}
+
 export function enforceReactServerFunctionContract() {
   const rscEntrypoint = read('packages/react/src/experimental/rsc.ts');
   const rootEntrypoint = read('packages/react/src/index.ts');
@@ -2356,6 +2390,7 @@ export function main() {
   enforceNoNodeGlobalBufferInDenoAndCloudflareWorkerServices();
   enforceViteToolingDiscoverability();
   enforceReactPageCatalogContract();
+  enforceReactPageMetadataIdentityContract();
   enforceReactClientSubpathContract();
   enforceReactRscGraduationGovernance(changedFiles);
   enforceReactServerFunctionContract();

--- a/tooling/governance/verify-platform-consistency-governance.test.ts
+++ b/tooling/governance/verify-platform-consistency-governance.test.ts
@@ -14,6 +14,7 @@ import {
   enforcePlatformShellLifecycleContract,
   enforceReactClientSubpathContract,
   enforceReactPageCatalogContract,
+  enforceReactPageMetadataIdentityContract,
   enforceReactServerFunctionContract,
   isGovernedPackageSourcePath,
   parsePackageNamesFromFamilyTable,
@@ -130,6 +131,12 @@ describe('enforceReactClientSubpathContract', () => {
 describe('enforceReactPageCatalogContract', () => {
   it('keeps compiled React page diagnostics aligned across source and bilingual docs', () => {
     expect(() => enforceReactPageCatalogContract()).not.toThrow();
+  });
+});
+
+describe('enforceReactPageMetadataIdentityContract', () => {
+  it('keeps metadata replacement identity aligned across source, evidence, and bilingual docs', () => {
+    expect(() => enforceReactPageMetadataIdentityContract()).not.toThrow();
   });
 });
 


### PR DESCRIPTION
## Summary

Correct the canonical React page metadata decision so `<meta>` descriptor identity matches the shipped `@fluojs/react` implementation, regression evidence, and package README guidance.

Closes #2981

## Changes

- Clarify in the EN/KO architecture decision that identity uses the present `name` or `property` attribute and its value, never `content`.
- Mirror the corrected replacement contract in `docs/CONTEXT.md` and `docs/CONTEXT.ko.md`.
- Add governance enforcement and focused regression coverage to keep source, existing package tests, README guidance, decision docs, and context docs aligned.

## Testing

- `git diff --check` — passed.
- Changed tooling-file LSP diagnostics — no diagnostics; Markdown has no configured LSP and was checked by repository docs gates.
- `pnpm exec biome check tooling/governance/verify-platform-consistency-governance.mjs tooling/governance/verify-platform-consistency-governance.d.mts tooling/governance/verify-platform-consistency-governance.test.ts` — passed.
- `pnpm docs:sync-check` — passed (42 EN/KO page pairs and 10 navigation metadata pairs).
- `pnpm verify:platform-consistency-governance` — passed.
- `pnpm vitest run tooling/governance/verify-platform-consistency-governance.test.ts` — passed (125 tests).
- `pnpm build` — passed.
- `pnpm typecheck` — passed.
- `pnpm test` — 4,772 passed and 1 skipped; one unrelated `packages/platform-bun/src/published-declaration-surface.test.ts` module-resolution failure occurred during the parallel full suite. Rebuilding `@fluojs/http` and `@fluojs/platform-bun` and rerunning that test in isolation passed (1 test).

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

No changeset is required because this is a documentation/governance correction with no runtime, public API, package contents, or release metadata change.

## Public export documentation

해당 없음 — no public exports or source TSDoc surfaces changed.

## Behavioral contract

- No runtime behavior changed. The canonical decision now matches `packages/react/src/page-metadata.ts`, its existing regression coverage, and the package README EN/KO contract.
- No documented behavioral contract or intentional limitation was removed.

## Platform consistency governance (SSOT)

- The changed architecture and context surfaces retain EN/KO parity.
- `docs/CONTEXT.md` and `docs/CONTEXT.ko.md` provide the required discoverability companions.
- Governance enforcement and regression coverage prevent the descriptor identity wording from drifting away from executable behavior.