### PR TITLE
Resolve #2997: Release GraphQL cross-instance runtime objects

### DIFF
--- a/.changeset/release-graphql-cross-instance-objects.md
+++ b/.changeset/release-graphql-cross-instance-objects.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/graphql": patch
+---
+
+Release cross-realm GraphQL runtime object allowances when an application shuts down or fails to bootstrap without disturbing other active GraphQL applications.

--- a/packages/graphql/README.ko.md
+++ b/packages/graphql/README.ko.md
@@ -252,8 +252,8 @@ GraphqlModule.forRoot({
 - `graphiql` 기본값은 `false`입니다. `introspection`은 명시하지 않으면 `graphiql` 설정을 따르므로, production 앱은 기본적으로 비공개 상태를 유지하고 로컬 GraphiQL 세션만 opt in할 수 있습니다.
 - `limits`에는 request validation budget을 전달하거나 `false`를 전달할 수 있습니다. `false`는 fluo 밖에서 동등한 제어를 적용할 때만 사용하세요.
 - Streaming GraphQL 응답은 downstream response stream이 닫히거나 오류를 내면 upstream fetch body를 cancel하므로 SSE subscription 리소스를 즉시 해제합니다.
-- GraphQL 스키마 해석 이후 bootstrap이 실패하면 임시 `graphql/jsutils/instanceOf` 패치를 원복한 뒤 원래 오류를 다시 던지므로, 실패한 시작 시도가 이후 애플리케이션 시작의 process-wide GraphQL 동작을 오염시키지 않습니다.
-- 각 활성 GraphQL 애플리케이션은 자체 cross-realm GraphQL object allowlist를 소유합니다. Shutdown 또는 bootstrap 실패 시 다른 실행 중인 애플리케이션을 위해 process-wide `instanceOf` 패치를 유지하면서 해당 애플리케이션의 object만 제거합니다.
+- GraphQL 스키마 해석 이후 bootstrap이 실패하면 원래 오류를 다시 던지기 전에 실패한 service의 cross-realm GraphQL object allowlist만 제거합니다. 다른 활성 GraphQL 애플리케이션이 하나도 남지 않은 경우에만 package의 process-wide `graphql/jsutils/instanceOf` 패치를 원복합니다.
+- 각 활성 GraphQL 애플리케이션은 자체 cross-realm GraphQL object allowlist를 소유합니다. Shutdown도 같은 release 규칙을 따르므로, 다른 실행 중인 애플리케이션은 process-wide `instanceOf` 패치를 유지하고 자신의 object만 허용합니다.
 - WebSocket 구독 경로에는 별도의 전송 budget이 기본 적용됩니다: 동시 연결 `100`, 최대 payload 크기 `64 KiB`, 연결당 활성 operation `25`개입니다.
 - `subscriptions.websocket.enabled` 기본값은 `false`입니다. 활성화하려면 upgrade를 지원하는 Node HTTP/S adapter가 필요합니다. `connectionInitWaitTimeoutMs`는 연결 초기화를 위해 `graphql-ws`로 전달되고, `keepAliveMs`는 설정 시 WebSocket keepalive ping 주기를 제어합니다.
 - 무제한 WebSocket 동작이 정말 필요할 때만 `subscriptions.websocket.limits = false`를 사용하고, 그 경우에도 동일한 수준의 외부 제어 수단을 마련해야 합니다.

--- a/packages/graphql/README.ko.md
+++ b/packages/graphql/README.ko.md
@@ -253,6 +253,7 @@ GraphqlModule.forRoot({
 - `limits`에는 request validation budget을 전달하거나 `false`를 전달할 수 있습니다. `false`는 fluo 밖에서 동등한 제어를 적용할 때만 사용하세요.
 - Streaming GraphQL 응답은 downstream response stream이 닫히거나 오류를 내면 upstream fetch body를 cancel하므로 SSE subscription 리소스를 즉시 해제합니다.
 - GraphQL 스키마 해석 이후 bootstrap이 실패하면 임시 `graphql/jsutils/instanceOf` 패치를 원복한 뒤 원래 오류를 다시 던지므로, 실패한 시작 시도가 이후 애플리케이션 시작의 process-wide GraphQL 동작을 오염시키지 않습니다.
+- 각 활성 GraphQL 애플리케이션은 자체 cross-realm GraphQL object allowlist를 소유합니다. Shutdown 또는 bootstrap 실패 시 다른 실행 중인 애플리케이션을 위해 process-wide `instanceOf` 패치를 유지하면서 해당 애플리케이션의 object만 제거합니다.
 - WebSocket 구독 경로에는 별도의 전송 budget이 기본 적용됩니다: 동시 연결 `100`, 최대 payload 크기 `64 KiB`, 연결당 활성 operation `25`개입니다.
 - `subscriptions.websocket.enabled` 기본값은 `false`입니다. 활성화하려면 upgrade를 지원하는 Node HTTP/S adapter가 필요합니다. `connectionInitWaitTimeoutMs`는 연결 초기화를 위해 `graphql-ws`로 전달되고, `keepAliveMs`는 설정 시 WebSocket keepalive ping 주기를 제어합니다.
 - 무제한 WebSocket 동작이 정말 필요할 때만 `subscriptions.websocket.limits = false`를 사용하고, 그 경우에도 동일한 수준의 외부 제어 수단을 마련해야 합니다.

--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -253,6 +253,7 @@ GraphqlModule.forRoot({
 - `limits` accepts request validation budgets or `false`; use `false` only when equivalent controls exist outside fluo.
 - Streaming GraphQL responses cancel the upstream fetch body when the downstream response stream closes or errors, so SSE subscription resources are released promptly.
 - Bootstrap failures after GraphQL schema resolution restore the package's temporary `graphql/jsutils/instanceOf` patch before rethrowing, so failed startups do not leak process-wide GraphQL behavior into later app attempts.
+- Each active GraphQL application owns its cross-realm GraphQL object allowlist. Shutdown or failed bootstrap removes only that application's objects while the process-wide `instanceOf` patch remains active for other running applications.
 - WebSocket subscriptions use separate transport budgets by default: `100` concurrent connections, `64 KiB` maximum payload size, and `25` active operations per connection.
 - `subscriptions.websocket.enabled` defaults to `false`; enabling it requires a Node HTTP/S adapter with upgrade support. `connectionInitWaitTimeoutMs` is forwarded to `graphql-ws` for connection initialization, and `keepAliveMs` controls websocket keepalive pings when configured.
 - Set `subscriptions.websocket.limits = false` only when you intentionally need unbounded websocket behavior and can enforce equivalent controls elsewhere.

--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -252,8 +252,8 @@ GraphqlModule.forRoot({
 - `graphiql` defaults to `false`. `introspection` follows `graphiql` unless set explicitly, so production apps stay private by default while local GraphiQL sessions can opt in.
 - `limits` accepts request validation budgets or `false`; use `false` only when equivalent controls exist outside fluo.
 - Streaming GraphQL responses cancel the upstream fetch body when the downstream response stream closes or errors, so SSE subscription resources are released promptly.
-- Bootstrap failures after GraphQL schema resolution restore the package's temporary `graphql/jsutils/instanceOf` patch before rethrowing, so failed startups do not leak process-wide GraphQL behavior into later app attempts.
-- Each active GraphQL application owns its cross-realm GraphQL object allowlist. Shutdown or failed bootstrap removes only that application's objects while the process-wide `instanceOf` patch remains active for other running applications.
+- Bootstrap failures after GraphQL schema resolution remove only the failed service's cross-realm GraphQL object allowlist before rethrowing. The package restores its process-wide `graphql/jsutils/instanceOf` patch only when no other active GraphQL application remains.
+- Each active GraphQL application owns its cross-realm GraphQL object allowlist. Shutdown follows the same release rule, so another running application retains the process-wide `instanceOf` patch and only its own objects remain allowed.
 - WebSocket subscriptions use separate transport budgets by default: `100` concurrent connections, `64 KiB` maximum payload size, and `25` active operations per connection.
 - `subscriptions.websocket.enabled` defaults to `false`; enabling it requires a Node HTTP/S adapter with upgrade support. `connectionInitWaitTimeoutMs` is forwarded to `graphql-ws` for connection initialization, and `keepAliveMs` controls websocket keepalive pings when configured.
 - Set `subscriptions.websocket.limits = false` only when you intentionally need unbounded websocket behavior and can enforce equivalent controls elsewhere.

--- a/packages/graphql/src/instance-of-lifecycle.test.ts
+++ b/packages/graphql/src/instance-of-lifecycle.test.ts
@@ -1,0 +1,105 @@
+import { createRequire } from 'node:module';
+
+import { Container } from '@fluojs/di';
+import type { HttpApplicationAdapter } from '@fluojs/http';
+import type { ApplicationLogger, CompiledModule } from '@fluojs/runtime';
+import { GraphQLObjectType, GraphQLSchema, GraphQLString } from 'graphql';
+import { describe, expect, it } from 'vitest';
+
+import { GraphqlLifecycleService } from './service.js';
+
+type GraphqlInstanceOf = (value: unknown, constructor: { prototype?: { [Symbol.toStringTag]?: string } }) => boolean;
+
+const runtimeRequire = createRequire(import.meta.url);
+
+function createCrossRealmSchema(name: string): GraphQLSchema {
+  const schema = new GraphQLSchema({
+    query: new GraphQLObjectType({
+      fields: {
+        value: {
+          resolve: () => name,
+          type: GraphQLString,
+        },
+      },
+      name: `${name}Query`,
+    }),
+  });
+  const crossRealmPrototype = Object.create(
+    null,
+    Object.getOwnPropertyDescriptors(GraphQLSchema.prototype),
+  );
+
+  return Object.create(crossRealmPrototype, Object.getOwnPropertyDescriptors(schema));
+}
+
+function createService(schema: GraphQLSchema, websocketEnabled = false): GraphqlLifecycleService {
+  const adapter: HttpApplicationAdapter = {
+    async close() {},
+    async listen() {},
+  };
+  const compiledModules: CompiledModule[] = [];
+  const logger: ApplicationLogger = {
+    debug() {},
+    error() {},
+    log() {},
+    warn() {},
+  };
+
+  return new GraphqlLifecycleService(new Container(), compiledModules, logger, adapter, {
+    schema,
+    ...(websocketEnabled ? { subscriptions: { websocket: { enabled: true } } } : {}),
+  });
+}
+
+describe('GraphqlLifecycleService cross-instance object isolation', () => {
+  it("releases one application's cross-realm objects while another keeps the instanceOf patch active", async () => {
+    // Given
+    const instanceOfModule: { instanceOf: GraphqlInstanceOf } = runtimeRequire('graphql/jsutils/instanceOf.js');
+    const releasedSchema = createCrossRealmSchema('Released');
+    const activeSchema = createCrossRealmSchema('Active');
+    const releasedService = createService(releasedSchema);
+    const activeService = createService(activeSchema);
+
+    try {
+      await releasedService.onApplicationBootstrap();
+      await activeService.onApplicationBootstrap();
+      expect(instanceOfModule.instanceOf(releasedSchema, GraphQLSchema)).toBe(true);
+      expect(instanceOfModule.instanceOf(activeSchema, GraphQLSchema)).toBe(true);
+
+      // When
+      await releasedService.onApplicationShutdown();
+
+      // Then
+      expect(() => instanceOfModule.instanceOf(releasedSchema, GraphQLSchema)).toThrow();
+      expect(instanceOfModule.instanceOf(activeSchema, GraphQLSchema)).toBe(true);
+    } finally {
+      await releasedService.onApplicationShutdown();
+      await activeService.onApplicationShutdown();
+    }
+  });
+
+  it("releases a failed application's cross-realm objects while another keeps the instanceOf patch active", async () => {
+    // Given
+    const instanceOfModule: { instanceOf: GraphqlInstanceOf } = runtimeRequire('graphql/jsutils/instanceOf.js');
+    const failedSchema = createCrossRealmSchema('Failed');
+    const activeSchema = createCrossRealmSchema('ActiveAfterFailure');
+    const failedService = createService(failedSchema, true);
+    const activeService = createService(activeSchema);
+
+    try {
+      await activeService.onApplicationBootstrap();
+
+      // When
+      await expect(failedService.onApplicationBootstrap()).rejects.toThrow(
+        'GraphQL websocket subscriptions require an HTTP adapter with getServer().',
+      );
+
+      // Then
+      expect(() => instanceOfModule.instanceOf(failedSchema, GraphQLSchema)).toThrow();
+      expect(instanceOfModule.instanceOf(activeSchema, GraphQLSchema)).toBe(true);
+    } finally {
+      await failedService.onApplicationShutdown();
+      await activeService.onApplicationShutdown();
+    }
+  });
+});

--- a/packages/graphql/src/service.ts
+++ b/packages/graphql/src/service.ts
@@ -103,9 +103,8 @@ interface GraphqlDeps {
   subscribe: typeof subscribeGraphql;
 }
 
-let graphqlInstanceOfPatchRefCount = 0;
 let restoreGraphqlInstanceOfPatch: (() => void) | undefined;
-const allowedCrossRealmGraphqlObjects = new WeakSet<object>();
+const activeAllowedCrossRealmGraphqlObjectSets = new Set<WeakSet<object>>();
 
 /**
  * Declares the HTTP endpoints that receive GraphQL GET and POST requests.
@@ -146,7 +145,11 @@ function getCrossRealmGraphqlTag(value: unknown, constructor: GraphqlConstructor
   return valueClassName === className ? className : undefined;
 }
 
-function markAllowedCrossRealmGraphqlObjects(value: unknown, visited = new WeakSet<object>()): void {
+function markAllowedCrossRealmGraphqlObjects(
+  value: unknown,
+  allowedObjects: WeakSet<object>,
+  visited = new WeakSet<object>(),
+): void {
   if (typeof value !== 'object' || value === null) {
     return;
   }
@@ -164,19 +167,19 @@ function markAllowedCrossRealmGraphqlObjects(value: unknown, visited = new WeakS
     (typeof tag === 'string' && tag.startsWith('GraphQL')) ||
     (typeof constructorName === 'string' && constructorName.startsWith('GraphQL'))
   ) {
-    allowedCrossRealmGraphqlObjects.add(value);
+    allowedObjects.add(value);
   }
 
   if (Array.isArray(value)) {
     for (const item of value) {
-      markAllowedCrossRealmGraphqlObjects(item, visited);
+      markAllowedCrossRealmGraphqlObjects(item, allowedObjects, visited);
     }
 
     return;
   }
 
   for (const nestedValue of Object.values(value)) {
-    markAllowedCrossRealmGraphqlObjects(nestedValue, visited);
+    markAllowedCrossRealmGraphqlObjects(nestedValue, allowedObjects, visited);
   }
 }
 
@@ -188,59 +191,67 @@ function isAllowedCrossRealmGraphqlObject(
     return false;
   }
 
-  return allowedCrossRealmGraphqlObjects.has(value) && getCrossRealmGraphqlTag(value, constructor) !== undefined;
-}
-
-function installGraphqlInstanceOfPatch(instanceOfModule: GraphqlInstanceOfModule): () => void {
-  if (restoreGraphqlInstanceOfPatch) {
-    graphqlInstanceOfPatchRefCount += 1;
-    return releaseGraphqlInstanceOfPatch;
+  for (const allowedObjects of activeAllowedCrossRealmGraphqlObjectSets) {
+    if (allowedObjects.has(value)) {
+      return getCrossRealmGraphqlTag(value, constructor) !== undefined;
+    }
   }
 
-  const patchedFrom = instanceOfModule.instanceOf;
+  return false;
+}
 
-  const patchedInstanceOf: GraphqlInstanceOf = (value, constructor) => {
-    try {
-      if (patchedFrom(value, constructor)) {
-        return true;
+function installGraphqlInstanceOfPatch(
+  instanceOfModule: GraphqlInstanceOfModule,
+  allowedObjects: WeakSet<object>,
+): () => void {
+  activeAllowedCrossRealmGraphqlObjectSets.add(allowedObjects);
+
+  if (!restoreGraphqlInstanceOfPatch) {
+    const patchedFrom = instanceOfModule.instanceOf;
+
+    const patchedInstanceOf: GraphqlInstanceOf = (value, constructor) => {
+      try {
+        if (patchedFrom(value, constructor)) {
+          return true;
+        }
+      } catch (error) {
+        if (isAllowedCrossRealmGraphqlObject(value, constructor)) {
+          return true;
+        }
+
+        throw error;
       }
-    } catch (error) {
-      if (isAllowedCrossRealmGraphqlObject(value, constructor)) {
-        return true;
+
+      return isAllowedCrossRealmGraphqlObject(value, constructor);
+    };
+    instanceOfModule.instanceOf = patchedInstanceOf;
+
+    restoreGraphqlInstanceOfPatch = () => {
+      if (instanceOfModule.instanceOf !== patchedInstanceOf) {
+        return;
       }
 
-      throw error;
-    }
+      instanceOfModule.instanceOf = patchedFrom;
+    };
+  }
 
-    return isAllowedCrossRealmGraphqlObject(value, constructor);
-  };
-  instanceOfModule.instanceOf = patchedInstanceOf;
+  let released = false;
 
-  graphqlInstanceOfPatchRefCount = 1;
-  restoreGraphqlInstanceOfPatch = () => {
-    if (instanceOfModule.instanceOf !== patchedInstanceOf) {
+  return () => {
+    if (released) {
       return;
     }
 
-    instanceOfModule.instanceOf = patchedFrom;
+    released = true;
+    activeAllowedCrossRealmGraphqlObjectSets.delete(allowedObjects);
+
+    if (activeAllowedCrossRealmGraphqlObjectSets.size > 0) {
+      return;
+    }
+
+    restoreGraphqlInstanceOfPatch?.();
+    restoreGraphqlInstanceOfPatch = undefined;
   };
-
-  return releaseGraphqlInstanceOfPatch;
-}
-
-function releaseGraphqlInstanceOfPatch(): void {
-  if (graphqlInstanceOfPatchRefCount === 0) {
-    return;
-  }
-
-  graphqlInstanceOfPatchRefCount -= 1;
-
-  if (graphqlInstanceOfPatchRefCount > 0) {
-    return;
-  }
-
-  restoreGraphqlInstanceOfPatch?.();
-  restoreGraphqlInstanceOfPatch = undefined;
 }
 
 async function loadGraphqlDeps(): Promise<GraphqlDeps> {
@@ -282,6 +293,7 @@ async function loadGraphqlDeps(): Promise<GraphqlDeps> {
  */
 @Inject(RUNTIME_CONTAINER, COMPILED_MODULES, APPLICATION_LOGGER, HTTP_APPLICATION_ADAPTER, GRAPHQL_INTERNAL_MODULE_OPTIONS_TOKEN)
 export class GraphqlLifecycleService implements OnApplicationBootstrap, OnApplicationShutdown {
+  private allowedCrossRealmGraphqlObjects: WeakSet<object> | undefined;
   private graphQLErrorConstructor: typeof GraphQLErrorType | undefined;
   private middlewareRegistered = false;
   private readonly operationContainers = new WeakMap<Request, Container>();
@@ -406,6 +418,7 @@ export class GraphqlLifecycleService implements OnApplicationBootstrap, OnApplic
     this.graphQLErrorConstructor = undefined;
     this.releaseGraphqlInstanceOfPatch?.();
     this.releaseGraphqlInstanceOfPatch = undefined;
+    this.allowedCrossRealmGraphqlObjects = undefined;
     this.subscribeGraphqlOperation = undefined;
     this.yoga = undefined;
   }
@@ -434,13 +447,16 @@ export class GraphqlLifecycleService implements OnApplicationBootstrap, OnApplic
   }
 
   private resolveSchema(deps: GraphqlDeps): GraphQLSchemaType {
-    this.releaseGraphqlInstanceOfPatch ??= installGraphqlInstanceOfPatch(deps.instanceOfModule);
+    const allowedObjects = this.allowedCrossRealmGraphqlObjects ?? new WeakSet<object>();
+    this.allowedCrossRealmGraphqlObjects = allowedObjects;
+    this.releaseGraphqlInstanceOfPatch ??= installGraphqlInstanceOfPatch(deps.instanceOfModule, allowedObjects);
+    const markAllowedObject = (value: unknown) => markAllowedCrossRealmGraphqlObjects(value, allowedObjects);
 
-    return resolveSchema(deps, this.options.schema, () => this.createCodeFirstSchema(deps), markAllowedCrossRealmGraphqlObjects);
+    return resolveSchema(deps, this.options.schema, () => this.createCodeFirstSchema(deps, markAllowedObject), markAllowedObject);
   }
 
-  private createCodeFirstSchema(deps: GraphqlDeps): GraphQLSchemaType {
-    return createCodeFirstSchema(deps, this.runtimeContainer, this.discoverResolverDescriptors(), markAllowedCrossRealmGraphqlObjects);
+  private createCodeFirstSchema(deps: GraphqlDeps, markAllowedObject: (value: unknown) => void): GraphQLSchemaType {
+    return createCodeFirstSchema(deps, this.runtimeContainer, this.discoverResolverDescriptors(), markAllowedObject);
   }
 
   private discoverResolverDescriptors(): ResolverDescriptor[] {


### PR DESCRIPTION
## Summary

Isolate GraphQL cross-realm runtime object allowances to each active application lifecycle so shutdown or failed bootstrap cannot leave stale objects accepted while another application keeps the process-wide patch active.

Linked context: Closes #2997

## Changes

- replace the module-global object allowlist with per-service `WeakSet` registrations tracked only while each service is active
- release the matching registration on shutdown and bootstrap-failure reset without restoring the shared patch until the final active service exits
- add multi-instance shutdown and failed-bootstrap lifecycle regressions
- align the English and Korean package contracts
- add a patch Changeset for `@fluojs/graphql`

## Testing

- `pnpm vitest run --project packages packages/graphql/src/instance-of-lifecycle.test.ts`
- `pnpm --dir packages/graphql typecheck`
- `pnpm --dir packages/graphql exec vitest run -c vitest.config.ts --maxWorkers=1`
- `pnpm build`
- `pnpm docs:sync-check`
- `pnpm verify:platform-consistency-governance`
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main`
- `FLUO_CLI_SANDBOX_ROOT=<isolated-temp-path> pnpm verify:release-readiness`

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Patch release for `@fluojs/graphql`: application shutdown and failed bootstrap now release stale cross-realm runtime allowances.

## Public export documentation

- [x] No public exports changed; source TSDoc remains unaffected.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] The lifecycle isolation contract is documented in the affected package README.
- [x] Intentional limitations remain explicit.
- [x] Shutdown and failed-bootstrap invariants are covered by multi-instance regression tests.

## Platform consistency governance (SSOT)

- [x] English and Korean package README contracts remain synchronized.
- [x] No platform contract SSOT changed; `pnpm verify:platform-consistency-governance` passes.
- [x] No adapter conformance claim changed; package-local lifecycle regressions provide the applicable evidence.