### PR TITLE
Resolve #3067: Reject unsupported OpenAPI Path Item keys

### DIFF
--- a/.changeset/strict-openapi-path-items.md
+++ b/.changeset/strict-openapi-path-items.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/openapi': patch
+---
+
+Reject unsupported handler methods and transformed Path Item keys instead of emitting invalid OpenAPI 3.1 documents.

--- a/book/beginner/ch10-openapi.ko.md
+++ b/book/beginner/ch10-openapi.ko.md
@@ -98,6 +98,8 @@ export class AppModule {}
 
 `sources`에서 발견한 descriptor와 explicit `descriptors` 항목이 같은 OpenAPI path 및 HTTP method로 해석되면 나중 descriptor가 우선합니다. `OpenApiModule`은 discovered source를 먼저, explicit descriptor를 나중에 합성하므로 충돌 시 explicit descriptor가 의도적인 override 지점입니다.
 
+OpenAPI Path Item은 Fluo의 runtime 전용 `@All(...)` catch-all을 하나의 operation으로 표현할 수 없습니다. 문서화할 endpoint가 여러 method를 지원한다면 explicit standard-method handler를 선언하세요. Builder는 잘못된 OpenAPI 3.1 출력을 만들지 않도록 `ALL`과 기타 unsupported descriptor method를 거부합니다. `documentTransform`은 standard Path Item field, `trace`, `x-*` extension을 추가할 수 있지만 `all`, `query` 같은 알 수 없는 key는 문서를 제공하기 전에 거부됩니다.
+
 ## 10.3 Adding Documentation Decorators to FluoBlog
 
 모듈 등록이 끝나면 API의 "뼈대"는 이미 문서화됩니다. 하지만 operation summary나 구체적인 응답 설명 같은 인간 친화적인 디테일은 부족할 것입니다. 이를 위해 문서화 데코레이터를 사용합니다.
@@ -334,6 +336,7 @@ fluo는 HTTP route rule로 이 path들을 정규화합니다. 두 OpenAPI module
 - FluoBlog은 이제 기계가 읽는 `/openapi.json`과, `ui: true`로 opt-in했기 때문에 인간이 읽는 `/docs` 인터랙티브 UI를 노출하며, `documentPath`와 `uiPath`로 여러 document instance를 분리할 수 있습니다.
 - 메타데이터 재사용 덕분에 유효성 검사 규칙과 DTO 형태가 문서와 자동으로 동기화됩니다.
 - 허용되는 legacy `nullable` metadata는 OpenAPI 3.0 전용 keyword가 아니라 유효한 OpenAPI 3.1 null union으로 생성됩니다.
+- Descriptor method와 transform된 Path Item key를 검증하여 runtime 전용 `ALL` 또는 알 수 없는 field가 OpenAPI 3.1 문서에 들어가지 못하게 합니다.
 - 결정론적인 문서 출력은 API "계약"이 안정적이고 전문적으로 유지되도록 돕습니다.
 - 이제 Part 1이 끝났습니다. 라우팅, 검증, 직렬화, 보호, 문서화가 완료된 HTTP API를 갖게 되었습니다.
 

--- a/book/beginner/ch10-openapi.md
+++ b/book/beginner/ch10-openapi.md
@@ -98,6 +98,8 @@ This explicitness matches the rest of the framework's philosophy. **Important th
 
 If a descriptor discovered from `sources` and an explicit entry in `descriptors` resolve to the same OpenAPI path and HTTP method, the later descriptor wins. `OpenApiModule` composes discovered sources first and explicit descriptors second, so the explicit descriptor is the intentional override point for a collision.
 
+OpenAPI Path Items cannot represent Fluo's runtime-only `@All(...)` catch-all as one operation. If a documented endpoint supports several methods, declare explicit standard-method handlers instead. The builder rejects `ALL` and other unsupported descriptor methods rather than producing invalid OpenAPI 3.1 output. A `documentTransform` may add standard Path Item fields, `trace`, or `x-*` extensions, but unknown keys such as `all` and `query` are rejected before serving the document.
+
 ## 10.3 Adding Documentation Decorators to FluoBlog
 
 Once the Module is registered, the API's "skeleton" is already documented. It will still lack human-friendly details such as operation summaries or specific response descriptions. Documentation Decorators fill that gap.
@@ -334,6 +336,7 @@ Following this pattern gives users a clean and organized documentation experienc
 - FluoBlog now exposes machine-readable `/openapi.json` and, because it opts into `ui: true`, a human-readable `/docs` interactive UI; `documentPath` and `uiPath` can separate multiple document instances.
 - Metadata reuse keeps validation rules and DTO shapes synchronized automatically with the documentation.
 - Accepted legacy `nullable` metadata is emitted as valid OpenAPI 3.1 null unions rather than the OpenAPI 3.0-only keyword.
+- Descriptor methods and transformed Path Item keys are validated so runtime-only `ALL` or unknown fields cannot escape into the OpenAPI 3.1 document.
 - Deterministic documentation output helps the API "contract" stay stable and professional.
 - Part 1 is now complete. You have an HTTP API with routing, validation, serialization, protection, and documentation.
 

--- a/docs/architecture/openapi.ko.md
+++ b/docs/architecture/openapi.ko.md
@@ -22,6 +22,7 @@
 | --- | --- | --- |
 | 기본 문서 버전 | `buildOpenApiDocument(...)`는 항상 `openapi: '3.1.0'`을 생성합니다. | `packages/openapi/src/schema-builder.ts` |
 | HTTP 라우트 메타데이터 | 경로, HTTP 메서드, 핸들러 이름, 해석된 URI 버전 경로는 fluo HTTP handler descriptor에서 옵니다. Express 스타일 `:id` 경로 세그먼트는 최종 문서에서 `{id}`로 변환됩니다. | `packages/openapi/src/schema-builder.ts` |
+| Descriptor method 검증 | Descriptor operation은 fluo가 작성할 수 있는 OpenAPI Path Item method인 `GET`, `PUT`, `POST`, `DELETE`, `OPTIONS`, `HEAD`, `PATCH`로 제한됩니다. Runtime 전용 `ALL` 및 향후 또는 custom unsupported method는 operation을 생성하기 전에 문서 생성을 실패시킵니다. | `packages/openapi/src/path-item.ts`, `packages/openapi/src/schema-builder.ts`, `packages/openapi/src/path-item.test.ts` |
 | 컨트롤러 태그 | `@ApiTag(...)`가 컨트롤러 태그를 정의합니다. 없으면 컨트롤러 클래스 이름이 기본 태그가 됩니다. | `packages/openapi/src/decorators.ts`, `packages/openapi/src/schema-builder.ts` |
 | 오퍼레이션 메타데이터 | `@ApiOperation(...)`는 핸들러별 `summary`, `description`, `deprecated` 플래그를 저장합니다. | `packages/openapi/src/decorators.ts` |
 | 응답 메타데이터 | `@ApiResponse(...)`는 명시적 status/description/schema/type 메타데이터를 저장합니다. DTO `type` 값은 component schema reference로 변환됩니다. Handler 반환값과 TypeScript 반환 타입은 검사하지 않습니다. `@ApiResponse(...)`가 없으면 builder는 추론된 response schema가 아니라 method-derived 또는 `@HttpCode(...)` success status와 `OK` description만 생성합니다. | `packages/openapi/src/decorators.ts`, `packages/openapi/src/schema-builder.ts` |
@@ -39,12 +40,13 @@
 | Swagger UI | `ui: true`일 때 `GET uiPath`는 runtime global prefix 아래에서도 해당 module instance의 `documentPath`를 가리키는 HTML을 렌더링합니다. `uiPath`의 기본값은 `/docs`입니다. 기본 asset은 고정된 `swagger-ui-dist` 버전 `5.32.2`를 사용하며, self-hosted 또는 CSP-controlled deployment에서는 `swaggerUiAssets.cssUrl`과 `swaggerUiAssets.jsBundleUrl`로 URL을 교체할 수 있습니다. | `packages/openapi/src/openapi-module.ts`, `packages/openapi/src/swagger-ui.ts` |
 | 기본 오류 응답 | `defaultErrorResponsesPolicy`의 기본값은 `'inject'`입니다. `'omit'`으로 설정하면 builder가 프레임워크 기본 오류 응답을 추가하지 않을 수 있습니다. | `packages/openapi/src/schema-builder.ts`, `packages/openapi/src/openapi-module.ts`, `packages/openapi/src/openapi-module.test.ts` |
 | 추가 모델 | `extraModels`를 사용하면 핸들러에서 직접 발견되지 않는 DTO 생성자도 포함할 수 있습니다. | `packages/openapi/src/openapi-module.ts`, `packages/openapi/src/schema-builder.ts` |
-| 최종 변환 | `documentTransform(document)`는 생성된 문서를 노출 전에 다시 쓸 수 있습니다. OpenAPI 3.1 배타적 경계 및 nullable 정규화는 변환된 결과에 실행됩니다. | `packages/openapi/src/openapi-module.ts`, `packages/openapi/src/schema-bounds.ts` |
+| 최종 변환 | `documentTransform(document)`는 생성된 문서를 노출 전에 다시 쓸 수 있습니다. Path Item은 OpenAPI 3.1 operation(`trace` 포함), fixed field(`$ref`, `summary`, `description`, `servers`, `parameters`), `x-*` extension을 기준으로 검증되며 알 수 없는 key는 생성을 실패시킵니다. 그 뒤 검증된 transform 결과에 배타적 경계 및 nullable 정규화를 실행합니다. | `packages/openapi/src/openapi-module.ts`, `packages/openapi/src/path-item.ts`, `packages/openapi/src/schema-bounds.ts` |
 
 ## 생성 경계
 
 - `@ApiExcludeEndpoint()`는 생성된 `paths`에서 특정 핸들러를 제거하지만, 런타임 라우트 자체를 바꾸지는 않습니다.
 - OpenAPI 생성은 descriptor 기반입니다. `sources`나 `descriptors`에 표현되지 않은 컨트롤러 또는 핸들러는 생성 문서 경계 밖입니다.
+- `@All(...)`은 계속 `@fluojs/http` runtime matching 기능이며 하나의 OpenAPI operation으로 표현할 수 없습니다. 문서화할 동작은 explicit standard-method handler로 나누거나 catch-all descriptor를 OpenAPI 입력에서 제외하세요.
 - Response 생성은 return-value-driven 방식이 아니라 metadata-driven 방식입니다. Client가 문서에서 response content를 확인해야 하면 `@ApiResponse(...)`에 `schema` 또는 `type`을 사용합니다.
 - 이 패키지는 HTTP 표면만 문서화합니다. 비HTTP 전송에 대한 계약은 생성하지 않습니다.
 - Swagger UI는 선택적이며 런타임에서 제공됩니다. UI 지원이 비활성화되어도 OpenAPI JSON 문서는 계속 제공됩니다.

--- a/docs/architecture/openapi.md
+++ b/docs/architecture/openapi.md
@@ -22,6 +22,7 @@ This document defines the current OpenAPI document-generation contract implement
 | --- | --- | --- |
 | Base document version | `buildOpenApiDocument(...)` always emits `openapi: '3.1.0'`. | `packages/openapi/src/schema-builder.ts` |
 | HTTP route metadata | Paths, HTTP methods, handler names, and resolved URI-versioned routes come from fluo HTTP handler descriptors. Express-style `:id` path segments are converted to `{id}` in the final document. | `packages/openapi/src/schema-builder.ts` |
+| Descriptor method validation | Descriptor operations are limited to OpenAPI Path Item methods that fluo can author: `GET`, `PUT`, `POST`, `DELETE`, `OPTIONS`, `HEAD`, and `PATCH`. Runtime-only `ALL` and any future or custom unsupported method fail generation before operation emission. | `packages/openapi/src/path-item.ts`, `packages/openapi/src/schema-builder.ts`, `packages/openapi/src/path-item.test.ts` |
 | Controller tags | `@ApiTag(...)` defines controller tags. If absent, the controller class name becomes the default tag. | `packages/openapi/src/decorators.ts`, `packages/openapi/src/schema-builder.ts` |
 | Operation metadata | `@ApiOperation(...)` stores `summary`, `description`, and `deprecated` flags per handler. | `packages/openapi/src/decorators.ts` |
 | Response metadata | `@ApiResponse(...)` stores explicit status/description/schema/type metadata. DTO `type` values become component schema references. Handler return values and TypeScript return types are not inspected. Without `@ApiResponse(...)`, the builder emits only a method-derived or `@HttpCode(...)` success status with description `OK`, not an inferred response schema. | `packages/openapi/src/decorators.ts`, `packages/openapi/src/schema-builder.ts` |
@@ -39,12 +40,13 @@ This document defines the current OpenAPI document-generation contract implement
 | Swagger UI | With `ui: true`, `GET uiPath` renders HTML that points to that module instance's `documentPath`, including under a runtime global prefix. `uiPath` defaults to `/docs`. The default assets use the pinned `swagger-ui-dist` version `5.32.2`; `swaggerUiAssets.cssUrl` and `swaggerUiAssets.jsBundleUrl` can replace those URLs for self-hosted or CSP-controlled deployments. | `packages/openapi/src/openapi-module.ts`, `packages/openapi/src/swagger-ui.ts` |
 | Default error responses | `defaultErrorResponsesPolicy` defaults to `'inject'`. The builder can also omit framework-added defaults when set to `'omit'`. | `packages/openapi/src/schema-builder.ts`, `packages/openapi/src/openapi-module.ts`, `packages/openapi/src/openapi-module.test.ts` |
 | Extra models | `extraModels` lets the module include DTO constructors that are not otherwise discovered from handlers. | `packages/openapi/src/openapi-module.ts`, `packages/openapi/src/schema-builder.ts` |
-| Final transform | `documentTransform(document)` can rewrite the generated document before it is exposed. OpenAPI 3.1 exclusive-bound and nullable normalization runs on the transformed result. | `packages/openapi/src/openapi-module.ts`, `packages/openapi/src/schema-bounds.ts` |
+| Final transform | `documentTransform(document)` can rewrite the generated document before it is exposed. Its Path Items are validated against OpenAPI 3.1 operations (including `trace`), fixed fields (`$ref`, `summary`, `description`, `servers`, `parameters`), and `x-*` extensions; unknown keys fail generation. Exclusive-bound and nullable normalization then runs on the validated transformed result. | `packages/openapi/src/openapi-module.ts`, `packages/openapi/src/path-item.ts`, `packages/openapi/src/schema-bounds.ts` |
 
 ## Generation Boundaries
 
 - `@ApiExcludeEndpoint()` removes one handler from generated `paths`, but it does not change the runtime route itself.
 - OpenAPI generation is descriptor-driven. Controllers or handlers not represented in `sources` or `descriptors` are outside the generated document boundary.
+- `@All(...)` remains an `@fluojs/http` runtime matching feature and cannot be represented as one OpenAPI operation. Split documented behavior into explicit standard-method handlers or leave the catch-all descriptor outside the OpenAPI input.
 - Response generation is metadata-driven rather than return-value-driven. Use `@ApiResponse(...)` with `schema` or `type` when clients need response content in the document.
 - The package documents the HTTP surface only. It does not generate contracts for non-HTTP transports.
 - Swagger UI is optional and runtime-served; the OpenAPI JSON document remains available even when UI support is disabled.

--- a/packages/openapi/README.ko.md
+++ b/packages/openapi/README.ko.md
@@ -77,6 +77,11 @@ await app.listen(3000);
 ### 자동 명세 생성
 fluo는 `sources`와 `descriptors`로 전달된 controller 및 handler descriptor만 조사하여 OpenAPI 3.1.0 문서를 작성합니다. 이 명시적 입력 집합의 경로, 메서드, 파라미터, 요청 바디가 포함되며, controller를 application module에 import하는 것만으로는 자동 추가되지 않습니다.
 
+### OpenAPI 3.1 Path Item 검증
+Builder는 표준 Path Item operation인 `get`, `put`, `post`, `delete`, `options`, `head`, `patch`만 생성합니다. Fluo catch-all `ALL` descriptor는 runtime routing 입력이지 OpenAPI operation이 아니므로, 비표준 `all` key로 직렬화하지 않고 문서 생성을 거부합니다. 지원하지 않는 다른 descriptor method도 같은 path-specific error로 실패합니다.
+
+`documentTransform` 이후에는 모든 Path Item을 다시 검증합니다. Transform은 OpenAPI 3.1 operation(`trace` 포함), fixed field(`$ref`, `summary`, `description`, `servers`, `parameters`), `x-*` specification extension을 사용할 수 있습니다. `all`, `query` 또는 기타 알 수 없는 key는 문서가 노출되기 전에 생성을 실패시킵니다.
+
 ### 응답 미디어 타입
 HTTP 핸들러가 `@fluojs/http`의 `@Produces(...)`를 선언하면, 생성된 OpenAPI 응답은 해당 미디어 타입을 response `content` 키로 사용합니다. 예를 들어 `@ApiResponse(...)` 스키마가 있는 핸들러에 `@Produces('application/json', 'application/problem+json')`를 붙이면, `application/json`만으로 되돌아가지 않고 두 미디어 타입 모두 같은 응답 스키마로 방출합니다.
 

--- a/packages/openapi/README.md
+++ b/packages/openapi/README.md
@@ -77,6 +77,11 @@ When a prebuilt descriptor and a discovered source resolve to the same OpenAPI p
 ### Automated Specification Generation
 fluo inspects only the controllers and handler descriptors supplied through `sources` and `descriptors` to build an OpenAPI 3.1.0 document. This includes paths, methods, parameters, and request bodies for that explicit input set; importing a controller into an application module does not add it automatically.
 
+### OpenAPI 3.1 Path Item Validation
+The builder emits only standard Path Item operations: `get`, `put`, `post`, `delete`, `options`, `head`, and `patch`. Fluo catch-all `ALL` descriptors are runtime routing inputs, not OpenAPI operations, so document generation rejects them instead of serializing a nonstandard `all` key. Unsupported descriptor methods fail with the same path-specific error.
+
+After `documentTransform`, every Path Item is validated again. Transforms may use the OpenAPI 3.1 operations (including `trace`), fixed fields (`$ref`, `summary`, `description`, `servers`, and `parameters`), and `x-*` specification extensions. Keys such as `all`, `query`, or other unknown fields fail document generation before the document is exposed.
+
 ### Response Media Types
 When an HTTP handler declares `@Produces(...)` from `@fluojs/http`, generated OpenAPI responses use those media types as the response `content` keys. For example, `@Produces('application/json', 'application/problem+json')` on a handler with an `@ApiResponse(...)` schema emits both media types with the same response schema instead of silently falling back to only `application/json`.
 

--- a/packages/openapi/src/path-item-exclusion.test.ts
+++ b/packages/openapi/src/path-item-exclusion.test.ts
@@ -1,0 +1,28 @@
+import { All, Controller, createHandlerMapping } from '@fluojs/http';
+import { describe, expect, it } from 'vitest';
+
+import { ApiExcludeEndpoint } from './decorators.js';
+import { buildOpenApiDocument } from './schema-builder.js';
+
+describe('OpenAPI Path Item exclusion', () => {
+  it('omits excluded ALL descriptors before validating their operation method', () => {
+    // Given
+    @Controller('/fallback')
+    class FallbackController {
+      @ApiExcludeEndpoint()
+      @All('/') handle() { return undefined; }
+    }
+    const descriptors = createHandlerMapping([{ controllerToken: FallbackController }]).descriptors;
+
+    // When
+    const document = buildOpenApiDocument({
+      defaultErrorResponsesPolicy: 'omit',
+      descriptors,
+      title: 'Excluded Path Item API',
+      version: '1.0.0',
+    });
+
+    // Then
+    expect(document.paths).toEqual({});
+  });
+});

--- a/packages/openapi/src/path-item.test.ts
+++ b/packages/openapi/src/path-item.test.ts
@@ -1,0 +1,155 @@
+import {
+  All,
+  Controller,
+  createHandlerMapping,
+  Delete,
+  Get,
+  Head,
+  Options,
+  Patch,
+  Post,
+  Put,
+} from '@fluojs/http';
+import { describe, expect, it } from 'vitest';
+
+import { buildOpenApiDocument } from './schema-builder.js';
+
+const DOCUMENT_OPTIONS = {
+  defaultErrorResponsesPolicy: 'omit' as const,
+  title: 'Path Item API',
+  version: '1.0.0',
+};
+
+describe('OpenAPI Path Item validation', () => {
+  it('rejects ALL descriptors instead of emitting a nonstandard operation', () => {
+    // Given
+    @Controller('/fallback')
+    class FallbackController {
+      @All('/') handle() { return undefined; }
+    }
+    const descriptors = createHandlerMapping([{ controllerToken: FallbackController }]).descriptors;
+
+    // When
+    const buildDocument = () => buildOpenApiDocument({ ...DOCUMENT_OPTIONS, descriptors });
+
+    // Then
+    expect(buildDocument).toThrow('OpenAPI cannot document unsupported HTTP method "ALL" for path "/fallback".');
+  });
+
+  it.each(['QUERY', 'BREW'])('rejects unsupported %s descriptor methods deterministically', (method) => {
+    // Given
+    @Controller('/unsupported')
+    class UnsupportedController {
+      @Get('/') handle() { return undefined; }
+    }
+    const descriptors = createHandlerMapping([{ controllerToken: UnsupportedController }]).descriptors;
+    const descriptor = descriptors[0];
+    if (descriptor === undefined) {
+      throw new TypeError('Expected the unsupported-method fixture to create one descriptor.');
+    }
+    Reflect.set(descriptor.route, 'method', method);
+
+    // When
+    const buildDocument = () => buildOpenApiDocument({ ...DOCUMENT_OPTIONS, descriptors });
+
+    // Then
+    expect(buildDocument).toThrow(`OpenAPI cannot document unsupported HTTP method "${method}" for path "/unsupported".`);
+  });
+
+  it('emits every operation supported by Fluo descriptors', () => {
+    // Given
+    @Controller('/methods')
+    class MethodsController {
+      @Get('/') get() { return undefined; }
+      @Put('/') put() { return undefined; }
+      @Post('/') post() { return undefined; }
+      @Delete('/') delete() { return undefined; }
+      @Options('/') options() { return undefined; }
+      @Head('/') head() { return undefined; }
+      @Patch('/') patch() { return undefined; }
+    }
+    const descriptors = createHandlerMapping([{ controllerToken: MethodsController }]).descriptors;
+
+    // When
+    const document = buildOpenApiDocument({ ...DOCUMENT_OPTIONS, descriptors });
+
+    // Then
+    expect(Object.keys(document.paths['/methods'] ?? {}).sort()).toEqual([
+      'delete', 'get', 'head', 'options', 'patch', 'post', 'put',
+    ]);
+    expect(document.openapi).toBe('3.1.0');
+  });
+
+  it.each(['all', 'query', 'connect'])('rejects transformed Path Item key %s', (key) => {
+    // Given
+    @Controller('/health')
+    class HealthController {
+      @Get('/') getHealth() { return undefined; }
+    }
+    const descriptors = createHandlerMapping([{ controllerToken: HealthController }]).descriptors;
+
+    // When
+    const buildDocument = () => buildOpenApiDocument({
+      ...DOCUMENT_OPTIONS,
+      descriptors,
+      documentTransform: (document) => {
+        const pathItem = document.paths['/health'];
+        if (pathItem === undefined) {
+          throw new TypeError('Expected the transformed document to contain the health path.');
+        }
+        Reflect.set(pathItem, key, pathItem.get);
+        return document;
+      },
+    });
+
+    // Then
+    expect(buildDocument).toThrow(`OpenAPI Path Item for path "/health" contains unsupported key "${key}".`);
+  });
+
+  it('preserves transformed trace, fixed fields, and specification extensions', () => {
+    // Given
+    @Controller('/health')
+    class HealthController {
+      @Get('/') getHealth() { return undefined; }
+    }
+    const descriptors = createHandlerMapping([{ controllerToken: HealthController }]).descriptors;
+
+    // When
+    const document = buildOpenApiDocument({
+      ...DOCUMENT_OPTIONS,
+      descriptors,
+      documentTransform: (generatedDocument) => {
+        const operation = generatedDocument.paths['/health']?.get;
+        if (operation === undefined) {
+          throw new TypeError('Expected the transformed document to contain the health GET operation.');
+        }
+        return {
+          ...generatedDocument,
+          paths: {
+            '/health': {
+              $ref: '#/components/pathItems/Health',
+              description: 'Health operations',
+              parameters: [{ in: 'header', name: 'x-request-id', schema: { type: 'string' } }],
+              servers: [{ url: 'https://api.example.com' }],
+              summary: 'Health',
+              trace: { ...operation, operationId: 'traceHealth' },
+              'x-owner': 'platform',
+            },
+          },
+        };
+      },
+    });
+
+    // Then
+    expect(document.paths['/health']).toEqual({
+      $ref: '#/components/pathItems/Health',
+      description: 'Health operations',
+      parameters: [{ in: 'header', name: 'x-request-id', schema: { type: 'string' } }],
+      servers: [{ url: 'https://api.example.com' }],
+      summary: 'Health',
+      trace: expect.objectContaining({ operationId: 'traceHealth' }),
+      'x-owner': 'platform',
+    });
+    expect(JSON.parse(JSON.stringify(document))).toMatchObject({ openapi: '3.1.0' });
+  });
+});

--- a/packages/openapi/src/path-item.test.ts
+++ b/packages/openapi/src/path-item.test.ts
@@ -20,6 +20,32 @@ const DOCUMENT_OPTIONS = {
   version: '1.0.0',
 };
 
+function resolveLocalJsonPointerTarget(value: unknown, pointer: string): unknown {
+  if (!pointer.startsWith('#/')) {
+    return undefined;
+  }
+
+  return decodeURIComponent(pointer.slice(2)).split('/').reduce<unknown>((current, token) => {
+    if (typeof current !== 'object' || current === null) {
+      return undefined;
+    }
+
+    return Reflect.get(current, token.replaceAll('~1', '/').replaceAll('~0', '~'));
+  }, value);
+}
+
+function collectLocalJsonReferences(value: unknown): string[] {
+  if (typeof value !== 'object' || value === null) {
+    return [];
+  }
+
+  const reference = Reflect.get(value, '$ref');
+  return [
+    ...(typeof reference === 'string' && reference.startsWith('#/') ? [reference] : []),
+    ...Object.values(value).flatMap(collectLocalJsonReferences),
+  ];
+}
+
 describe('OpenAPI Path Item validation', () => {
   it('rejects ALL descriptors instead of emitting a nonstandard operation', () => {
     // Given
@@ -106,6 +132,41 @@ describe('OpenAPI Path Item validation', () => {
     expect(buildDocument).toThrow(`OpenAPI Path Item for path "/health" contains unsupported key "${key}".`);
   });
 
+  it('normalizes schemas in transformed Path Item parameters', () => {
+    // Given
+    const descriptors: readonly [] = [];
+
+    // When
+    const document = buildOpenApiDocument({
+      ...DOCUMENT_OPTIONS,
+      descriptors,
+      documentTransform: (generatedDocument) => ({
+        ...generatedDocument,
+        paths: {
+          '/scores': {
+            parameters: [{
+              in: 'query',
+              name: 'minimum-score',
+              schema: {
+                exclusiveMinimum: true,
+                minimum: 0,
+                nullable: true,
+                type: 'number',
+              },
+            }],
+          },
+        },
+      }),
+    });
+
+    // Then
+    expect(document.paths['/scores']?.parameters).toEqual([{
+      in: 'query',
+      name: 'minimum-score',
+      schema: { exclusiveMinimum: 0, type: ['number', 'null'] },
+    }]);
+  });
+
   it('preserves transformed trace, fixed fields, and specification extensions', () => {
     // Given
     @Controller('/health')
@@ -127,13 +188,16 @@ describe('OpenAPI Path Item validation', () => {
           ...generatedDocument,
           paths: {
             '/health': {
-              $ref: '#/components/pathItems/Health',
               description: 'Health operations',
+              get: operation,
               parameters: [{ in: 'header', name: 'x-request-id', schema: { type: 'string' } }],
               servers: [{ url: 'https://api.example.com' }],
               summary: 'Health',
               trace: { ...operation, operationId: 'traceHealth' },
               'x-owner': 'platform',
+            },
+            '/health-reference': {
+              $ref: '#/paths/~1health',
             },
           },
         };
@@ -142,14 +206,37 @@ describe('OpenAPI Path Item validation', () => {
 
     // Then
     expect(document.paths['/health']).toEqual({
-      $ref: '#/components/pathItems/Health',
       description: 'Health operations',
+      get: expect.objectContaining({ responses: { 200: { description: 'OK' } } }),
       parameters: [{ in: 'header', name: 'x-request-id', schema: { type: 'string' } }],
       servers: [{ url: 'https://api.example.com' }],
       summary: 'Health',
       trace: expect.objectContaining({ operationId: 'traceHealth' }),
       'x-owner': 'platform',
     });
-    expect(JSON.parse(JSON.stringify(document))).toMatchObject({ openapi: '3.1.0' });
+    expect(document.paths['/health-reference']).toEqual({ $ref: '#/paths/~1health' });
+    const serializedDocument: unknown = JSON.parse(JSON.stringify(document));
+    expect(serializedDocument).toMatchObject({
+      info: {
+        title: 'Path Item API',
+        version: '1.0.0',
+      },
+      openapi: '3.1.0',
+      paths: {
+        '/health': {
+          get: { responses: { 200: { description: 'OK' } } },
+          trace: { responses: { 200: { description: 'OK' } } },
+        },
+        '/health-reference': { $ref: '#/paths/~1health' },
+      },
+    });
+    const localReferences = collectLocalJsonReferences(serializedDocument);
+    expect(localReferences).toEqual(['#/paths/~1health']);
+    expect(localReferences.filter((reference) => resolveLocalJsonPointerTarget(serializedDocument, reference) === undefined))
+      .toEqual([]);
+    expect(resolveLocalJsonPointerTarget(serializedDocument, '#/paths/~1health')).toMatchObject({
+      get: { responses: { 200: { description: 'OK' } } },
+      trace: { responses: { 200: { description: 'OK' } } },
+    });
   });
 });

--- a/packages/openapi/src/path-item.ts
+++ b/packages/openapi/src/path-item.ts
@@ -1,0 +1,109 @@
+import type { OpenApiOperationObject, OpenApiParameterObject } from './schema-builder.js';
+
+/** Standard OpenAPI 3.1 operation keys accepted on a Path Item Object. */
+export type OpenApiOperationMethod = 'delete' | 'get' | 'head' | 'options' | 'patch' | 'post' | 'put' | 'trace';
+
+interface OpenApiReferenceObject {
+  $ref: string;
+  summary?: string;
+  description?: string;
+}
+
+interface OpenApiServerObject {
+  url: string;
+  description?: string;
+  variables?: Record<string, {
+    default: string;
+    description?: string;
+    enum?: string[];
+  }>;
+}
+
+/**
+ * OpenAPI Path Item Object containing standard operations, fixed fields, and specification extensions.
+ */
+export interface OpenApiPathItemObject {
+  $ref?: string;
+  summary?: string;
+  description?: string;
+  servers?: OpenApiServerObject[];
+  parameters?: (OpenApiParameterObject | OpenApiReferenceObject)[];
+  delete?: OpenApiOperationObject;
+  get?: OpenApiOperationObject;
+  head?: OpenApiOperationObject;
+  options?: OpenApiOperationObject;
+  patch?: OpenApiOperationObject;
+  post?: OpenApiOperationObject;
+  put?: OpenApiOperationObject;
+  trace?: OpenApiOperationObject;
+  [extension: `x-${string}`]: unknown;
+}
+
+const OPENAPI_PATH_ITEM_FIXED_FIELDS: ReadonlySet<string> = new Set([
+  '$ref',
+  'description',
+  'parameters',
+  'servers',
+  'summary',
+]);
+
+const DESCRIPTOR_OPERATION_METHODS: ReadonlyMap<string, OpenApiOperationMethod> = new Map([
+  ['DELETE', 'delete'],
+  ['GET', 'get'],
+  ['HEAD', 'head'],
+  ['OPTIONS', 'options'],
+  ['PATCH', 'patch'],
+  ['POST', 'post'],
+  ['PUT', 'put'],
+]);
+
+const OPENAPI_OPERATION_METHODS: ReadonlySet<string> = new Set<OpenApiOperationMethod>([
+  ...DESCRIPTOR_OPERATION_METHODS.values(),
+  'trace',
+]);
+
+/**
+ * Resolve one Fluo descriptor method to its standard OpenAPI operation key.
+ *
+ * @param method Descriptor method supplied by HTTP route metadata.
+ * @param path OpenAPI path used to identify invalid descriptor input.
+ * @returns The corresponding standard OpenAPI operation key.
+ * @throws {TypeError} When Fluo cannot author the descriptor method as an OpenAPI operation.
+ */
+export function resolveDescriptorOperationMethod(method: string, path: string): OpenApiOperationMethod {
+  const operationMethod = DESCRIPTOR_OPERATION_METHODS.get(method);
+  if (operationMethod !== undefined) {
+    return operationMethod;
+  }
+
+  throw new TypeError(`OpenAPI cannot document unsupported HTTP method "${method}" for path "${path}".`);
+}
+
+/**
+ * Determine whether a Path Item key is a standard OpenAPI 3.1 operation.
+ *
+ * @param key Path Item key to inspect.
+ * @returns Whether the key is a standard operation key.
+ */
+export function isOpenApiOperationMethod(key: string): key is OpenApiOperationMethod {
+  return OPENAPI_OPERATION_METHODS.has(key);
+}
+
+/**
+ * Validate every transformed Path Item against the OpenAPI 3.1 key policy.
+ *
+ * @param paths Final document paths after any caller transform.
+ * @returns Nothing when every Path Item key is valid.
+ * @throws {TypeError} When a Path Item contains an unknown non-extension key.
+ */
+export function validateOpenApiPathItemKeys(paths: Readonly<Record<string, object>>): void {
+  for (const [path, pathItem] of Object.entries(paths)) {
+    for (const key of Object.keys(pathItem)) {
+      if (isOpenApiOperationMethod(key) || OPENAPI_PATH_ITEM_FIXED_FIELDS.has(key) || key.startsWith('x-')) {
+        continue;
+      }
+
+      throw new TypeError(`OpenAPI Path Item for path "${path}" contains unsupported key "${key}".`);
+    }
+  }
+}

--- a/packages/openapi/src/schema-bounds.ts
+++ b/packages/openapi/src/schema-bounds.ts
@@ -1,3 +1,4 @@
+import { isOpenApiOperationMethod } from './path-item.js';
 import type {
   OpenApiDocument,
   OpenApiMediaTypeObject,
@@ -216,10 +217,15 @@ function normalizePaths(
   for (const [path, pathItem] of Object.entries(paths)) {
     const normalizedPathItem: OpenApiPathItemObject = {};
 
-    for (const [method, operation] of Object.entries(pathItem)) {
-      normalizedPathItem[method] = operation
-        ? normalizeOperation(operation, `paths.${path}.${method}`, normalizedSchemas)
-        : undefined;
+    for (const [key, value] of Object.entries(pathItem)) {
+      if (isOpenApiOperationMethod(key)) {
+        normalizedPathItem[key] = value
+          ? normalizeOperation(value, `paths.${path}.${key}`, normalizedSchemas)
+          : undefined;
+        continue;
+      }
+
+      Reflect.set(normalizedPathItem, key, value);
     }
 
     normalizedPaths[path] = normalizedPathItem;

--- a/packages/openapi/src/schema-bounds.ts
+++ b/packages/openapi/src/schema-bounds.ts
@@ -217,7 +217,26 @@ function normalizePaths(
   for (const [path, pathItem] of Object.entries(paths)) {
     const normalizedPathItem: OpenApiPathItemObject = {};
 
+    if (pathItem.parameters) {
+      normalizedPathItem.parameters = pathItem.parameters.map((parameter, index) => (
+        'schema' in parameter
+          ? {
+              ...parameter,
+              schema: normalizeOpenApiSchemaBounds(
+                parameter.schema,
+                `paths.${path}.parameters[${String(index)}].schema`,
+                normalizedSchemas,
+              ),
+            }
+          : { ...parameter }
+      ));
+    }
+
     for (const [key, value] of Object.entries(pathItem)) {
+      if (key === 'parameters') {
+        continue;
+      }
+
       if (isOpenApiOperationMethod(key)) {
         normalizedPathItem[key] = value
           ? normalizeOperation(value, `paths.${path}.${key}`, normalizedSchemas)

--- a/packages/openapi/src/schema-builder.ts
+++ b/packages/openapi/src/schema-builder.ts
@@ -1192,13 +1192,13 @@ function buildOperationEntry(
   usedOperationIds: Set<string>,
 ): BuiltOperationEntry | undefined {
   const openApiPath = expressPathToOpenApi(descriptor.route.path);
-  const method = resolveDescriptorOperationMethod(descriptor.route.method, openApiPath);
   const methodMeta = getMethodApiMetadata(descriptor.controllerToken, descriptor.methodName);
 
   if (methodMeta?.excludeEndpoint === true) {
     return undefined;
   }
 
+  const method = resolveDescriptorOperationMethod(descriptor.route.method, openApiPath);
   const responses = createOperationResponses(
     descriptor,
     methodMeta,

--- a/packages/openapi/src/schema-builder.ts
+++ b/packages/openapi/src/schema-builder.ts
@@ -8,10 +8,17 @@ import {
   getMethodApiMetadata,
   type MethodApiMetadata,
 } from './decorators.js';
+import {
+  type OpenApiOperationMethod,
+  type OpenApiPathItemObject,
+  resolveDescriptorOperationMethod,
+  validateOpenApiPathItemKeys,
+} from './path-item.js';
+
+export type { OpenApiPathItemObject } from './path-item.js';
+
 import { normalizeOpenApiDocumentSchemaBounds } from './schema-bounds.js';
 import { cloneSnapshotValue } from './snapshot.js';
-
-type OpenApiOperationMethod = Lowercase<HttpMethod>;
 
 /**
  * JSON Schema primitive type names accepted by OpenAPI 3.1 schema objects.
@@ -170,13 +177,6 @@ export interface OpenApiOperationObject {
   responses: Record<string, OpenApiResponseObject>;
   requestBody?: OpenApiRequestBodyObject;
   security?: OpenApiSecurityRequirementObject[];
-}
-
-/**
- * OpenAPI path-item object containing one or more HTTP method operations.
- */
-export interface OpenApiPathItemObject {
-  [method: string]: OpenApiOperationObject | undefined;
 }
 
 /**
@@ -1192,7 +1192,7 @@ function buildOperationEntry(
   usedOperationIds: Set<string>,
 ): BuiltOperationEntry | undefined {
   const openApiPath = expressPathToOpenApi(descriptor.route.path);
-  const method = descriptor.route.method.toLowerCase() as OpenApiOperationMethod;
+  const method = resolveDescriptorOperationMethod(descriptor.route.method, openApiPath);
   const methodMeta = getMethodApiMetadata(descriptor.controllerToken, descriptor.methodName);
 
   if (methodMeta?.excludeEndpoint === true) {
@@ -1322,5 +1322,7 @@ export function buildOpenApiDocument(options: BuildOpenApiDocumentOptions): Open
     paths,
   };
 
-  return normalizeOpenApiDocumentSchemaBounds(options.documentTransform ? options.documentTransform(document) : document);
+  const transformedDocument = options.documentTransform ? options.documentTransform(document) : document;
+  validateOpenApiPathItemKeys(transformedDocument.paths);
+  return normalizeOpenApiDocumentSchemaBounds(transformedDocument);
 }


### PR DESCRIPTION
## Summary

Reject unsupported descriptor methods and transformed Path Item keys before `@fluojs/openapi` can expose an invalid OpenAPI 3.1 document.

Linked context: Closes #3067

## Changes

- Restrict descriptor-authored operations to `GET`, `PUT`, `POST`, `DELETE`, `OPTIONS`, `HEAD`, and `PATCH`, with path-specific errors for `ALL`, `QUERY`, and custom methods.
- Validate final `documentTransform` Path Items while preserving standard operations including `trace`, fixed fields, and `x-*` extensions.
- Preserve non-operation Path Item fields during schema normalization and tighten the public `OpenApiPathItemObject` shape.
- Add direct regression coverage plus synchronized EN/KO package, architecture, and beginner documentation.
- Add a patch Changeset for `@fluojs/openapi`.

## Testing

- `pnpm verify:release-readiness` under Node.js `v22.22.1` with a dedicated external CLI sandbox: passed.
  - packages: 384 files, 4424 passed / 1 skipped
  - examples: 8 files, 23 passed
  - tooling: 39 files, 438 passed
  - CLI sandbox matrix: passed
- `pnpm docs:sync-check`: passed (42 EN/KO page pairs, 10 navigation metadata pairs).
- `pnpm verify:platform-consistency-governance`: passed.
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main`: passed.
- Changed TypeScript files: Biome check and package typecheck/build/tests passed; LSP error diagnostics are clean.
- `git diff --check`: passed.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

`.changeset/strict-openapi-path-items.md` records a patch release for `@fluojs/openapi`.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

The existing `OpenApiPathItemObject` public shape is now explicit about standard operations, fixed fields, and `x-*` extensions. Exported validation helpers carry TSDoc, and the repository public-export TSDoc gate passed within release readiness.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

`@All(...)` remains a runtime routing feature but is explicitly unsupported as a single OpenAPI operation; documented endpoints should use standard-method handlers.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests, such as `createPlatformConformanceHarness(...)` for platform component contracts or `createHttpAdapterPortabilityHarness(...)` for HTTP adapter portability contracts.

No platform adapter contract changed. EN/KO OpenAPI package, architecture, and beginner surfaces are synchronized, and the platform consistency governance verifier passed.