### PR TITLE
Resolve #2954: Enforce Cron shutdown deadline before Redis release I/O

### DIFF
--- a/.changeset/skip-expired-cron-releases.md
+++ b/.changeset/skip-expired-cron-releases.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/cron": patch
+---
+
+Skip Redis lock release I/O after the Cron shutdown deadline expires while retaining unresolved local ownership for status reporting.

--- a/packages/cron/src/distributed-lock-manager.ts
+++ b/packages/cron/src/distributed-lock-manager.ts
@@ -368,8 +368,8 @@ export class CronDistributedLockManager {
   private async releaseLease(lease: DistributedLockLease, timeoutMs?: number): Promise<boolean> {
     const redis = this.redisClient;
 
-    if (!redis) {
-      return true;
+    if (!redis || (timeoutMs !== undefined && timeoutMs <= 0)) {
+      return redis === undefined;
     }
 
     try {

--- a/packages/cron/src/lease-race.test.ts
+++ b/packages/cron/src/lease-race.test.ts
@@ -165,7 +165,7 @@ describe('Cron distributed lease race safety', () => {
         CronModule.forRoot({
           distributed: { enabled: true, keyPrefix: 'lease-race', lockTtlMs: 60_000, ownerId: 'shared-owner' },
           scheduler: firstScheduler.scheduler,
-          shutdown: { timeoutMs: 0 },
+          shutdown: { timeoutMs: 50 },
         }),
       ],
     });
@@ -200,11 +200,13 @@ describe('Cron distributed lease race safety', () => {
 
     const firstTick = requireValue(firstScheduler.callbacks[0], 'Expected the first cron callback.')();
     await firstTaskStarted.promise;
-    await firstApp.close();
+    const closePromise = firstApp.close();
+    await Promise.resolve();
     firstTaskFinished.resolve();
     await redis.waitForFirstRelease();
-    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(50);
     await firstTick;
+    await closePromise;
     redis.expire(lockKey);
 
     const secondTick = requireValue(secondScheduler.callbacks[0], 'Expected the second cron callback.')();

--- a/packages/cron/src/module.test.ts
+++ b/packages/cron/src/module.test.ts
@@ -2994,7 +2994,7 @@ describe('@fluojs/cron', () => {
     ).toBe(true);
   });
 
-  it('preserves active distributed locks when bounded shutdown times out', async () => {
+  it('retains active distributed locks after a task settles beyond the shutdown deadline', async () => {
     const firstScheduler = createManualScheduler();
     const secondScheduler = createManualScheduler();
     const redis = new InMemoryLockRedisClient();
@@ -3028,7 +3028,7 @@ describe('@fluojs/cron', () => {
           },
           scheduler: firstScheduler.scheduler,
           shutdown: {
-            timeoutMs: 1,
+            timeoutMs: 0,
           },
         }),
       ],
@@ -3074,7 +3074,7 @@ describe('@fluojs/cron', () => {
     await firstTick;
     await secondScheduler.records[0]!.tick();
 
-    expect(secondStore.count).toBe(1);
+    expect(secondStore.count).toBe(0);
 
     await appTwo.close();
   });
@@ -3154,7 +3154,7 @@ describe('@fluojs/cron', () => {
     }
   });
 
-  it('retries distributed lock release on a later shutdown call after a timed-out task settles', async () => {
+  it('does not retry distributed lock release after a timed-out task settles past the shutdown deadline', async () => {
     const scheduled = createManualScheduler();
     const redis = new ReleaseErrorOnceRedisClient();
     const started = createDeferred<void>();
@@ -3203,14 +3203,14 @@ describe('@fluojs/cron', () => {
     release.resolve();
     await tickPromise;
 
-    expect(redis.releaseAttempts).toBe(2);
-    expect(statusService.createPlatformStatusSnapshot().details.ownedLocks).toBe(0);
-    expect(loggerEvents.some((event) => event.includes('Failed to release distributed cron lock for distributed-timeout-release-retry.'))).toBe(true);
+    expect(redis.releaseAttempts).toBe(0);
+    expect(statusService.createPlatformStatusSnapshot().details.ownedLocks).toBe(1);
+    expect(loggerEvents.some((event) => event.includes('Failed to release distributed cron lock for distributed-timeout-release-retry.'))).toBe(false);
 
     await app.close();
 
-    expect(redis.releaseAttempts).toBe(2);
-    expect(statusService.createPlatformStatusSnapshot().details.ownedLocks).toBe(0);
+    expect(redis.releaseAttempts).toBe(0);
+    expect(statusService.createPlatformStatusSnapshot().details.ownedLocks).toBe(1);
   });
 
   it('bounds shutdown distributed lock release I/O and preserves local ownership on timeout', async () => {
@@ -3268,7 +3268,7 @@ describe('@fluojs/cron', () => {
     await closePromise;
 
     expect(closeResolved).toBe(true);
-    expect(redis.releaseAttempts).toBe(3);
+    expect(redis.releaseAttempts).toBe(2);
     expect(statusService.createPlatformStatusSnapshot().details.ownedLocks).toBe(1);
     expect(
       loggerEvents.some((event) =>
@@ -3277,7 +3277,7 @@ describe('@fluojs/cron', () => {
     ).toBe(true);
   });
 
-  it('preserves active dynamic distributed locks after remove when bounded shutdown times out', async () => {
+  it('retains active dynamic distributed locks after a task settles beyond the shutdown deadline', async () => {
     const firstScheduler = createManualScheduler();
     const secondScheduler = createManualScheduler();
     const redis = new InMemoryLockRedisClient();
@@ -3300,7 +3300,7 @@ describe('@fluojs/cron', () => {
           },
           scheduler: firstScheduler.scheduler,
           shutdown: {
-            timeoutMs: 1,
+            timeoutMs: 0,
           },
         }),
       ],
@@ -3359,7 +3359,7 @@ describe('@fluojs/cron', () => {
     await firstTick;
     await secondScheduler.records[0]!.tick();
 
-    expect(storeTwo.count).toBe(1);
+    expect(storeTwo.count).toBe(0);
 
     await appTwo.close();
   });

--- a/packages/cron/src/shutdown-release.test.ts
+++ b/packages/cron/src/shutdown-release.test.ts
@@ -180,7 +180,7 @@ describe('Cron distributed release during shutdown', () => {
     expect(Date.now() - elapsedShutdownDeadlineMs).toBeLessThanOrEqual(1);
   });
 
-  it('retries stopped-state release separately after task-finally release using the shutdown-start deadline', async () => {
+  it('does not start Redis release I/O after the shutdown deadline has elapsed', async () => {
     // Given
     vi.useFakeTimers();
     const scenario = await createShutdownReleaseScenario();
@@ -193,11 +193,11 @@ describe('Cron distributed release during shutdown', () => {
     await scenario.tickPromise;
 
     // Then
-    expect(scenario.getReleaseAttempts()).toBe(2);
+    expect(scenario.getReleaseAttempts()).toBe(0);
     expect(Date.now() - elapsedShutdownDeadlineMs).toBeLessThanOrEqual(1);
   });
 
-  it('retains unresolved ownership when task-finally lock release reaches the shutdown timeout', async () => {
+  it('retains unresolved ownership when the task settles after the shutdown deadline', async () => {
     // Given
     vi.useFakeTimers();
     const scenario = await createShutdownReleaseScenario();

--- a/packages/cron/src/stopped-release-retry-race.test.ts
+++ b/packages/cron/src/stopped-release-retry-race.test.ts
@@ -102,7 +102,7 @@ function createManualScheduler(): {
 }
 
 describe('Cron stopped-state release retry race safety', () => {
-  it('preserves a newer same-manager shared-key lease until its running task settles', async () => {
+  it('preserves a newer same-manager lease when tasks settle after the shutdown deadline', async () => {
     // Given
     const redis = new OneTimeStaleReleaseFailureRedisClient();
     const scheduled = createManualScheduler();
@@ -159,11 +159,11 @@ describe('Cron stopped-state release retry race safety', () => {
     await staleTick;
 
     // Then
-    expect(redis.staleReleaseFailures).toBe(1);
+    expect(redis.staleReleaseFailures).toBe(0);
     expect(redis.hasLock(lockKey)).toBe(true);
 
     currentTaskFinished.resolve();
     await currentTick;
-    expect(redis.hasLock(lockKey)).toBe(false);
+    expect(redis.hasLock(lockKey)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Cron shutdown-start deadline이 만료된 뒤 Redis lock release `eval` I/O가 새로 시작되지 않도록 합니다. 확인되지 않은 lock은 local ownership에 남겨 status snapshot에서 계속 관찰할 수 있습니다.

Linked context: Closes #2954

## Changes

- `CronDistributedLockManager`가 `timeoutMs <= 0`인 release를 Redis I/O 전에 중단하도록 변경했습니다.
- shutdown deadline 이후 post-task release, stopped-state retry, active/dynamic lock, stale lease race expectations를 regression tests에 반영했습니다.
- `@fluojs/cron` patch changeset `.changeset/skip-expired-cron-releases.md`를 추가했습니다.

## Testing

- `pnpm --filter @fluojs/cron... build` — 통과
- `pnpm --dir packages/cron build` — 통과
- `pnpm --dir packages/cron typecheck` — 통과
- `pnpm exec biome check packages/cron/src/distributed-lock-manager.ts packages/cron/src/shutdown-release.test.ts packages/cron/src/module.test.ts packages/cron/src/lease-race.test.ts packages/cron/src/stopped-release-retry-race.test.ts` — 통과
- `pnpm --dir packages/cron test` — 9 files, 104 tests 통과
- changed-file LSP diagnostics — error 없음
- `git diff --check` — 통과

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

`@fluojs/cron` contract-preserving bug fix이므로 patch changeset을 포함합니다.

## Public export documentation

- [x] 해당 없음 — public export/API surface를 변경하지 않았습니다.
- [x] 해당 없음 — exported function signature를 변경하지 않았습니다.
- [x] 해당 없음 — source example 또는 README example을 변경하지 않았습니다.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] 기존 `packages/cron/README.md`와 companion docs가 이미 shutdown-start deadline 계약을 명시하므로 문서 변경이 필요하지 않습니다.
- [x] Intentional limitations are explicitly stated and unchanged.
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT governance docs를 변경하지 않아 English/Korean mirror 구조에 영향이 없습니다.
- [x] Platform contract docs를 변경하지 않았습니다.
- [x] Platform alignment 또는 conformance claim을 추가하지 않았으며 Cron package lifecycle tests로 변경을 검증했습니다.