### PR TITLE
Resolve #2995: Stop dispatch after native response termination

### DIFF
--- a/.changeset/issue-2995-express-native-response-termination.md
+++ b/.changeset/issue-2995-express-native-response-termination.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/platform-express": patch
+---
+
+Stop fluo dispatch when native Express middleware ends or destroys the response before calling `next()`.

--- a/packages/platform-express/src/adapter.test.ts
+++ b/packages/platform-express/src/adapter.test.ts
@@ -461,10 +461,11 @@ describe('@fluojs/platform-express', () => {
     }
   });
 
-  it('lets native Express middleware terminate a response without entering fluo dispatch', async () => {
+  it('stops catch-all dispatch when native Express middleware ends the response before next', async () => {
     const dispatch = vi.fn();
-    const nativeMiddleware: RequestHandler = (_request, response) => {
+    const nativeMiddleware: RequestHandler = (_request, response, next) => {
       response.status(202).json({ owner: 'express' });
+      next();
     };
     const port = await findAvailablePort();
     const adapter = createExpressAdapter({
@@ -484,6 +485,51 @@ describe('@fluojs/platform-express', () => {
       expect(response.statusCode).toBe(202);
       expect(JSON.parse(response.body)).toEqual({ owner: 'express' });
       expect(dispatch).not.toHaveBeenCalled();
+    } finally {
+      await adapter.close();
+    }
+  });
+
+  it('stops native route dispatch when native Express middleware ends the response before next', async () => {
+    const nativeMiddleware: RequestHandler = (_request, response, next) => {
+      response.status(202).json({ owner: 'express' });
+      next();
+    };
+
+    @Controller('/native-response')
+    class NativeResponseController {
+      @Get('/route')
+      route() {
+        return { owner: 'fluo' };
+      }
+    }
+
+    const root = new Container().register(NativeResponseController);
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: NativeResponseController }]),
+      rootContainer: root,
+    });
+    const nativeDispatch = vi.spyOn(dispatcher, 'dispatchNativeRoute');
+    const fullDispatch = vi.spyOn(dispatcher, 'dispatch');
+    const port = await findAvailablePort();
+    const adapter = createExpressAdapter({
+      nativeMiddleware: [nativeMiddleware],
+      port,
+    }) as ExpressHttpApplicationAdapter;
+
+    await adapter.listen(dispatcher);
+
+    try {
+      const response = await requestHttp({
+        method: 'GET',
+        path: '/native-response/route',
+        port,
+      });
+
+      expect(response.statusCode).toBe(202);
+      expect(JSON.parse(response.body)).toEqual({ owner: 'express' });
+      expect(nativeDispatch).not.toHaveBeenCalled();
+      expect(fullDispatch).not.toHaveBeenCalled();
     } finally {
       await adapter.close();
     }

--- a/packages/platform-express/src/adapter.ts
+++ b/packages/platform-express/src/adapter.ts
@@ -190,6 +190,10 @@ type ExpressMultipartLikeError = Error & {
   type?: unknown;
 };
 
+function isExpressResponseTerminated(response: ExpressResponse): boolean {
+  return response.writableEnded || response.destroyed;
+}
+
 /**
  * Represents the express http application adapter.
  */
@@ -241,6 +245,10 @@ export class ExpressHttpApplicationAdapter implements HttpApplicationAdapter {
     this.server = createExpressServer(this.httpsOptions, this.app);
     this.app.use(this.router);
     this.app.use((request: ExpressRequest, response: ExpressResponse) => {
+      if (isExpressResponseTerminated(response)) {
+        return;
+      }
+
       void this.handleRequest(request, response);
     });
     this.server.on('connection', (socket) => {
@@ -368,6 +376,10 @@ export class ExpressHttpApplicationAdapter implements HttpApplicationAdapter {
 
     for (const route of nativeRoutes) {
       this.router.all(route.path, (request: ExpressRequest, response: ExpressResponse, next: () => void) => {
+        if (isExpressResponseTerminated(response)) {
+          return;
+        }
+
         if (!route.methods.includes(request.method.toUpperCase() as ExpressNativeRouteMethod)) {
           next();
           return;


### PR DESCRIPTION
## Summary

Prevent fluo dispatch after native Express middleware has already ended or destroyed the native response, preserving native response ownership.

Linked context: Closes #2995

## Changes

- Guard both Express Router handoff and catch-all handoff with `writableEnded` / `destroyed` checks.
- Add request-level regressions for native-route and catch-all dispatch after `response.json(...); next()`.
- Add a patch Changeset for `@fluojs/platform-express`.

## Testing

- Red: both new regression tests failed before the guard because fluo dispatch was called once.
- `pnpm --dir packages/platform-express exec vitest run -c vitest.config.ts -t "stops (catch-all|native route) dispatch when native Express middleware ends the response before next"` — 2 passed.
- `pnpm --dir packages/platform-express test` — 67 passed.
- `pnpm --dir packages/platform-express typecheck` — passed.
- `pnpm build` — passed.
- `pnpm verify` — 416 test files passed; 4802 tests passed, 1 skipped.
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main` — passed.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Patch rationale: this restores the documented native response ownership behavior without changing the public API.

## Public export documentation

No public exports changed. Existing TSDoc and README API inventory remain applicable.

## Behavioral contract

- [x] No documented behavioral contracts were removed.
- [x] Existing EN/KO package READMEs and governed docs already state that ending a native response skips fluo dispatch, so no wording change was required.
- [x] Router and catch-all runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

No governance SSOT document changed. The fix aligns the Express implementation with the already documented platform-specific `nativeMiddleware` contract; no new cross-platform claim or public surface was introduced.