### PR TITLE
Resolve #2998: Keep deferred eviction runtime-portable

### DIFF
--- a/.changeset/keep-deferred-eviction-portable.md
+++ b/.changeset/keep-deferred-eviction-portable.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/cache-manager': patch
+---
+
+Keep deferred HTTP cache eviction portable when runtimes return Web-standard numeric timer handles while preserving Node.js non-blocking timer behavior.

--- a/packages/cache-manager/src/deferred-eviction.ts
+++ b/packages/cache-manager/src/deferred-eviction.ts
@@ -95,7 +95,7 @@ export function installDeferredEviction(
 
     restore();
   }, EVICTION_FALLBACK_TIMEOUT_MS);
-  fallbackTimer.unref();
+  fallbackTimer.unref?.();
 
   if (signal) {
     signal.addEventListener('abort', cancel, { once: true });

--- a/packages/cache-manager/src/interceptor.dispatch-regression.test.ts
+++ b/packages/cache-manager/src/interceptor.dispatch-regression.test.ts
@@ -57,6 +57,7 @@ function createSimpleJsonResponse(): SimpleJsonDispatchResponse {
 
 describe('CacheInterceptor response dispatch regressions', () => {
   afterEach(() => {
+    vi.unstubAllGlobals();
     vi.useRealTimers();
   });
 
@@ -170,6 +171,80 @@ describe('CacheInterceptor response dispatch regressions', () => {
       // Then
       await expect(cache.get('/products')).resolves.toBeUndefined();
     } finally {
+      await app.close();
+    }
+  });
+
+  it('keeps deferred eviction portable when setTimeout returns a Web or Deno numeric handle', async () => {
+    // Given
+    @Controller('/products')
+    @UseInterceptors(CacheInterceptor)
+    class ProductController {
+      @Post('/refresh')
+      @CacheEvict('/products')
+      refresh() {
+        return { refreshed: true };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [ProductController],
+      imports: [CacheModule.forRoot({ store: 'memory' })],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+
+    try {
+      const cache = await app.container.resolve(CacheService);
+      await cache.set('/products', { version: 'previous' }, 120);
+      const response = createSimpleJsonResponse();
+      vi.stubGlobal('setTimeout', vi.fn(() => 1));
+
+      // When
+      await app.dispatch(createRequest('/products/refresh'), response);
+
+      // Then
+      expect(response.body).toEqual({ refreshed: true });
+      await expect(cache.get('/products')).resolves.toBeUndefined();
+    } finally {
+      vi.unstubAllGlobals();
+      await app.close();
+    }
+  });
+
+  it('unreferences deferred eviction timers when the runtime exposes a Node timer handle', async () => {
+    // Given
+    @Controller('/products')
+    @UseInterceptors(CacheInterceptor)
+    class ProductController {
+      @Post('/refresh')
+      @CacheEvict('/products')
+      refresh() {
+        return { refreshed: true };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [ProductController],
+      imports: [CacheModule.forRoot({ store: 'memory' })],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+
+    try {
+      const unref = vi.fn();
+      const response = createSimpleJsonResponse();
+      vi.stubGlobal('setTimeout', vi.fn(() => ({ unref })));
+
+      // When
+      await app.dispatch(createRequest('/products/refresh'), response);
+
+      // Then
+      expect(unref).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.unstubAllGlobals();
       await app.close();
     }
   });


### PR DESCRIPTION
## Summary

Runtime-neutral HTTP request pipeline의 deferred cache eviction이 Web/Deno의 numeric timer handle에서도 Node-specific `Timeout.unref()` 호출로 실패하지 않도록 portability를 복원합니다.

Linked context: Closes #2998

## Changes

- `fallbackTimer.unref?.()`로 Node timer capability를 feature-detect합니다.
- Web/Deno numeric timer handle에서 정상 response commit과 eviction이 유지되는 request-dispatch regression을 추가합니다.
- Node timer handle에서는 `unref()`가 계속 호출되는 regression을 추가합니다.
- `@fluojs/cache-manager` patch Changeset을 추가합니다.

## Testing

- `pnpm exec vitest run -c vitest.config.ts src/interceptor.dispatch-regression.test.ts` — 5 tests passed
- `pnpm --filter @fluojs/cache-manager... build` — 9-package dependency closure build passed
- `pnpm --filter @fluojs/cache-manager typecheck` — passed
- `pnpm --filter @fluojs/cache-manager test` — 13 files, 145 tests passed
- `pnpm exec biome check packages/cache-manager/src/deferred-eviction.ts packages/cache-manager/src/interceptor.dispatch-regression.test.ts` — passed
- Changed-file TypeScript diagnostics — no diagnostics

## Release impact

- [x] This PR has consumer-visible release impact and includes `.changeset/keep-deferred-eviction-portable.md` with a patch bump for `@fluojs/cache-manager`.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] 해당 없음 — public export 또는 exported symbol signature를 변경하지 않습니다.
- [x] 기존 source TSDoc과 README scenario의 역할은 그대로 유지됩니다.

## Behavioral contract

- [x] 문서화된 deferred eviction 시점, commit gate, failure containment를 변경하지 않습니다.
- [x] 기존 `packages/cache-manager/README.md`와 `README.ko.md`는 Node에서만 timer를 unref한다는 현재 계약을 이미 정확히 설명하므로 문서 변경이 필요하지 않습니다.
- [x] Web/Deno numeric handle과 Node `unref()` invariant를 request-dispatch regression으로 고정했습니다.

## Platform consistency governance (SSOT)

- [x] Governance 문서나 EN/KO mirror를 변경하지 않았습니다.
- [x] Node-only timer capability를 optional feature로 취급해 runtime-neutral request pipeline을 보존합니다.
- [x] Platform adapter 계약 변경이 아니므로 adapter portability harness는 해당 없으며, owning `@fluojs/cache-manager` dispatch seam에서 regression을 검증했습니다.
