### PR TITLE
Correct Express bootstrap and run option docs

### DIFF
--- a/packages/platform-express/README.ko.md
+++ b/packages/platform-express/README.ko.md
@@ -154,7 +154,12 @@ Native stack은 adapter 생성 시 고정됩니다. Adapter는 Node HTTP/S liste
 - `ExpressHttpApplicationAdapter`: 핵심 어댑터 구현 클래스입니다. `getServer()`는 좁은 platform integration을 위해 underlying Node HTTP/HTTPS server를 노출하며 `ExpressServer`를 반환하고, `getListenTarget()`은 startup 이후 resolved bind target과 public URL을 보고하며, `getRealtimeCapability()`는 realtime package가 사용하는 server-backed capability를 반환합니다. 이러한 helper는 모두 일반 애플리케이션 코드에 native server object를 퍼뜨리기보다 infrastructure boundary에만 두세요.
 - Option type: `ExpressAdapterOptions`, `BootstrapExpressApplicationOptions`, `RunExpressApplicationOptions`, `ExpressNativeMiddleware`, `CorsInput`, `ExpressApplicationSignal`.
 
-`createExpressAdapter(options, multipartOptions?)`는 `host`, `https`, `maxBodySize`, `nativeMiddleware`, `port`, `rawBody`, `retryDelayMs`, `retryLimit`, `shutdownTimeoutMs`를 지원합니다. `ExpressHttpApplicationAdapter`를 직접 생성하는 경우에도 factory와 같은 numeric validation이 적용됩니다. `bootstrapExpressApplication(...)`과 `runExpressApplication(...)`은 `cors`, `globalPrefix`, `globalPrefixExclude`, `middleware`, `multipart`, `nativeMiddleware`, `securityHeaders`, `forceExitTimeoutMs`, `shutdownSignals`, `logger`도 받습니다. startup/shutdown diagnostics에는 framework console logger를 기본으로 사용하며, `logger`가 제공되면 주입된 `ApplicationLogger`를 따릅니다.
+`createExpressAdapter(options, multipartOptions?)`는 `host`, `https`, `maxBodySize`, `nativeMiddleware`, `port`, `rawBody`, `retryDelayMs`, `retryLimit`, `shutdownTimeoutMs`를 지원합니다. `ExpressHttpApplicationAdapter`를 직접 생성하는 경우에도 factory와 같은 numeric validation이 적용됩니다.
+
+- `BootstrapExpressApplicationOptions`와 `RunExpressApplicationOptions`는 위의 adapter option과 함께 `cors`, `globalPrefix`, `globalPrefixExclude`, `middleware`, `multipart`, `nativeMiddleware`, `securityHeaders`, `logger`를 공통으로 받습니다.
+- `RunExpressApplicationOptions`만 signal-driven shutdown을 위한 `forceExitTimeoutMs`와 `shutdownSignals`를 추가로 받습니다.
+
+두 helper는 startup/shutdown diagnostics에 framework console logger를 기본으로 사용하며, `logger`가 제공되면 주입된 `ApplicationLogger`를 따릅니다.
 
 ## 관련 패키지
 

--- a/packages/platform-express/README.md
+++ b/packages/platform-express/README.md
@@ -154,7 +154,12 @@ To avoid changing documented fluo semantics, overlapping same-shape param routes
 - `ExpressHttpApplicationAdapter`: The core adapter implementation class. `getServer()` exposes the underlying Node HTTP/HTTPS server for narrow platform integrations and returns `ExpressServer`, `getListenTarget()` reports the resolved bind target and public URL after startup, and `getRealtimeCapability()` returns the server-backed capability used by realtime packages. Keep these helpers at infrastructure boundaries instead of threading native server objects through ordinary application code.
 - Option types: `ExpressAdapterOptions`, `BootstrapExpressApplicationOptions`, `RunExpressApplicationOptions`, `ExpressNativeMiddleware`, `CorsInput`, `ExpressApplicationSignal`.
 
-`createExpressAdapter(options, multipartOptions?)` supports `host`, `https`, `maxBodySize`, `nativeMiddleware`, `port`, `rawBody`, `retryDelayMs`, `retryLimit`, and `shutdownTimeoutMs`. Direct `ExpressHttpApplicationAdapter` construction applies the same numeric validation as the factory. `bootstrapExpressApplication(...)` and `runExpressApplication(...)` also accept `cors`, `globalPrefix`, `globalPrefixExclude`, `middleware`, `multipart`, `nativeMiddleware`, `securityHeaders`, `forceExitTimeoutMs`, `shutdownSignals`, and `logger`; they use the framework console logger by default for startup and shutdown diagnostics and honor an injected `ApplicationLogger` when provided.
+`createExpressAdapter(options, multipartOptions?)` supports `host`, `https`, `maxBodySize`, `nativeMiddleware`, `port`, `rawBody`, `retryDelayMs`, `retryLimit`, and `shutdownTimeoutMs`. Direct `ExpressHttpApplicationAdapter` construction applies the same numeric validation as the factory.
+
+- `BootstrapExpressApplicationOptions` and `RunExpressApplicationOptions` share `cors`, `globalPrefix`, `globalPrefixExclude`, `middleware`, `multipart`, `nativeMiddleware`, `securityHeaders`, and `logger` in addition to the adapter options above.
+- `RunExpressApplicationOptions` alone adds `forceExitTimeoutMs` and `shutdownSignals` for signal-driven shutdown.
+
+Both helpers use the framework console logger by default for startup and shutdown diagnostics and honor an injected `ApplicationLogger` when `logger` is provided.
 
 ## Related Packages
 

--- a/packages/platform-express/src/adapter.test.ts
+++ b/packages/platform-express/src/adapter.test.ts
@@ -263,6 +263,40 @@ describe('@fluojs/platform-express', () => {
     expect(migrationGuide).toContain('explicit `nativeMiddleware` option');
   });
 
+  it('separates shared bootstrap options from run-only signal options in both package READMEs', () => {
+    const packageReadme = readFileSync(new URL('../README.md', import.meta.url), 'utf8');
+    const packageReadmeKo = readFileSync(new URL('../README.ko.md', import.meta.url), 'utf8');
+    const sharedOptionNames = [
+      'cors',
+      'globalPrefix',
+      'globalPrefixExclude',
+      'middleware',
+      'multipart',
+      'nativeMiddleware',
+      'securityHeaders',
+      'logger',
+    ] as const;
+
+    for (const readme of [packageReadme, packageReadmeKo]) {
+      const lines = readme.split('\n');
+      const sharedOptionsLines = lines.filter(
+        (line) => line.includes('`BootstrapExpressApplicationOptions`') && line.includes('`RunExpressApplicationOptions`') && line.includes('`cors`') && line.includes('`logger`'),
+      );
+      const runOnlyOptionsLines = lines.filter(
+        (line) => line.includes('`RunExpressApplicationOptions`') && line.includes('`forceExitTimeoutMs`') && line.includes('`shutdownSignals`'),
+      );
+
+      expect(sharedOptionsLines).toHaveLength(1);
+      for (const optionName of sharedOptionNames) {
+        expect(sharedOptionsLines[0]).toContain(`\`${optionName}\``);
+      }
+      expect(sharedOptionsLines[0]).not.toContain('`forceExitTimeoutMs`');
+      expect(sharedOptionsLines[0]).not.toContain('`shutdownSignals`');
+      expect(runOnlyOptionsLines).toHaveLength(1);
+      expect(runOnlyOptionsLines[0]).not.toContain('`BootstrapExpressApplicationOptions`');
+    }
+  });
+
   describe('adapter portability', () => {
     it('supports HTTP-owned JSON and HTML error representations', async () => {
       await expressPortabilityHarness.assertSupportsHttpErrorRepresentations();


### PR DESCRIPTION
## Summary
- separate shared Express bootstrap/run options from run-only signal options in EN/KO README
- clarify that forceExitTimeoutMs and shutdownSignals belong only to RunExpressApplicationOptions
- add package-local regression assertions for option ownership

## Release impact
- documentation and test-only correction
- no runtime or public API behavior change
- no changeset required

## Behavioral contract
- README option ownership now matches the exported TypeScript option types

## Verification
- Express tests: 65 passed
- docs sync, platform governance, focused governance tests, build, typecheck, Biome, and diagnostics passed

Closes #2961