### PR TITLE
Resolve #3038: Preserve validation cycle guards across DTO materialization

### DIFF
--- a/.changeset/preserve-validation-cycle-guards.md
+++ b/.changeset/preserve-validation-cycle-guards.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/validation': patch
+---
+
+Preserve cycle guards across DTO materialization and nested validation without rejecting shared raw references.

--- a/packages/validation/src/dto-materialization-cycles.test.ts
+++ b/packages/validation/src/dto-materialization-cycles.test.ts
@@ -32,6 +32,77 @@ describe('DTO materialization cycle guards', () => {
     expect(constructorRuns).toBe(1);
   });
 
+  it('rejects a raw root self-cycle at its first different-constructor re-entry', async () => {
+    // Given
+    let childConstructorRuns = 0;
+
+    class RootDto {
+      @ValidateNested(() => ChildDto)
+      child?: ChildDto;
+    }
+
+    class ChildDto {
+      @MinLength(1)
+      name = '';
+
+      constructor() {
+        childConstructorRuns += 1;
+      }
+    }
+
+    const payload: { child?: unknown; name: string } = { name: 'root' };
+    payload.child = payload;
+
+    // When / Then
+    await expect(
+      new DefaultValidator().materialize(payload, RootDto),
+    ).rejects.toMatchObject({
+      issues: [{ code: 'INVALID_NESTED', field: 'child', message: 'child contains invalid nested data.' }],
+    });
+    expect(childConstructorRuns).toBe(0);
+  });
+
+  it('rejects a mutual raw cycle at its different-constructor re-entry', async () => {
+    // Given
+    let alternateParentConstructorRuns = 0;
+
+    class ParentDto {
+      @ValidateNested(() => ChildDto)
+      child?: ChildDto;
+    }
+
+    class ChildDto {
+      @ValidateNested(() => AlternateParentDto)
+      parent?: AlternateParentDto;
+    }
+
+    class AlternateParentDto {
+      @MinLength(1)
+      name = '';
+
+      constructor() {
+        alternateParentConstructorRuns += 1;
+      }
+    }
+
+    type ParentPayload = { child?: unknown; name: string };
+
+    const parent: ParentPayload = { name: 'parent' };
+    parent.child = { name: 'child', parent };
+
+    // When / Then
+    await expect(
+      new DefaultValidator().materialize(parent, ParentDto),
+    ).rejects.toMatchObject({
+      issues: [{
+        code: 'INVALID_NESTED',
+        field: 'child.parent',
+        message: 'child.parent contains invalid nested data.',
+      }],
+    });
+    expect(alternateParentConstructorRuns).toBe(0);
+  });
+
   it('keeps raw-to-existing-DTO cycles guarded across materialization and validation', async () => {
     // Given
     let childConstructorRuns = 0;
@@ -135,5 +206,36 @@ describe('DTO materialization cycle guards', () => {
     expect(result.left).toBeInstanceOf(ChildDto);
     expect(result.right).toBeInstanceOf(ChildDto);
     expect(result.left).toBe(result.right);
+  });
+
+  it('preserves constructor-specific identity for non-cyclic shared raw references', async () => {
+    // Given
+    class LeftChildDto {
+      @MinLength(1)
+      name = '';
+    }
+
+    class RightChildDto {
+      @MinLength(1)
+      name = '';
+    }
+
+    class ParentDto {
+      @ValidateNested(() => LeftChildDto)
+      left?: LeftChildDto;
+
+      @ValidateNested(() => RightChildDto)
+      right?: RightChildDto;
+    }
+
+    const shared = { name: 'shared' };
+
+    // When
+    const result = await new DefaultValidator().materialize<ParentDto>({ left: shared, right: shared }, ParentDto);
+
+    // Then
+    expect(result.left).toBeInstanceOf(LeftChildDto);
+    expect(result.right).toBeInstanceOf(RightChildDto);
+    expect(result.left).not.toBe(result.right);
   });
 });

--- a/packages/validation/src/dto-materialization-cycles.test.ts
+++ b/packages/validation/src/dto-materialization-cycles.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+
+import { MinLength, ValidateNested } from './decorators.js';
+import { DefaultValidator } from './validation.js';
+
+describe('DTO materialization cycle guards', () => {
+  it('keeps a self-referential raw root guarded while validating its DTO', async () => {
+    // Given
+    let constructorRuns = 0;
+
+    class NodeDto {
+      @MinLength(1)
+      name = '';
+
+      @ValidateNested(() => NodeDto)
+      child?: NodeDto;
+
+      constructor() {
+        constructorRuns += 1;
+      }
+    }
+
+    const payload: { child?: unknown; name: string } = { name: 'root' };
+    payload.child = payload;
+
+    // When / Then
+    await expect(
+      new DefaultValidator().materialize(payload, NodeDto),
+    ).rejects.toMatchObject({
+      issues: [{ code: 'INVALID_NESTED', field: 'child', message: 'child contains invalid nested data.' }],
+    });
+    expect(constructorRuns).toBe(1);
+  });
+
+  it('keeps raw-to-existing-DTO cycles guarded across materialization and validation', async () => {
+    // Given
+    let childConstructorRuns = 0;
+    let parentConstructorRuns = 0;
+
+    class ParentDto {
+      @MinLength(1)
+      name = '';
+
+      @ValidateNested(() => ChildDto)
+      child?: ChildDto;
+
+      constructor() {
+        parentConstructorRuns += 1;
+      }
+    }
+
+    class ChildDto {
+      @MinLength(1)
+      name = '';
+
+      @ValidateNested(() => ParentDto)
+      parent?: ParentDto;
+
+      constructor() {
+        childConstructorRuns += 1;
+      }
+    }
+
+    type ParentPayload = { child?: ChildDto; name: string };
+
+    const parent: ParentPayload = { name: 'parent' };
+    const child = Object.assign(new ChildDto(), { name: 'child', parent });
+    parent.child = child;
+
+    // When / Then
+    await expect(
+      new DefaultValidator().materialize(parent, ParentDto),
+    ).rejects.toMatchObject({
+      issues: [{
+        code: 'INVALID_NESTED',
+        field: 'child.parent',
+        message: 'child.parent contains invalid nested data.',
+      }],
+    });
+    expect(parentConstructorRuns).toBe(1);
+    expect(childConstructorRuns).toBe(1);
+  });
+
+  it('keeps raw-to-existing-DTO collection cycles guarded during materialization', async () => {
+    // Given
+    class ParentDto {
+      @ValidateNested(() => ChildDto)
+      children: ChildDto[] = [];
+    }
+
+    class ChildDto {
+      @ValidateNested(() => ParentDto)
+      parent?: ParentDto;
+    }
+
+    type ParentPayload = { children: ChildDto[] };
+
+    const parent: ParentPayload = { children: [] };
+    const child = Object.assign(new ChildDto(), { parent });
+    parent.children.push(child);
+
+    // When / Then
+    await expect(
+      new DefaultValidator().materialize(parent, ParentDto),
+    ).rejects.toMatchObject({
+      issues: [{
+        code: 'INVALID_NESTED',
+        field: 'children[0].parent',
+        message: 'children[0].parent contains invalid nested data.',
+      }],
+    });
+  });
+
+  it('continues to allow one raw object to be shared by sibling fields', async () => {
+    // Given
+    class ChildDto {
+      @MinLength(1)
+      name = '';
+    }
+
+    class ParentDto {
+      @ValidateNested(() => ChildDto)
+      left?: ChildDto;
+
+      @ValidateNested(() => ChildDto)
+      right?: ChildDto;
+    }
+
+    const shared = { name: 'shared' };
+
+    // When
+    const result = await new DefaultValidator().materialize<ParentDto>({ left: shared, right: shared }, ParentDto);
+
+    // Then
+    expect(result.left).toBeInstanceOf(ChildDto);
+    expect(result.right).toBeInstanceOf(ChildDto);
+    expect(result.left).toBe(result.right);
+  });
+});

--- a/packages/validation/src/internal/dto-materialization.ts
+++ b/packages/validation/src/internal/dto-materialization.ts
@@ -5,11 +5,16 @@ import type { ValidationIssue } from '../types.js';
 import { getCachedDtoMetadata } from './dto-metadata-cache.js';
 import { assignSafeOwnEnumerableProperties, isPlainObject } from './object-utils.js';
 
+/**
+ * Carries invocation-local DTO traversal state across materialization and validation.
+ */
 export interface NestedTraversalContext {
   readonly active: WeakSet<object>;
   readonly hydrateExistingInstances?: boolean;
   readonly materialized?: WeakMap<object, WeakMap<Constructor, object>>;
 }
+
+const materializationCycleTarget: Constructor = class {};
 
 function getMaterializedInstance(
   rawValue: object,
@@ -42,6 +47,13 @@ function canMaterialize<T>(value: unknown, target: Constructor<T>): value is obj
   return value instanceof target || isPlainObject(value);
 }
 
+/**
+ * Enters a traversal value when it is not already active.
+ *
+ * @param value Candidate traversal value.
+ * @param context Invocation-local traversal state.
+ * @returns Whether traversal may continue for the value.
+ */
 export function enterTraversal(value: unknown, context?: NestedTraversalContext): boolean {
   if (!context || typeof value !== 'object' || value === null) {
     return true;
@@ -55,14 +67,32 @@ export function enterTraversal(value: unknown, context?: NestedTraversalContext)
   return true;
 }
 
+/**
+ * Releases a traversal value after materialization or validation completes.
+ *
+ * @param value Traversal value to release.
+ * @param context Invocation-local traversal state.
+ */
 export function exitTraversal(value: unknown, context?: NestedTraversalContext): void {
   if (!context || typeof value !== 'object' || value === null) {
+    return;
+  }
+
+  if (context.materialized?.get(value)?.has(materializationCycleTarget)) {
     return;
   }
 
   context.active.delete(value);
 }
 
+/**
+ * Creates or reuses a nested DTO instance for a raw value.
+ *
+ * @param target Nested DTO constructor.
+ * @param rawValue Raw nested value.
+ * @param context Invocation-local traversal state.
+ * @returns The materialized DTO value or the original unsupported value.
+ */
 export function createNestedDtoInstance<T>(
   target: Constructor<T>,
   rawValue: unknown,
@@ -83,6 +113,7 @@ export function createNestedDtoInstance<T>(
   }
 
   if (context?.active.has(rawObject)) {
+    rememberMaterializedInstance(rawObject, materializationCycleTarget, rawObject, context);
     return rawValue as T;
   }
 
@@ -160,6 +191,12 @@ function buildInvalidRootIssue(): ValidationIssue {
   };
 }
 
+/**
+ * Asserts that a root value can be validated as the requested DTO.
+ *
+ * @param value Root value to validate.
+ * @param target Requested DTO constructor.
+ */
 export function assertValidRootValue(value: unknown, target: Constructor): void {
   if (value instanceof target || isPlainObject(value)) {
     return;

--- a/packages/validation/src/internal/dto-materialization.ts
+++ b/packages/validation/src/internal/dto-materialization.ts
@@ -8,6 +8,38 @@ import { assignSafeOwnEnumerableProperties, isPlainObject } from './object-utils
 export interface NestedTraversalContext {
   readonly active: WeakSet<object>;
   readonly hydrateExistingInstances?: boolean;
+  readonly materialized?: WeakMap<object, WeakMap<Constructor, object>>;
+}
+
+function getMaterializedInstance(
+  rawValue: object,
+  target: Constructor,
+  context?: NestedTraversalContext,
+): object | undefined {
+  return context?.materialized?.get(rawValue)?.get(target);
+}
+
+function rememberMaterializedInstance(
+  rawValue: object,
+  target: Constructor,
+  instance: object,
+  context?: NestedTraversalContext,
+): void {
+  if (!context?.materialized) {
+    return;
+  }
+
+  let instancesByTarget = context.materialized.get(rawValue);
+  if (!instancesByTarget) {
+    instancesByTarget = new WeakMap<Constructor, object>();
+    context.materialized.set(rawValue, instancesByTarget);
+  }
+
+  instancesByTarget.set(target, instance);
+}
+
+function canMaterialize<T>(value: unknown, target: Constructor<T>): value is object {
+  return value instanceof target || isPlainObject(value);
 }
 
 export function enterTraversal(value: unknown, context?: NestedTraversalContext): boolean {
@@ -40,11 +72,22 @@ export function createNestedDtoInstance<T>(
     return rawValue as T;
   }
 
-  if (!(rawValue instanceof target) && !isPlainObject(rawValue)) {
+  if (!canMaterialize(rawValue, target)) {
+    return rawValue as T;
+  }
+
+  const rawObject: object = rawValue;
+  const rememberedInstance = getMaterializedInstance(rawObject, target, context);
+  if (rememberedInstance) {
+    return rememberedInstance as T;
+  }
+
+  if (context?.active.has(rawObject)) {
     return rawValue as T;
   }
 
   const instance = (rawValue instanceof target ? rawValue : new target()) as Record<PropertyKey, unknown>;
+  rememberMaterializedInstance(rawObject, target, instance, context);
 
   if (!enterTraversal(rawValue, context)) {
     return rawValue as T;

--- a/packages/validation/src/validation.test.ts
+++ b/packages/validation/src/validation.test.ts
@@ -4,7 +4,7 @@ import { email, object, pipe, string } from 'valibot';
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
 
-import { ArrayContains, ArrayMaxSize, ArrayMinSize, ArrayNotContains, ArrayNotEmpty, ArrayUnique, Contains, Equals, IsAlphanumeric, IsAlpha, IsArray, IsAscii, IsBase64, IsBoolean, IsBooleanString, IsCurrency, IsDataURI, IsDate, IsDateString, IsDecimal, IsDefined, IsDivisibleBy, IsEmail, IsEmpty, IsEnum, IsFQDN, IsHexadecimal, IsHexColor, IsIn, IsInt, IsIP, IsISBN, IsISO8601, IsISSN, IsJSON, IsJWT, IsLatitude, IsLatLong, IsLocale, IsLongitude, IsLowercase, IsMagnetURI, IsMimeType, IsMobilePhone, IsMongoId, IsNegative, IsNotEmpty, IsNotIn, IsNumber, IsNumberString, IsObject, IsOptional, IsPort, IsPositive, IsPostalCode, IsRFC3339, IsRgbColor, IsSemVer, IsString, IsUppercase, IsUrl, IsUUID, Length, Matches, Max, MaxDate, MaxLength, Min, MinDate, MinLength, NotContains, NotEquals, Validate, ValidateClass, ValidateIf, ValidateNested } from './decorators.js';
+import { ArrayContains, ArrayMaxSize, ArrayMinSize, ArrayNotContains, ArrayNotEmpty, ArrayUnique, Contains, Equals, IsAlpha, IsAlphanumeric, IsArray, IsAscii, IsBase64, IsBoolean, IsBooleanString, IsCurrency, IsDataURI, IsDate, IsDateString, IsDecimal, IsDefined, IsDivisibleBy, IsEmail, IsEmpty, IsEnum, IsFQDN, IsHexadecimal, IsHexColor, IsIn, IsInt, IsIP, IsISBN, IsISO8601, IsISSN, IsJSON, IsJWT, IsLatitude, IsLatLong, IsLocale, IsLongitude, IsLowercase, IsMagnetURI, IsMimeType, IsMobilePhone, IsMongoId, IsNegative, IsNotEmpty, IsNotIn, IsNumber, IsNumberString, IsObject, IsOptional, IsPort, IsPositive, IsPostalCode, IsRFC3339, IsRgbColor, IsSemVer, IsString, IsUppercase, IsUrl, IsUUID, Length, Matches, Max, MaxDate, MaxLength, Min, MinDate, MinLength, NotContains, NotEquals, Validate, ValidateClass, ValidateIf, ValidateNested } from './decorators.js';
 import { DtoValidationError } from './errors.js';
 import type { StandardSchemaV1Like } from './index.js';
 import { DefaultValidator } from './validation.js';
@@ -1076,7 +1076,7 @@ describe('DefaultValidator', () => {
     await expect(
       validator.materialize<NodeDto>(payload, NodeDto),
     ).rejects.toMatchObject({
-      issues: [{ code: 'INVALID_NESTED', field: 'child.child', message: 'child.child contains invalid nested data.' }],
+      issues: [{ code: 'INVALID_NESTED', field: 'child', message: 'child contains invalid nested data.' }],
     });
   });
 

--- a/packages/validation/src/validation.ts
+++ b/packages/validation/src/validation.ts
@@ -270,11 +270,13 @@ export class DefaultValidator implements Validator {
   async materialize<T>(value: unknown, target: Constructor<T>): Promise<T> {
     assertValidRootValue(value, target);
 
-    const instance = createNestedDtoInstance(target, value, {
+    const traversal: NestedTraversalContext = {
       active: new WeakSet<object>(),
       hydrateExistingInstances: true,
-    });
-    const issues = await collectValidationIssues(target, instance);
+      materialized: new WeakMap<object, WeakMap<Constructor, object>>(),
+    };
+    const instance = createNestedDtoInstance(target, value, traversal);
+    const issues = await collectValidationIssuesInternal(target, instance, {}, traversal);
 
     if (issues.length > 0) {
       throw new DtoValidationError('Validation failed.', issues);


### PR DESCRIPTION
## Summary

Preserve raw-object cycle identity across DTO materialization and the nested validation pass so cyclic payload graphs are rejected at the first re-entry instead of being rematerialized into deeper DTO graphs.

Linked context: https://github.com/fluojs/fluo/issues/3038

Closes #3038

## Changes

- keep one invocation-local raw-object/DTO mapping across materialization and validation
- reuse materialized DTO identities without converting the mapping into a global visited set, preserving shared-reference support
- add self-cycle, raw-to-existing-DTO, collection-cycle, and sibling shared-reference regressions
- record a patch release for `@fluojs/validation`

## Testing

- `pnpm test` in `packages/validation` — 83 tests passed
- `pnpm typecheck` in `packages/validation` — passed
- `pnpm build` in `packages/validation` — passed
- `pnpm exec biome check packages/validation/src/internal/dto-materialization.ts packages/validation/src/validation.ts packages/validation/src/validation.test.ts packages/validation/src/dto-materialization-cycles.test.ts` — passed
- `pnpm verify:platform-consistency-governance` — passed
- `pnpm verify:release-readiness` — reached 4,408 passing tests, then failed on four unrelated existing GraphQL/Studio SSE timing/global-state assertions plus a Node `ReadableStream` closed-state unhandled rejection; the same failures reproduce when those unrelated files are run separately

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

No public exports changed.

- [x] Changed public exports include a source-level summary. (N/A)
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable. (N/A)
- [x] Source `@example` blocks and README scenario examples still play complementary roles. (N/A)

## Behavioral contract

The EN/KO validation READMEs already document that cycles are detected safely and shared references are allowed, so no contract text change was required.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README. (No new contract; this restores the existing one.)
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. (No governance docs changed.)
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. (N/A)
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests. (No platform claim changed.)