### PR TITLE
Resolve #3057: Correct Guard and request binding book examples

### DIFF
--- a/book/beginner/ch09-guards-interceptors.ko.md
+++ b/book/beginner/ch09-guards-interceptors.ko.md
@@ -53,12 +53,12 @@ FluoBlog가 읽기 라우트는 공개하지만 쓰기 라우트는 간단한 ad
 guard의 역할을 설명하기에 적절한 상황입니다.
 
 ```typescript
-import { ForbiddenException, type RequestContext } from '@fluojs/http';
+import { ForbiddenException, type GuardContext } from '@fluojs/http';
 
 export class AdminGuard {
-  // input은 (있는 경우) 검증된 요청 본문입니다.
-  canActivate(input: unknown, ctx: RequestContext) {
-    const role = ctx.request.headers['x-role'];
+  // Guard는 request DTO binding 전에 실행되므로 request context를 직접 확인합니다.
+  canActivate(context: GuardContext) {
+    const role = context.requestContext.request.headers['x-role'];
 
     if (role !== 'admin') {
       // 8장에서 배운 구조화된 예외를 던집니다.
@@ -71,6 +71,8 @@ export class AdminGuard {
   }
 }
 ```
+
+Guard는 binding된 controller DTO가 아니라 하나의 `GuardContext`를 받습니다. Guard는 `@RequestDto(...)` binding과 validation 전에 실행되므로 header나 다른 request metadata는 `requestContext`에서 확인하세요.
 
 그다음 이 guard를 컨트롤러나 특정 메서드에 적용합니다.
 

--- a/book/beginner/ch09-guards-interceptors.md
+++ b/book/beginner/ch09-guards-interceptors.md
@@ -53,12 +53,12 @@ Suppose FluoBlog keeps read routes public but requires a simple admin header for
 This is a good situation for explaining the role of a Guard.
 
 ```typescript
-import { ForbiddenException, type RequestContext } from '@fluojs/http';
+import { ForbiddenException, type GuardContext } from '@fluojs/http';
 
 export class AdminGuard {
-  // input is the validated request body, if one exists.
-  canActivate(input: unknown, ctx: RequestContext) {
-    const role = ctx.request.headers['x-role'];
+  // Guards run before request DTO binding, so inspect the request context directly.
+  canActivate(context: GuardContext) {
+    const role = context.requestContext.request.headers['x-role'];
 
     if (role !== 'admin') {
       // Throw the structured exception learned in Chapter 8.
@@ -71,6 +71,8 @@ export class AdminGuard {
   }
 }
 ```
+
+A Guard receives one `GuardContext`, not a bound controller DTO. Use its `requestContext` to inspect headers or other request metadata because Guards run before `@RequestDto(...)` binding and validation.
 
 Then apply this Guard to a Controller or to a specific method.
 

--- a/book/intermediate/ch22-bun.ko.md
+++ b/book/intermediate/ch22-bun.ko.md
@@ -156,7 +156,7 @@ Bun의 장점은 HTTP 처리에만 머물지 않습니다. 네이티브 sqlite �
 
 Drizzle과 함께 쓰면 Node 기반 Postgres 구성과 Bun 기반 SQLite 구성을 같은 저장소 패턴 안에서 비교할 수 있습니다. fluo에서는 드라이버별 로직을 프로바이더 경계에 두고, 도메인 서비스가 스키마와 쿼리 계약에 집중하도록 설계하는 것이 중요합니다.
 
-Bun 어댑터의 핵심 책임은 Bun의 `Request` 및 `Response` 객체를 fluo 내부 컨텍스트로 변환하는 것입니다. 이 경계 덕분에 `@Body()` 및 `@Headers()` 같은 데코레이터는 런타임이 바뀌어도 같은 의미를 유지합니다. 성능을 판단할 때는 변환 계층의 비용과 실제 비즈니스 로직의 비용을 함께 측정해야 합니다.
+Bun 어댑터의 핵심 책임은 Bun의 `Request` 및 `Response` 객체를 fluo 내부 컨텍스트로 변환하는 것입니다. 이 경계는 런타임이 바뀌어도 fluo의 request binding 계약을 유지합니다. `@RequestDto(...)`가 controller input DTO를 선택하고, `@FromBody(...)`와 `@FromHeader(...)` 같은 field decorator가 request 값을 binding합니다. Controller에서 low-level request data가 필요하면 두 번째 인자로 명시적인 `RequestContext`를 받으세요. 성능을 판단할 때는 변환 계층의 비용과 실제 비즈니스 로직의 비용을 함께 측정해야 합니다.
 
 Bun은 서버 측 로직에서도 `fetch` API를 중심에 둡니다. fluo는 내부 디스패처를 웹 표준 `Request` 및 `Response` 객체와 맞춰 이 모델을 자연스럽게 사용합니다. 그 결과 Bun 이식은 단순한 성능 실험이 아니라 표준 기반 런타임 경계를 검증하는 과정이 됩니다.
 

--- a/book/intermediate/ch22-bun.md
+++ b/book/intermediate/ch22-bun.md
@@ -156,7 +156,7 @@ Bun's advantages are not limited to HTTP processing. With the native sqlite modu
 
 When used with Drizzle, you can compare Node-based Postgres configuration and Bun-based SQLite configuration inside the same repository pattern. In fluo, it is important to keep driver-specific logic at Provider boundaries and design domain services to focus on schema and query contracts.
 
-The Bun adapter's core responsibility is converting Bun's `Request` and `Response` objects into fluo's internal context. Thanks to this boundary, Decorators such as `@Body()` and `@Headers()` keep the same meaning even when the runtime changes. When evaluating performance, measure both the cost of the conversion layer and the cost of the actual business logic.
+The Bun adapter's core responsibility is converting Bun's `Request` and `Response` objects into fluo's internal context. This boundary preserves fluo's request binding contract when the runtime changes: `@RequestDto(...)` selects the controller input DTO, while field decorators such as `@FromBody(...)` and `@FromHeader(...)` bind request values. When a controller needs low-level request data, receive an explicit `RequestContext` as its second argument. When evaluating performance, measure both the cost of the conversion layer and the cost of the actual business logic.
 
 Bun also centers the `fetch` API in server-side logic. fluo naturally uses this model by aligning its internal Dispatcher with Web-standard `Request` and `Response` objects. As a result, porting to Bun is not just a performance experiment; it is a process for validating standard-based runtime boundaries.
 

--- a/tooling/governance/verify-platform-consistency-governance.mjs
+++ b/tooling/governance/verify-platform-consistency-governance.mjs
@@ -1248,6 +1248,8 @@ function enforceCanonicalRuntimeMatrixReferences() {
   const beginnerIntroKo = readFileSync(join(repoRoot, 'book/beginner/ch00-introduction.ko.md'), 'utf8');
   const beginnerCliSetup = readFileSync(join(repoRoot, 'book/beginner/ch02-cli-setup.md'), 'utf8');
   const beginnerCliSetupKo = readFileSync(join(repoRoot, 'book/beginner/ch02-cli-setup.ko.md'), 'utf8');
+  const beginnerGuards = readFileSync(join(repoRoot, 'book/beginner/ch09-guards-interceptors.md'), 'utf8');
+  const beginnerGuardsKo = readFileSync(join(repoRoot, 'book/beginner/ch09-guards-interceptors.ko.md'), 'utf8');
   const beginnerProduction = readFileSync(join(repoRoot, 'book/beginner/ch21-production.md'), 'utf8');
   const beginnerProductionKo = readFileSync(join(repoRoot, 'book/beginner/ch21-production.ko.md'), 'utf8');
   const customAdapter = readFileSync(join(repoRoot, 'book/advanced/ch13-custom-adapter.md'), 'utf8');
@@ -1544,6 +1546,38 @@ function enforceCanonicalRuntimeMatrixReferences() {
       migrateFromNestjsKo.includes('manual host는 shutdown, websocket upgrade, native `routes` acceleration을 직접 소유') &&
       docsContextKo.includes('동기 `createBunFetchHandler(...)` 사용법'),
     'Korean Bun adapter docs must keep synchronous manual fetch hosting, pre-listen realtime binding, and signal-driven shutdown ownership discoverable together.',
+  );
+  assert(
+    beginnerGuards.includes('type GuardContext') &&
+      beginnerGuards.includes('canActivate(context: GuardContext)') &&
+      beginnerGuards.includes("context.requestContext.request.headers['x-role']") &&
+      !beginnerGuards.includes('canActivate(input: unknown, ctx: RequestContext)'),
+    'The English guards chapter must use the one-argument GuardContext contract and read request data before DTO binding through requestContext.',
+  );
+  assert(
+    beginnerGuardsKo.includes('type GuardContext') &&
+      beginnerGuardsKo.includes('canActivate(context: GuardContext)') &&
+      beginnerGuardsKo.includes("context.requestContext.request.headers['x-role']") &&
+      !beginnerGuardsKo.includes('canActivate(input: unknown, ctx: RequestContext)'),
+    'The Korean guards chapter must use the one-argument GuardContext contract and read request data before DTO binding through requestContext.',
+  );
+  assert(
+    bunChapter.includes('`@RequestDto(...)`') &&
+      bunChapter.includes('`@FromBody(...)`') &&
+      bunChapter.includes('`@FromHeader(...)`') &&
+      bunChapter.includes('`RequestContext`') &&
+      !bunChapter.includes('`@Body()`') &&
+      !bunChapter.includes('`@Headers()`'),
+    'The English Bun chapter must document fluo DTO field binding and explicit RequestContext instead of NestJS parameter decorators.',
+  );
+  assert(
+    bunChapterKo.includes('`@RequestDto(...)`') &&
+      bunChapterKo.includes('`@FromBody(...)`') &&
+      bunChapterKo.includes('`@FromHeader(...)`') &&
+      bunChapterKo.includes('`RequestContext`') &&
+      !bunChapterKo.includes('`@Body()`') &&
+      !bunChapterKo.includes('`@Headers()`'),
+    'The Korean Bun chapter must document fluo DTO field binding and explicit RequestContext instead of NestJS parameter decorators.',
   );
   assert(
     docsContext.includes('docs/reference/package-chooser.md') && docsContext.includes('@fluojs/i18n'),

--- a/tooling/governance/verify-platform-consistency-governance.mjs
+++ b/tooling/governance/verify-platform-consistency-governance.mjs
@@ -305,6 +305,58 @@ function read(relativePath) {
   return readFileSync(join(repoRoot, relativePath), 'utf8');
 }
 
+function hasOneArgumentGuardContextContract(markdown) {
+  const guardCodeBlocks = [...markdown.matchAll(/```(?:typescript|ts)\s*\n([\s\S]*?)```/gu)]
+    .map((match) => match[1] ?? '')
+    .filter((code) => /\bcanActivate\s*\(/u.test(code));
+
+  return guardCodeBlocks.length > 0 && guardCodeBlocks.every((code) => {
+    const signatures = [...code.matchAll(/\bcanActivate\s*\(([^)]*)\)/gu)];
+    return code.includes('type GuardContext') && signatures.length > 0 && signatures.every((signature) => {
+      const parameter = /^\s*([A-Za-z_$][\w$]*)\s*:\s*GuardContext\s*$/u.exec(signature[1] ?? '');
+      return parameter !== null && code.includes(`${parameter[1]}.requestContext.request`);
+    });
+  });
+}
+
+function hasRequestContextSecondArgumentGuidance(markdown) {
+  return markdown.split(/\n\s*\n/gu).some((paragraph) =>
+    paragraph.includes('`@RequestDto(...)`') &&
+    paragraph.includes('`@FromBody(...)`') &&
+    paragraph.includes('`@FromHeader(...)`') &&
+    paragraph.includes('`RequestContext`') &&
+    /controller/iu.test(paragraph) &&
+    /(?:second\s+(?:controller\s+)?argument|두 번째\s+인자)/iu.test(paragraph));
+}
+
+export function enforceHttpBookRequestContracts(readText = read) {
+  const guardChapterPaths = [
+    'book/beginner/ch09-guards-interceptors.md',
+    'book/beginner/ch09-guards-interceptors.ko.md',
+  ];
+  const bunChapterPaths = [
+    'book/intermediate/ch22-bun.md',
+    'book/intermediate/ch22-bun.ko.md',
+  ];
+
+  for (const chapterPath of guardChapterPaths) {
+    assert(
+      hasOneArgumentGuardContextContract(readText(chapterPath)),
+      `${chapterPath} must use a one-argument GuardContext signature and read request data through that context's requestContext.`,
+    );
+  }
+
+  for (const chapterPath of bunChapterPaths) {
+    const chapter = readText(chapterPath);
+    assert(
+      hasRequestContextSecondArgumentGuidance(chapter) &&
+        !chapter.includes('`@Body()`') &&
+        !chapter.includes('`@Headers()`'),
+      `${chapterPath} must keep fluo DTO field binding and explicit RequestContext as the second controller argument instead of NestJS parameter decorators.`,
+    );
+  }
+}
+
 function hasChanged(changedFiles, path) {
   return changedFiles.includes(path);
 }
@@ -1248,8 +1300,6 @@ function enforceCanonicalRuntimeMatrixReferences() {
   const beginnerIntroKo = readFileSync(join(repoRoot, 'book/beginner/ch00-introduction.ko.md'), 'utf8');
   const beginnerCliSetup = readFileSync(join(repoRoot, 'book/beginner/ch02-cli-setup.md'), 'utf8');
   const beginnerCliSetupKo = readFileSync(join(repoRoot, 'book/beginner/ch02-cli-setup.ko.md'), 'utf8');
-  const beginnerGuards = readFileSync(join(repoRoot, 'book/beginner/ch09-guards-interceptors.md'), 'utf8');
-  const beginnerGuardsKo = readFileSync(join(repoRoot, 'book/beginner/ch09-guards-interceptors.ko.md'), 'utf8');
   const beginnerProduction = readFileSync(join(repoRoot, 'book/beginner/ch21-production.md'), 'utf8');
   const beginnerProductionKo = readFileSync(join(repoRoot, 'book/beginner/ch21-production.ko.md'), 'utf8');
   const customAdapter = readFileSync(join(repoRoot, 'book/advanced/ch13-custom-adapter.md'), 'utf8');
@@ -1546,38 +1596,6 @@ function enforceCanonicalRuntimeMatrixReferences() {
       migrateFromNestjsKo.includes('manual host는 shutdown, websocket upgrade, native `routes` acceleration을 직접 소유') &&
       docsContextKo.includes('동기 `createBunFetchHandler(...)` 사용법'),
     'Korean Bun adapter docs must keep synchronous manual fetch hosting, pre-listen realtime binding, and signal-driven shutdown ownership discoverable together.',
-  );
-  assert(
-    beginnerGuards.includes('type GuardContext') &&
-      beginnerGuards.includes('canActivate(context: GuardContext)') &&
-      beginnerGuards.includes("context.requestContext.request.headers['x-role']") &&
-      !beginnerGuards.includes('canActivate(input: unknown, ctx: RequestContext)'),
-    'The English guards chapter must use the one-argument GuardContext contract and read request data before DTO binding through requestContext.',
-  );
-  assert(
-    beginnerGuardsKo.includes('type GuardContext') &&
-      beginnerGuardsKo.includes('canActivate(context: GuardContext)') &&
-      beginnerGuardsKo.includes("context.requestContext.request.headers['x-role']") &&
-      !beginnerGuardsKo.includes('canActivate(input: unknown, ctx: RequestContext)'),
-    'The Korean guards chapter must use the one-argument GuardContext contract and read request data before DTO binding through requestContext.',
-  );
-  assert(
-    bunChapter.includes('`@RequestDto(...)`') &&
-      bunChapter.includes('`@FromBody(...)`') &&
-      bunChapter.includes('`@FromHeader(...)`') &&
-      bunChapter.includes('`RequestContext`') &&
-      !bunChapter.includes('`@Body()`') &&
-      !bunChapter.includes('`@Headers()`'),
-    'The English Bun chapter must document fluo DTO field binding and explicit RequestContext instead of NestJS parameter decorators.',
-  );
-  assert(
-    bunChapterKo.includes('`@RequestDto(...)`') &&
-      bunChapterKo.includes('`@FromBody(...)`') &&
-      bunChapterKo.includes('`@FromHeader(...)`') &&
-      bunChapterKo.includes('`RequestContext`') &&
-      !bunChapterKo.includes('`@Body()`') &&
-      !bunChapterKo.includes('`@Headers()`'),
-    'The Korean Bun chapter must document fluo DTO field binding and explicit RequestContext instead of NestJS parameter decorators.',
   );
   assert(
     docsContext.includes('docs/reference/package-chooser.md') && docsContext.includes('@fluojs/i18n'),
@@ -2548,6 +2566,7 @@ export function main() {
   enforceConfigNestjsMigrationDocs();
   enforceExpressRuntimeMigrationDocsSync();
   enforceCanonicalRuntimeMatrixReferences();
+  enforceHttpBookRequestContracts();
   enforceRemovedRuntimeFactoryNamesNotUsedInDocs();
   enforceNoDirectProcessEnvInOrdinaryPackageSource();
   enforceNoNodeGlobalBufferInDenoAndCloudflareWorkerServices();

--- a/tooling/governance/verify-platform-consistency-governance.test.ts
+++ b/tooling/governance/verify-platform-consistency-governance.test.ts
@@ -77,6 +77,7 @@ async function loadGovernanceInternals() {
     enforceAdvancedBookCoreBoundaryCompanions: (changedFiles: string[]) => void;
     enforceContractCompanionUpdates: (changedFiles: string[]) => void;
     enforceDenoPermissionGuidance: (readText?: (relativePath: string) => string) => void;
+    enforceHttpBookRequestContracts: (readText?: (relativePath: string) => string) => void;
   };
 }
 
@@ -315,6 +316,53 @@ describe('enforceDenoPermissionGuidance', () => {
 
     expect(() => enforceDenoPermissionGuidance()).not.toThrow();
   });
+});
+
+describe('enforceHttpBookRequestContracts', () => {
+  const guardRegressionCases = [
+    'book/beginner/ch09-guards-interceptors.md',
+    'book/beginner/ch09-guards-interceptors.ko.md',
+  ] as const;
+  const bunRegressionCases = [
+    'book/intermediate/ch22-bun.md',
+    'book/intermediate/ch22-bun.ko.md',
+  ] as const;
+
+  it('accepts the current bilingual Guard and Bun request-binding examples', async () => {
+    const { enforceHttpBookRequestContracts } = await loadGovernanceInternals();
+
+    expect(() => enforceHttpBookRequestContracts()).not.toThrow();
+  });
+
+  it.each(guardRegressionCases)('rejects an additional two-argument Guard signature in %s', async (targetPath) => {
+    const { enforceHttpBookRequestContracts } = await loadGovernanceInternals();
+
+    expect(() => enforceHttpBookRequestContracts((relativePath) => {
+      const content = readFileSync(join(repoRoot, relativePath), 'utf8');
+      return relativePath === targetPath
+        ? `${content}\n\n\`\`\`typescript\ncanActivate(input, ctx) {\n  return ctx.requestContext.request.headers['x-role'];\n}\n\`\`\`\n`
+        : content;
+    })).toThrowError(/one-argument GuardContext signature/u);
+  });
+
+  it.each(bunRegressionCases)(
+    'rejects decoy RequestContext text when second controller argument guidance is removed from %s',
+    async (targetPath) => {
+      const { enforceHttpBookRequestContracts } = await loadGovernanceInternals();
+
+      expect(() => enforceHttpBookRequestContracts((relativePath) => {
+        const content = readFileSync(join(repoRoot, relativePath), 'utf8');
+        return relativePath === targetPath
+          ? content.split(/\n\s*\n/gu).map((paragraph) =>
+            paragraph.includes('`@RequestDto(...)`') &&
+              paragraph.includes('`@FromBody(...)`') &&
+              paragraph.includes('`@FromHeader(...)`')
+              ? '`@RequestDto(...)`, `@FromBody(...)`, and `@FromHeader(...)` stay portable. `RequestContext` is public.'
+              : paragraph).join('\n\n')
+          : content;
+      })).toThrowError(/second controller argument/u);
+    },
+  );
 });
 
 describe('enforceCloudflareWorkersLifecycleDocsSync', () => {


### PR DESCRIPTION
## Summary

Correct the official EN/KO book examples so they match the existing `@fluojs/http` Guard and request-binding contracts.

Linked context: https://github.com/fluojs/fluo/issues/3057

Closes #3057

## Changes

- Update the beginner Guard example to receive one `GuardContext` and inspect `context.requestContext` before DTO binding.
- Replace NestJS-style Bun chapter parameter decorator references with `@RequestDto(...)`, `@FromBody(...)`, `@FromHeader(...)`, and explicit `RequestContext` guidance.
- Strengthen the platform consistency governance verifier so these EN/KO book contracts cannot drift back.

## Testing

- `pnpm docs:sync-check`
- `pnpm verify:platform-consistency-governance`
- `pnpm vitest run tooling/governance/verify-platform-consistency-governance.test.ts` (126 passed)
- `pnpm exec vitest run packages/websockets/src/tutorial-api-drift.test.ts` (6 passed)
- `pnpm exec biome check tooling/governance/verify-platform-consistency-governance.mjs`
- Changed-file diagnostics: no diagnostics for the modified `.mjs`; Markdown LSP is not configured, so Markdown correctness is covered by locale parity and governance checks.

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

Docs-only correction to existing `@fluojs/http` behavior. No package source, public API, published package contents, or runtime behavior changed, so no `.changeset/*.md` was added.

## Public export documentation

Not applicable: no public exports or source TSDoc changed.

- [x] Changed public exports include a source-level summary. (N/A: no public exports changed)
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable. (N/A: no exported functions changed)
- [x] Source `@example` blocks and README scenario examples still play complementary roles. (N/A: book-only examples corrected)

## Behavioral contract

This PR preserves the existing Guard ordering and request-binding behavior documented by `packages/http/README.md` and implemented in `packages/http/src/types.ts` plus `packages/http/src/dispatch/dispatch-handler-policy.ts`.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README. (N/A: no new contract)
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests. (Existing runtime tests; this PR adds focused documentation governance assertions)

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. (N/A: no platform contract changed; focused governance enforcement added)
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests. (N/A: no README or adapter conformance claim changed)