### PR TITLE
Restore Discord transient webhook retries

### DIFF
--- a/.changeset/restore-discord-webhook-retries.md
+++ b/.changeset/restore-discord-webhook-retries.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/discord': patch
+---
+
+Restore bounded retries for transient Discord webhook responses and transport failures while preserving abort propagation and sanitized caller-visible errors.

--- a/packages/discord/src/webhook-retry.test.ts
+++ b/packages/discord/src/webhook-retry.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { DiscordTransportError } from './errors.js';
+import type { DiscordFetchLike } from './types.js';
+import { createDiscordWebhookTransport } from './webhook.js';
+
+describe('Discord webhook retries', () => {
+  it.each([408, 429, 502])('retries transient HTTP %s responses before succeeding', async (status) => {
+    vi.useFakeTimers();
+
+    try {
+      const fetchLike = vi
+        .fn<DiscordFetchLike>()
+        .mockResolvedValueOnce({
+          ok: false,
+          status,
+          async text() {
+            return 'temporary provider response';
+          },
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          async text() {
+            return JSON.stringify({ id: `msg-${String(status)}` });
+          },
+        });
+      const transport = createDiscordWebhookTransport({
+        fetch: fetchLike,
+        webhookUrl: 'https://discord.com/api/webhooks/123/abc',
+      });
+
+      const pending = transport.send(
+        { attachments: [], components: [], content: `Retry HTTP ${String(status)}`, embeds: [] },
+        {},
+      );
+      const expectation = expect(pending).resolves.toMatchObject({
+        messageId: `msg-${String(status)}`,
+        ok: true,
+        statusCode: 200,
+      });
+      await vi.runAllTimersAsync();
+
+      await expectation;
+      expect(fetchLike).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('retries transport-level exceptions before succeeding', async () => {
+    vi.useFakeTimers();
+
+    try {
+      const fetchLike = vi
+        .fn<DiscordFetchLike>()
+        .mockRejectedValueOnce(new Error('provider response contained a secret'))
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          async text() {
+            return JSON.stringify({ id: 'msg-retried' });
+          },
+        });
+      const transport = createDiscordWebhookTransport({
+        fetch: fetchLike,
+        webhookUrl: 'https://discord.com/api/webhooks/123/abc',
+      });
+
+      const pending = transport.send(
+        { attachments: [], components: [], content: 'Retry transport failure', embeds: [] },
+        {},
+      );
+      const expectation = expect(pending).resolves.toMatchObject({
+        messageId: 'msg-retried',
+        ok: true,
+        statusCode: 200,
+      });
+      await vi.runAllTimersAsync();
+
+      await expectation;
+      expect(fetchLike).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('surfaces a sanitized status error after transient retries are exhausted', async () => {
+    vi.useFakeTimers();
+
+    try {
+      const fetchLike = vi.fn<DiscordFetchLike>().mockResolvedValue({
+        ok: false,
+        status: 503,
+        statusText: 'Service Unavailable',
+        async text() {
+          return '{"token":"secret","detail":"provider unavailable"}';
+        },
+      });
+      const transport = createDiscordWebhookTransport({
+        fetch: fetchLike,
+        webhookUrl: 'https://discord.com/api/webhooks/123/abc',
+      });
+
+      const pending = transport.send(
+        { attachments: [], components: [], content: 'Retry exhausted status', embeds: [] },
+        {},
+      );
+      const expectation = expect(pending).rejects.toThrowError(
+        new DiscordTransportError(
+          'Discord webhook delivery failed with status 503 Service Unavailable after 3 attempt(s). Upstream response body was omitted from the caller-visible error.',
+        ),
+      );
+      await vi.runAllTimersAsync();
+
+      await expectation;
+      expect(fetchLike).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not retry permanent HTTP failures', async () => {
+    const fetchLike = vi.fn<DiscordFetchLike>().mockResolvedValue({
+      ok: false,
+      status: 400,
+      statusText: 'Bad Request',
+      async text() {
+        return '{"token":"secret","detail":"invalid request"}';
+      },
+    });
+    const transport = createDiscordWebhookTransport({
+      fetch: fetchLike,
+      webhookUrl: 'https://discord.com/api/webhooks/123/abc',
+    });
+
+    await expect(
+      transport.send({ attachments: [], components: [], content: 'Permanent failure', embeds: [] }, {}),
+    ).rejects.toThrowError(
+      new DiscordTransportError(
+        'Discord webhook delivery failed with status 400 Bad Request after 1 attempt(s). Upstream response body was omitted from the caller-visible error.',
+      ),
+    );
+    expect(fetchLike).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/discord/src/webhook.ts
+++ b/packages/discord/src/webhook.ts
@@ -169,8 +169,10 @@ export function createDiscordWebhookTransport(options: DiscordWebhookTransportOp
   return {
     async send(message: NormalizedDiscordMessage, context: DiscordTransportContext) {
       for (let attempt = 1; attempt <= DEFAULT_RETRY_ATTEMPTS; attempt += 1) {
+        let response: DiscordFetchResponse;
+
         try {
-          const response = await fetchLike(resolveWebhookUrl(parsedWebhookUrl, message, wait), {
+          response = await fetchLike(resolveWebhookUrl(parsedWebhookUrl, message, wait), {
             body: JSON.stringify(createWebhookPayload(message)),
             headers: {
               'content-type': 'application/json; charset=utf-8',
@@ -178,41 +180,8 @@ export function createDiscordWebhookTransport(options: DiscordWebhookTransportOp
             method: 'POST',
             signal: context.signal,
           });
-
-          const body = await readResponseBody(response);
-
-          if (!response.ok) {
-            if (attempt < DEFAULT_RETRY_ATTEMPTS && isTransientStatus(response.status)) {
-              await waitForRetry(DEFAULT_RETRY_DELAY_MS * 2 ** (attempt - 1), context.signal);
-              continue;
-            }
-
-            throw new DiscordTransportError(createStatusFailureMessage(response, attempt));
-          }
-
-          const parsed = parseJsonRecord(body);
-          const warnings: string[] = [];
-
-          if (body && !parsed) {
-            warnings.push('Discord webhook returned a non-JSON success body.');
-          }
-
-          return {
-            channelId: getStringField(parsed, 'channel_id'),
-            guildId: getStringField(parsed, 'guild_id'),
-            messageId: getStringField(parsed, 'id'),
-            ok: true,
-            response: body || undefined,
-            statusCode: response.status,
-            threadId: getStringField(parsed, 'thread_id') ?? message.threadId,
-            warnings,
-          };
         } catch (error) {
           if (isAbortError(error) || context.signal?.aborted) {
-            throw error;
-          }
-
-          if (error instanceof DiscordTransportError) {
             throw error;
           }
 
@@ -223,6 +192,35 @@ export function createDiscordWebhookTransport(options: DiscordWebhookTransportOp
 
           throw new DiscordTransportError(createTransportFailureMessage(attempt));
         }
+
+        const body = await readResponseBody(response);
+
+        if (!response.ok) {
+          if (attempt < DEFAULT_RETRY_ATTEMPTS && isTransientStatus(response.status)) {
+            await waitForRetry(DEFAULT_RETRY_DELAY_MS * 2 ** (attempt - 1), context.signal);
+            continue;
+          }
+
+          throw new DiscordTransportError(createStatusFailureMessage(response, attempt));
+        }
+
+        const parsed = parseJsonRecord(body);
+        const warnings: string[] = [];
+
+        if (body && !parsed) {
+          warnings.push('Discord webhook returned a non-JSON success body.');
+        }
+
+        return {
+          channelId: getStringField(parsed, 'channel_id'),
+          guildId: getStringField(parsed, 'guild_id'),
+          messageId: getStringField(parsed, 'id'),
+          ok: true,
+          response: body || undefined,
+          statusCode: response.status,
+          threadId: getStringField(parsed, 'thread_id') ?? message.threadId,
+          warnings,
+        };
       }
 
       throw new DiscordTransportError(createTransportFailureMessage(DEFAULT_RETRY_ATTEMPTS));


### PR DESCRIPTION
## Summary

Restore the documented bounded retry behavior for Discord webhook delivery when Discord returns transient HTTP responses or a transport request fails.

Linked context: Closes #2957

## Changes

- Retry HTTP 408, 429, and 5xx responses until the configured final attempt.
- Retry transient transport exceptions while preserving immediate abort propagation, permanent failure behavior, and sanitized errors.
- Add fake-timer regressions for transient responses, transport failures, retry exhaustion, and permanent failures.
- Add a patch changeset for `@fluojs/discord`.

## Testing

- `pnpm --filter @fluojs/discord test` — 55 passed.
- Full Node.js 22 test suite — 425 files passed; 4840 tests passed, 1 skipped.
- `pnpm build` — passed.
- `pnpm typecheck` — passed.
- `pnpm lint` — passed.
- Changeset release lane verification — passed.
- `pnpm verify:platform-consistency-governance` — passed.
- Release readiness verification with an isolated sandbox — passed.
- Changed-file LSP diagnostics and `git diff --check` — passed.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Patch release for `@fluojs/discord` because webhook delivery now again honors the documented retry contract for transient failures.

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

No public exports changed.

- [ ] Changed public exports include a source-level summary.
- [ ] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [ ] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [ ] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

The package README already documents the bounded retry contract, so no README change is required.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

No platform contract or governance documentation changed.

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by the applicable platform harness tests, such as `createPlatformConformanceHarness(...)` for platform component contracts or `createHttpAdapterPortabilityHarness(...)` for HTTP adapter portability contracts.
