### PR TITLE
Resolve #3069: Suppress framework-managed HEAD response bodies

### DIFF
--- a/.changeset/suppress-http-head-response-bodies.md
+++ b/.changeset/suppress-http-head-response-bodies.md
@@ -1,8 +1,11 @@
 ---
 "@fluojs/http": patch
+"@fluojs/platform-express": patch
 "@fluojs/testing": patch
 ---
 
 Suppress framework-managed response bodies for `HEAD` requests while preserving selected status and headers across successful, canonical JSON error, negotiated error, and `406` outcomes.
 
 Extend the shared HTTP adapter portability assertion to cover successful and canonical JSON `HEAD` responses across supported network and fetch-style adapters.
+
+Preserve Express response metadata by committing framework-suppressed `HEAD` bodies without reserializing them as empty text.

--- a/.changeset/suppress-http-head-response-bodies.md
+++ b/.changeset/suppress-http-head-response-bodies.md
@@ -1,0 +1,8 @@
+---
+"@fluojs/http": patch
+"@fluojs/testing": patch
+---
+
+Suppress framework-managed response bodies for `HEAD` requests while preserving selected status and headers across successful, canonical JSON error, negotiated error, and `406` outcomes.
+
+Extend the shared HTTP adapter portability assertion to cover successful and canonical JSON `HEAD` responses across supported network and fetch-style adapters.

--- a/packages/http/src/dispatch/dispatch-error-representation.ts
+++ b/packages/http/src/dispatch/dispatch-error-representation.ts
@@ -1,10 +1,10 @@
 import { HandlerNotFoundError } from '../errors.js';
 import {
+  createErrorResponse,
   HttpException,
   InternalServerErrorException,
   NotAcceptableException,
   NotFoundException,
-  createErrorResponse,
 } from '../exceptions.js';
 import type {
   DispatcherLogger,
@@ -131,7 +131,10 @@ export async function writeErrorResponse(
 
   if (provider === undefined || !isHttpRepresentationEligible(error)) {
     requestContext.response.setStatus(httpError.status);
-    await requestContext.response.send(createErrorResponse(httpError, requestContext.requestId));
+    const body = requestContext.request.method.toUpperCase() === 'HEAD'
+      ? undefined
+      : createErrorResponse(httpError, requestContext.requestId);
+    await requestContext.response.send(body);
     return;
   }
 

--- a/packages/http/src/dispatch/dispatch-error-representation.ts
+++ b/packages/http/src/dispatch/dispatch-error-representation.ts
@@ -131,10 +131,12 @@ export async function writeErrorResponse(
 
   if (provider === undefined || !isHttpRepresentationEligible(error)) {
     requestContext.response.setStatus(httpError.status);
-    const body = requestContext.request.method.toUpperCase() === 'HEAD'
-      ? undefined
-      : createErrorResponse(httpError, requestContext.requestId);
-    await requestContext.response.send(body);
+    if (requestContext.request.method.toUpperCase() === 'HEAD') {
+      requestContext.response.setHeader('Content-Type', JSON_CONTENT_TYPE);
+      await requestContext.response.send(undefined);
+      return;
+    }
+    await requestContext.response.send(createErrorResponse(httpError, requestContext.requestId));
     return;
   }
 

--- a/packages/http/src/dispatch/dispatch-response-policy.test.ts
+++ b/packages/http/src/dispatch/dispatch-response-policy.test.ts
@@ -5,12 +5,13 @@ import {
   Controller,
   createDispatcher,
   createHandlerMapping,
-    type FrameworkRequest,
-    type FrameworkResponse,
-    Get,
-    Header,
-    type MiddlewareContext,
-    type Next,
+  type FrameworkRequest,
+  type FrameworkResponse,
+  Get,
+  Head,
+  Header,
+  type MiddlewareContext,
+  type Next,
 } from '../index.js';
 
 type CustomResponseWriterContext = {
@@ -43,12 +44,16 @@ function createResponse(): FrameworkResponse & { body?: unknown } {
   };
 }
 
-function createRequest(path: string, headers: FrameworkRequest['headers'] = {}): FrameworkRequest {
+function createRequest(
+  path: string,
+  headers: FrameworkRequest['headers'] = {},
+  method: FrameworkRequest['method'] = 'GET',
+): FrameworkRequest {
   return {
     body: undefined,
     cookies: {},
     headers,
-    method: 'GET',
+    method,
     params: {},
     path,
     query: {},
@@ -102,6 +107,40 @@ describe('dispatch response policy', () => {
     expect(response.headers['x-react-route']).toBe('html');
     expect(response.headers['Content-Type']).toBe('text/html; charset=utf-8');
     expect(response.body).toBe('<main>React SSR</main>');
+  });
+
+  it('preserves application-owned custom response writer behavior for HEAD', async () => {
+    const htmlEntry = { html: '<main>Application-owned HEAD body</main>' };
+
+    Object.defineProperty(htmlEntry, Symbol.for('fluo.http.responseWriter'), {
+      enumerable: false,
+      value(context: CustomResponseWriterContext) {
+        context.applySuccessResponseMetadata();
+        context.response.setHeader('Content-Type', 'text/html; charset=utf-8');
+        return context.response.send(htmlEntry.html);
+      },
+    });
+
+    @Controller('/custom-writer-head')
+    class CustomWriterHeadController {
+      @Head('/')
+      head() {
+        return htmlEntry;
+      }
+    }
+
+    const root = new Container().register(CustomWriterHeadController);
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: CustomWriterHeadController }]),
+      rootContainer: root,
+    });
+    const response = createResponse();
+
+    await dispatcher.dispatch(createRequest('/custom-writer-head', {}, 'HEAD'), response);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['Content-Type']).toBe('text/html; charset=utf-8');
+    expect(response.body).toBe('<main>Application-owned HEAD body</main>');
   });
 
   it('finalizes an integration-owned handler value before selecting its response writer', async () => {

--- a/packages/http/src/dispatch/dispatch-response-policy.ts
+++ b/packages/http/src/dispatch/dispatch-response-policy.ts
@@ -202,6 +202,10 @@ export function writeSuccessResponse(
 
   applySuccessResponseMetadata({ formatter, handler, response, value: responseValue });
 
+  if (request.method.toUpperCase() === 'HEAD') {
+    return response.send(undefined);
+  }
+
   if (!formatter && hasSimpleJsonResponseWriter(response) && canUseSimpleJsonFastPath(response, responseValue)) {
     return response.sendSimpleJson(responseValue);
   }

--- a/packages/http/src/dispatch/dispatch-response-policy.ts
+++ b/packages/http/src/dispatch/dispatch-response-policy.ts
@@ -15,6 +15,9 @@ import { writeErrorResponse } from './dispatch-error-policy.js';
 type SimpleJsonResponseBody = Record<string, unknown> | unknown[];
 const responseWriterKey = Symbol.for('fluo.http.responseWriter');
 const responseValueFinalizerKey = Symbol.for('fluo.http.responseValueFinalizer');
+const BINARY_CONTENT_TYPE = 'application/octet-stream';
+const JSON_CONTENT_TYPE = 'application/json; charset=utf-8';
+const TEXT_CONTENT_TYPE = 'text/plain; charset=utf-8';
 
 type FrameworkResponseWriterContext = {
   readonly applySuccessResponseMetadata: () => void;
@@ -141,6 +144,19 @@ function applySuccessResponseMetadata(context: SuccessResponseMetadataContext): 
   }
 }
 
+function applyImplicitHeadContentType(response: FrameworkResponse, value: unknown): void {
+  if (readHeader(response.headers, 'content-type') !== undefined || value === undefined) {
+    return;
+  }
+
+  if (value instanceof Uint8Array || value instanceof ArrayBuffer) {
+    response.setHeader('Content-Type', BINARY_CONTENT_TYPE);
+    return;
+  }
+
+  response.setHeader('Content-Type', typeof value === 'string' ? TEXT_CONTENT_TYPE : JSON_CONTENT_TYPE);
+}
+
 /**
  * Write success response.
  *
@@ -203,6 +219,7 @@ export function writeSuccessResponse(
   applySuccessResponseMetadata({ formatter, handler, response, value: responseValue });
 
   if (request.method.toUpperCase() === 'HEAD') {
+    applyImplicitHeadContentType(response, responseValue);
     return response.send(undefined);
   }
 

--- a/packages/http/src/dispatch/dispatcher.test.ts
+++ b/packages/http/src/dispatch/dispatcher.test.ts
@@ -879,6 +879,7 @@ describe('dispatcher runtime', () => {
     await dispatcher.dispatch(createRequest('/fast-json-head', 'HEAD'), response);
 
     expect(response.statusCode).toBe(200);
+    expect(response.headers['Content-Type']).toBe('application/json; charset=utf-8');
     expect(response.simpleJsonBody).toBeUndefined();
     expect(response.body).toBeUndefined();
     expect(response.committed).toBe(true);
@@ -967,6 +968,7 @@ describe('dispatcher runtime', () => {
     expect(optionsResponse.body).toEqual({ allow: ['GET', 'HEAD', 'OPTIONS'] });
     expect(headResponse.statusCode).toBe(202);
     expect(headResponse.headers['x-head-contract']).toBe('preserved');
+    expect(headResponse.headers['Content-Type']).toBe('application/json; charset=utf-8');
     expect(headResponse.body).toBeUndefined();
     expect(headResponse.committed).toBe(true);
   });
@@ -1401,6 +1403,12 @@ describe('dispatcher runtime', () => {
       head() {
         return { ok: true };
       }
+
+      @Produces('text/plain')
+      @Get('/formatted')
+      get() {
+        return { ok: true };
+      }
     }
 
     const root = new Container().register(NegotiationHeadController);
@@ -1418,12 +1426,63 @@ describe('dispatcher runtime', () => {
       handlerMapping: createHandlerMapping([{ controllerToken: NegotiationHeadController }]),
       rootContainer: root,
     });
+    const getResponse = createResponse();
+    const headResponse = createResponse();
+
+    await dispatcher.dispatch(createRequest('/negotiation-head/formatted', 'GET', { accept: 'text/plain' }), getResponse);
+    await dispatcher.dispatch(createRequest('/negotiation-head/formatted', 'HEAD', { accept: 'text/plain' }), headResponse);
+
+    expect(getResponse.body).toBe('plain:{"ok":true}');
+    expect(headResponse.statusCode).toBe(200);
+    expect(headResponse.headers['Content-Type']).toBe(getResponse.headers['Content-Type']);
+    expect(headResponse.body).toBeUndefined();
+    expect(headResponse.committed).toBe(true);
+  });
+
+  it('preserves the implicit text content type while suppressing framework-managed HEAD bodies', async () => {
+    @Controller('/plain-head')
+    class PlainHeadController {
+      @Head('/')
+      head() {
+        return 'plain response';
+      }
+    }
+
+    const root = new Container().register(PlainHeadController);
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: PlainHeadController }]),
+      rootContainer: root,
+    });
     const response = createResponse();
 
-    await dispatcher.dispatch(createRequest('/negotiation-head/formatted', 'HEAD', { accept: 'text/plain' }), response);
+    await dispatcher.dispatch(createRequest('/plain-head', 'HEAD'), response);
 
     expect(response.statusCode).toBe(200);
-    expect(response.headers['Content-Type']).toBe('text/plain');
+    expect(response.headers['Content-Type']).toBe('text/plain; charset=utf-8');
+    expect(response.body).toBeUndefined();
+    expect(response.committed).toBe(true);
+  });
+
+  it('preserves the implicit binary content type while suppressing framework-managed HEAD bodies', async () => {
+    @Controller('/binary-head')
+    class BinaryHeadController {
+      @Head('/')
+      head() {
+        return new Uint8Array([1, 2, 3]);
+      }
+    }
+
+    const root = new Container().register(BinaryHeadController);
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: BinaryHeadController }]),
+      rootContainer: root,
+    });
+    const response = createResponse();
+
+    await dispatcher.dispatch(createRequest('/binary-head', 'HEAD'), response);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['Content-Type']).toBe('application/octet-stream');
     expect(response.body).toBeUndefined();
     expect(response.committed).toBe(true);
   });

--- a/packages/http/src/dispatch/dispatcher.test.ts
+++ b/packages/http/src/dispatch/dispatcher.test.ts
@@ -6,6 +6,7 @@ import type {
   CallHandler,
   FrameworkRequest,
   FrameworkResponse,
+  FrameworkResponseStream,
   GuardContext,
   InterceptorContext,
   Middleware,
@@ -13,7 +14,6 @@ import type {
   Next,
   RequestContext,
   RequestObservationContext,
-  FrameworkResponseStream,
 } from '../index.js';
 import {
   type assertRequestContext,
@@ -22,15 +22,15 @@ import {
   createCorrelationMiddleware,
   createDispatcher,
   createHandlerMapping,
-  formatFastPathStats,
   FromBody,
   FromPath,
   FromQuery,
+  formatFastPathStats,
   Get,
-  getDispatcherFastPathStats,
   getCurrentRequestContext,
-  Header,
+  getDispatcherFastPathStats,
   Head,
+  Header,
   HttpCode,
   Options,
   Post,
@@ -860,6 +860,30 @@ describe('dispatcher runtime', () => {
     expect(arrayResponse.body).toBeUndefined();
   });
 
+  it('bypasses the simple JSON fast writer body for framework-managed HEAD responses', async () => {
+    @Controller('/fast-json-head')
+    class FastJsonHeadController {
+      @Head('/')
+      head() {
+        return { ok: true };
+      }
+    }
+
+    const root = new Container().register(FastJsonHeadController);
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: FastJsonHeadController }]),
+      rootContainer: root,
+    });
+    const response = createFastPathResponse();
+
+    await dispatcher.dispatch(createRequest('/fast-json-head', 'HEAD'), response);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.simpleJsonBody).toBeUndefined();
+    expect(response.body).toBeUndefined();
+    expect(response.committed).toBe(true);
+  });
+
   it('exposes automatic fast-path stats without emitting debug headers by default', async () => {
     @Controller('/fast-path-visibility')
     class FastPathVisibilityController {
@@ -921,6 +945,8 @@ describe('dispatcher runtime', () => {
       }
 
       @Head('/')
+      @Header('x-head-contract', 'preserved')
+      @HttpCode(202)
       head() {
         return { ok: true };
       }
@@ -939,8 +965,10 @@ describe('dispatcher runtime', () => {
 
     expect(optionsResponse.statusCode).toBe(200);
     expect(optionsResponse.body).toEqual({ allow: ['GET', 'HEAD', 'OPTIONS'] });
-    expect(headResponse.statusCode).toBe(200);
-    expect(headResponse.body).toEqual({ ok: true });
+    expect(headResponse.statusCode).toBe(202);
+    expect(headResponse.headers['x-head-contract']).toBe('preserved');
+    expect(headResponse.body).toBeUndefined();
+    expect(headResponse.committed).toBe(true);
   });
 
   it('falls back to full path when route capabilities are not fast-path safe', async () => {
@@ -1363,6 +1391,41 @@ describe('dispatcher runtime', () => {
     expect(response.statusCode).toBe(200);
     expect(response.headers['Content-Type']).toBe('text/plain');
     expect(response.body).toBe('plain:{"ok":true}');
+  });
+
+  it('keeps negotiated formatter headers while suppressing HEAD bodies', async () => {
+    @Controller('/negotiation-head')
+    class NegotiationHeadController {
+      @Produces('text/plain')
+      @Head('/formatted')
+      head() {
+        return { ok: true };
+      }
+    }
+
+    const root = new Container().register(NegotiationHeadController);
+    const dispatcher = createDispatcher({
+      contentNegotiation: {
+        formatters: [
+          {
+            format(body) {
+              return `plain:${JSON.stringify(body)}`;
+            },
+            mediaType: 'text/plain',
+          },
+        ],
+      },
+      handlerMapping: createHandlerMapping([{ controllerToken: NegotiationHeadController }]),
+      rootContainer: root,
+    });
+    const response = createResponse();
+
+    await dispatcher.dispatch(createRequest('/negotiation-head/formatted', 'HEAD', { accept: 'text/plain' }), response);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['Content-Type']).toBe('text/plain');
+    expect(response.body).toBeUndefined();
+    expect(response.committed).toBe(true);
   });
 
   it('returns 406 when Accept does not match available formatters', async () => {

--- a/packages/http/src/dispatch/error-representation.test.ts
+++ b/packages/http/src/dispatch/error-representation.test.ts
@@ -117,6 +117,7 @@ describe('HTTP-owned error representations', () => {
       await dispatcher.dispatch(createRequest(path, undefined, 'HEAD'), response);
 
       expect(response.statusCode).toBe(404);
+      expect(response.headers['Content-Type']).toBe('application/json; charset=utf-8');
       expect(response.body).toBeUndefined();
       expect(response.committed).toBe(true);
       expect(render).not.toHaveBeenCalled();

--- a/packages/http/src/dispatch/error-representation.test.ts
+++ b/packages/http/src/dispatch/error-representation.test.ts
@@ -107,4 +107,35 @@ describe('HTTP-owned error representations', () => {
     expect(render).not.toHaveBeenCalled();
   });
 
+  it.each(['/missing', '/failures/head'])(
+    'suppresses provider-less canonical JSON bodies for HEAD request %s',
+    async (path) => {
+      const render = vi.fn(() => '<main>unused</main>');
+      const { dispatcher } = createTestDispatcher({ render }, { errorRepresentation: undefined });
+      const response = createResponse();
+
+      await dispatcher.dispatch(createRequest(path, undefined, 'HEAD'), response);
+
+      expect(response.statusCode).toBe(404);
+      expect(response.body).toBeUndefined();
+      expect(response.committed).toBe(true);
+      expect(render).not.toHaveBeenCalled();
+    },
+  );
+
+  it('suppresses canonical JSON bodies for HEAD 406 outcomes', async () => {
+    const render = vi.fn(() => '<main>unused</main>');
+    const { dispatcher } = createTestDispatcher({ render });
+    const response = createResponse();
+
+    await dispatcher.dispatch(createRequest('/missing', 'image/avif', 'HEAD'), response);
+
+    expect(response.statusCode).toBe(406);
+    expect(response.headers['Content-Type']).toBe('application/json; charset=utf-8');
+    expect(response.headers.Vary).toBe('Accept');
+    expect(response.body).toBeUndefined();
+    expect(response.committed).toBe(true);
+    expect(render).not.toHaveBeenCalled();
+  });
+
 });

--- a/packages/platform-express/src/adapter.ts
+++ b/packages/platform-express/src/adapter.ts
@@ -680,6 +680,12 @@ function createFrameworkResponse(response: ExpressResponse): ExpressFrameworkRes
         return;
       }
 
+      if (body === undefined && response.req.method.toUpperCase() === 'HEAD') {
+        this.committed = true;
+        response.end();
+        return;
+      }
+
       const existingContentType = response.getHeader('content-type');
       const serialized = serializeResponseBody(body, typeof existingContentType === 'string' ? existingContentType : undefined);
 

--- a/packages/testing/src/portability/error-representation-portability-fixture.ts
+++ b/packages/testing/src/portability/error-representation-portability-fixture.ts
@@ -1,0 +1,155 @@
+import {
+  Controller,
+  Get,
+  Head,
+  Header,
+  HttpCode,
+  type HttpErrorRepresentationOptions,
+  type Middleware,
+  NotFoundException,
+  type RequestContext,
+} from '@fluojs/http';
+import { defineModule, type ModuleType } from '@fluojs/runtime';
+
+type ErrorRepresentationBootstrapOptions = {
+  readonly cors: false;
+  readonly errorRepresentation: HttpErrorRepresentationOptions | undefined;
+  readonly middleware: Middleware[];
+};
+
+type RepresentationResponses = {
+  readonly committed: Response;
+  readonly head: Response;
+  readonly html: Response;
+  readonly json: Response;
+  readonly jsonHead: Response;
+  readonly successHead: Response;
+  readonly unsupported: Response;
+  readonly unsupportedHead: Response;
+};
+
+function hasErrorCode(value: unknown, code: string): boolean {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const error: unknown = Reflect.get(value, 'error');
+  return typeof error === 'object' && error !== null && Reflect.get(error, 'code') === code;
+}
+
+function assertStatus(response: Response, expected: number, name: string, scenario: string): void {
+  if (response.status !== expected) {
+    throw new Error(`${name} changed ${scenario} status: expected ${String(expected)}, received ${String(response.status)}.`);
+  }
+}
+
+export async function assertProviderlessHeadResponse(name: string, response: Response): Promise<void> {
+  assertStatus(response, 404, name, 'provider-less canonical JSON HEAD error representation');
+  if (await response.text() !== '') {
+    throw new Error(`${name} changed provider-less canonical JSON HEAD body suppression.`);
+  }
+}
+
+export async function assertRepresentationResponses(
+  name: string,
+  responses: RepresentationResponses,
+): Promise<void> {
+  assertStatus(responses.html, 404, name, 'HTML error representation');
+  assertStatus(responses.json, 404, name, 'JSON error representation');
+  assertStatus(responses.head, 404, name, 'HEAD error representation');
+  assertStatus(responses.jsonHead, 404, name, 'canonical JSON HEAD error representation');
+  assertStatus(responses.successHead, 202, name, 'successful HEAD response');
+  assertStatus(responses.unsupported, 406, name, 'unsupported error representation');
+  assertStatus(responses.unsupportedHead, 406, name, 'unsupported HEAD error representation');
+  assertStatus(responses.committed, 202, name, 'already-committed response');
+
+  const [html, json, head, jsonHead, successHead, unsupported, unsupportedHead, committed] = await Promise.all([
+    responses.html.text(),
+    responses.json.json(),
+    responses.head.text(),
+    responses.jsonHead.text(),
+    responses.successHead.text(),
+    responses.unsupported.json(),
+    responses.unsupportedHead.text(),
+    responses.committed.text(),
+  ]);
+
+  if (!responses.html.headers.get('content-type')?.includes('text/html') || !html.includes('404:NOT_FOUND')) {
+    throw new Error(`${name} changed negotiated HTML error representation semantics.`);
+  }
+  if (!hasErrorCode(json, 'NOT_FOUND')) {
+    throw new Error(`${name} changed canonical JSON error representation semantics.`);
+  }
+  if (!responses.head.headers.get('content-type')?.includes('text/html') || head !== '') {
+    throw new Error(`${name} changed HEAD error representation body suppression.`);
+  }
+  if (!responses.jsonHead.headers.get('content-type')?.includes('application/json') || jsonHead !== '') {
+    throw new Error(`${name} changed canonical JSON HEAD error representation body suppression.`);
+  }
+  if (responses.successHead.headers.get('x-head-contract') !== 'preserved' || successHead !== '') {
+    throw new Error(`${name} changed successful HEAD status, header, or body semantics.`);
+  }
+  if (!hasErrorCode(unsupported, 'NOT_ACCEPTABLE')) {
+    throw new Error(`${name} changed unsupported error representation fallback semantics.`);
+  }
+  if (!responses.unsupportedHead.headers.get('content-type')?.includes('application/json') || unsupportedHead !== '') {
+    throw new Error(`${name} changed unsupported HEAD error representation body suppression.`);
+  }
+  if (committed !== 'handler-owned') {
+    throw new Error(`${name} rewrote an already-committed response through the error provider.`);
+  }
+}
+
+export function createRepresentationFixture(): ModuleType {
+  @Controller('/error-representations')
+  class ErrorRepresentationController {
+    @Get('/json')
+    json(): never {
+      throw new NotFoundException('Matched resource missing.');
+    }
+
+    @Head('/head')
+    head(): never {
+      throw new NotFoundException('HEAD resource missing.');
+    }
+
+    @Head('/success-head')
+    @Header('x-head-contract', 'preserved')
+    @HttpCode(202)
+    successHead() {
+      return { ok: true };
+    }
+
+    @Get('/committed')
+    async committed(_input: undefined, context: RequestContext): Promise<never> {
+      context.response.setStatus(202);
+      await context.response.send('handler-owned');
+      throw new NotFoundException('Committed response must not be replaced.');
+    }
+  }
+
+  class AppModule {}
+  defineModule(AppModule, { controllers: [ErrorRepresentationController] });
+  return AppModule;
+}
+
+export function createErrorRepresentationOptions(): ErrorRepresentationBootstrapOptions {
+  return {
+    cors: false,
+    errorRepresentation: {
+      html: {
+        render({ json }: { readonly json: { readonly error: { readonly code: string; readonly status: number } } }) {
+          return `<html><body>${String(json.error.status)}:${json.error.code}</body></html>`;
+        },
+      },
+    },
+    middleware: [],
+  };
+}
+
+export function createProviderlessErrorRepresentationOptions(): ErrorRepresentationBootstrapOptions {
+  return {
+    cors: false,
+    errorRepresentation: undefined,
+    middleware: [],
+  };
+}

--- a/packages/testing/src/portability/error-representation-portability-fixture.ts
+++ b/packages/testing/src/portability/error-representation-portability-fixture.ts
@@ -18,14 +18,25 @@ type ErrorRepresentationBootstrapOptions = {
 };
 
 type RepresentationResponses = {
+  readonly binary: Response;
+  readonly binaryHead: Response;
   readonly committed: Response;
   readonly head: Response;
   readonly html: Response;
   readonly json: Response;
   readonly jsonHead: Response;
+  readonly plain: Response;
+  readonly plainHead: Response;
+  readonly success: Response;
   readonly successHead: Response;
   readonly unsupported: Response;
   readonly unsupportedHead: Response;
+};
+
+type HeadRepresentationPair = {
+  readonly headResponse: Response;
+  readonly response: Response;
+  readonly scenario: string;
 };
 
 function hasErrorCode(value: unknown, code: string): boolean {
@@ -42,13 +53,43 @@ function assertStatus(response: Response, expected: number, name: string, scenar
   }
 }
 
-export async function assertProviderlessHeadResponse(name: string, response: Response): Promise<void> {
-  assertStatus(response, 404, name, 'provider-less canonical JSON HEAD error representation');
-  if (await response.text() !== '') {
-    throw new Error(`${name} changed provider-less canonical JSON HEAD body suppression.`);
+async function assertHeadRepresentationParity(
+  name: string,
+  pair: HeadRepresentationPair,
+): Promise<void> {
+  const contentType = pair.response.headers.get('content-type');
+  const headContentType = pair.headResponse.headers.get('content-type');
+  if (contentType === null || headContentType !== contentType) {
+    throw new Error(
+      `${name} changed ${pair.scenario} HEAD content type parity: GET=${String(contentType)}, HEAD=${String(headContentType)}.`,
+    );
+  }
+  if (await pair.response.arrayBuffer().then((body) => body.byteLength) === 0 || await pair.headResponse.text() !== '') {
+    throw new Error(`${name} changed ${pair.scenario} GET body or HEAD body suppression semantics.`);
   }
 }
 
+/**
+ * Verifies provider-less canonical JSON metadata and body suppression for a HEAD response.
+ *
+ * @param name Adapter name included in assertion failures.
+ * @param response Provider-less HEAD response returned by the adapter.
+ * @returns A promise that resolves when the response preserves the portable contract.
+ */
+export async function assertProviderlessHeadResponse(name: string, response: Response): Promise<void> {
+  assertStatus(response, 404, name, 'provider-less canonical JSON HEAD error representation');
+  if (response.headers.get('content-type') !== 'application/json; charset=utf-8' || await response.text() !== '') {
+    throw new Error(`${name} changed provider-less canonical JSON HEAD representation metadata or body suppression.`);
+  }
+}
+
+/**
+ * Verifies negotiated error and successful HEAD responses returned by an adapter.
+ *
+ * @param name Adapter name included in assertion failures.
+ * @param responses Responses collected from the shared representation fixture.
+ * @returns A promise that resolves when every response preserves the portable contract.
+ */
 export async function assertRepresentationResponses(
   name: string,
   responses: RepresentationResponses,
@@ -57,17 +98,21 @@ export async function assertRepresentationResponses(
   assertStatus(responses.json, 404, name, 'JSON error representation');
   assertStatus(responses.head, 404, name, 'HEAD error representation');
   assertStatus(responses.jsonHead, 404, name, 'canonical JSON HEAD error representation');
+  assertStatus(responses.success, 202, name, 'successful JSON response');
   assertStatus(responses.successHead, 202, name, 'successful HEAD response');
+  assertStatus(responses.plain, 200, name, 'successful plain text response');
+  assertStatus(responses.plainHead, 200, name, 'successful plain text HEAD response');
+  assertStatus(responses.binary, 200, name, 'successful binary response');
+  assertStatus(responses.binaryHead, 200, name, 'successful binary HEAD response');
   assertStatus(responses.unsupported, 406, name, 'unsupported error representation');
   assertStatus(responses.unsupportedHead, 406, name, 'unsupported HEAD error representation');
   assertStatus(responses.committed, 202, name, 'already-committed response');
 
-  const [html, json, head, jsonHead, successHead, unsupported, unsupportedHead, committed] = await Promise.all([
+  const [html, json, head, jsonHead, unsupported, unsupportedHead, committed] = await Promise.all([
     responses.html.text(),
     responses.json.json(),
     responses.head.text(),
     responses.jsonHead.text(),
-    responses.successHead.text(),
     responses.unsupported.json(),
     responses.unsupportedHead.text(),
     responses.committed.text(),
@@ -82,23 +127,43 @@ export async function assertRepresentationResponses(
   if (!responses.head.headers.get('content-type')?.includes('text/html') || head !== '') {
     throw new Error(`${name} changed HEAD error representation body suppression.`);
   }
-  if (!responses.jsonHead.headers.get('content-type')?.includes('application/json') || jsonHead !== '') {
-    throw new Error(`${name} changed canonical JSON HEAD error representation body suppression.`);
+  if (responses.jsonHead.headers.get('content-type') !== 'application/json; charset=utf-8' || jsonHead !== '') {
+    throw new Error(`${name} changed canonical JSON HEAD error representation metadata or body suppression.`);
   }
-  if (responses.successHead.headers.get('x-head-contract') !== 'preserved' || successHead !== '') {
-    throw new Error(`${name} changed successful HEAD status, header, or body semantics.`);
+  if (responses.successHead.headers.get('x-head-contract') !== 'preserved') {
+    throw new Error(`${name} changed successful HEAD explicit header semantics.`);
   }
+  await assertHeadRepresentationParity(name, {
+    headResponse: responses.successHead,
+    response: responses.success,
+    scenario: 'successful JSON',
+  });
+  await assertHeadRepresentationParity(name, {
+    headResponse: responses.plainHead,
+    response: responses.plain,
+    scenario: 'successful plain text',
+  });
+  await assertHeadRepresentationParity(name, {
+    headResponse: responses.binaryHead,
+    response: responses.binary,
+    scenario: 'successful binary',
+  });
   if (!hasErrorCode(unsupported, 'NOT_ACCEPTABLE')) {
     throw new Error(`${name} changed unsupported error representation fallback semantics.`);
   }
-  if (!responses.unsupportedHead.headers.get('content-type')?.includes('application/json') || unsupportedHead !== '') {
-    throw new Error(`${name} changed unsupported HEAD error representation body suppression.`);
+  if (responses.unsupportedHead.headers.get('content-type') !== 'application/json; charset=utf-8' || unsupportedHead !== '') {
+    throw new Error(`${name} changed unsupported HEAD error representation metadata or body suppression.`);
   }
   if (committed !== 'handler-owned') {
     throw new Error(`${name} rewrote an already-committed response through the error provider.`);
   }
 }
 
+/**
+ * Creates the shared application module used by error-representation portability checks.
+ *
+ * @returns A module containing success, error, HEAD, and committed-response routes.
+ */
 export function createRepresentationFixture(): ModuleType {
   @Controller('/error-representations')
   class ErrorRepresentationController {
@@ -119,6 +184,32 @@ export function createRepresentationFixture(): ModuleType {
       return { ok: true };
     }
 
+    @Get('/success-head')
+    @HttpCode(202)
+    success() {
+      return { ok: true };
+    }
+
+    @Head('/plain-head')
+    plainHead() {
+      return 'plain response';
+    }
+
+    @Get('/plain-head')
+    plain() {
+      return 'plain response';
+    }
+
+    @Head('/binary-head')
+    binaryHead() {
+      return new Uint8Array([1, 2, 3]);
+    }
+
+    @Get('/binary-head')
+    binary() {
+      return new Uint8Array([1, 2, 3]);
+    }
+
     @Get('/committed')
     async committed(_input: undefined, context: RequestContext): Promise<never> {
       context.response.setStatus(202);
@@ -132,6 +223,11 @@ export function createRepresentationFixture(): ModuleType {
   return AppModule;
 }
 
+/**
+ * Creates bootstrap options with the shared HTML error-representation provider enabled.
+ *
+ * @returns Common adapter bootstrap options for negotiated representation checks.
+ */
 export function createErrorRepresentationOptions(): ErrorRepresentationBootstrapOptions {
   return {
     cors: false,
@@ -146,6 +242,11 @@ export function createErrorRepresentationOptions(): ErrorRepresentationBootstrap
   };
 }
 
+/**
+ * Creates bootstrap options without an HTML error-representation provider.
+ *
+ * @returns Common adapter bootstrap options for canonical JSON fallback checks.
+ */
 export function createProviderlessErrorRepresentationOptions(): ErrorRepresentationBootstrapOptions {
   return {
     cors: false,

--- a/packages/testing/src/portability/error-representation-portability.ts
+++ b/packages/testing/src/portability/error-representation-portability.ts
@@ -1,14 +1,12 @@
+import type { HttpErrorRepresentationOptions, Middleware, RequestObserver } from '@fluojs/http';
+import type { ModuleType } from '@fluojs/runtime';
 import {
-  Controller,
-  Get,
-  Head,
-  type HttpErrorRepresentationOptions,
-  type Middleware,
-  NotFoundException,
-  type RequestContext,
-  type RequestObserver,
-} from '@fluojs/http';
-import { defineModule, type ModuleType } from '@fluojs/runtime';
+  assertProviderlessHeadResponse,
+  assertRepresentationResponses,
+  createErrorRepresentationOptions,
+  createProviderlessErrorRepresentationOptions,
+  createRepresentationFixture,
+} from './error-representation-portability-fixture.js';
 
 type NetworkApp = {
   close(): Promise<void>;
@@ -39,7 +37,7 @@ type WebHarnessOptions<TBootstrapOptions extends object, TApp extends WebApp> = 
 /** Adapter bootstrap fields required by the network error-representation portability scenario. */
 export type NetworkHttpErrorRepresentationBootstrapOptions = {
   readonly cors: false;
-  readonly errorRepresentation: HttpErrorRepresentationOptions;
+  readonly errorRepresentation: HttpErrorRepresentationOptions | undefined;
   readonly middleware: Middleware[];
   readonly observers: RequestObserver[];
   readonly port: 0;
@@ -48,7 +46,7 @@ export type NetworkHttpErrorRepresentationBootstrapOptions = {
 /** Adapter bootstrap fields required by the Web error-representation portability scenario. */
 export type WebHttpErrorRepresentationBootstrapOptions = {
   readonly cors: false;
-  readonly errorRepresentation: HttpErrorRepresentationOptions;
+  readonly errorRepresentation: HttpErrorRepresentationOptions | undefined;
   readonly middleware: Middleware[];
 };
 
@@ -68,101 +66,6 @@ function resolveListeningUrl(app: NetworkApp, name: string): string {
     throw new Error(`${name} error representation portability check could not resolve its listener URL.`);
   }
   return adapter.getListenTarget().url;
-}
-
-function hasErrorCode(value: unknown, code: string): boolean {
-  if (typeof value !== 'object' || value === null) {
-    return false;
-  }
-  const error: unknown = Reflect.get(value, 'error');
-  return typeof error === 'object' && error !== null && Reflect.get(error, 'code') === code;
-}
-
-function assertStatus(response: Response, expected: number, name: string, scenario: string): void {
-  if (response.status !== expected) {
-    throw new Error(`${name} changed ${scenario} status: expected ${String(expected)}, received ${String(response.status)}.`);
-  }
-}
-
-async function assertRepresentationResponses(
-  name: string,
-  responses: {
-    readonly committed: Response;
-    readonly head: Response;
-    readonly html: Response;
-    readonly json: Response;
-    readonly unsupported: Response;
-  },
-): Promise<void> {
-  assertStatus(responses.html, 404, name, 'HTML error representation');
-  assertStatus(responses.json, 404, name, 'JSON error representation');
-  assertStatus(responses.head, 404, name, 'HEAD error representation');
-  assertStatus(responses.unsupported, 406, name, 'unsupported error representation');
-  assertStatus(responses.committed, 202, name, 'already-committed response');
-
-  const [html, json, head, unsupported, committed] = await Promise.all([
-    responses.html.text(),
-    responses.json.json(),
-    responses.head.text(),
-    responses.unsupported.json(),
-    responses.committed.text(),
-  ]);
-
-  if (!responses.html.headers.get('content-type')?.includes('text/html') || !html.includes('404:NOT_FOUND')) {
-    throw new Error(`${name} changed negotiated HTML error representation semantics.`);
-  }
-  if (!hasErrorCode(json, 'NOT_FOUND')) {
-    throw new Error(`${name} changed canonical JSON error representation semantics.`);
-  }
-  if (!responses.head.headers.get('content-type')?.includes('text/html') || head !== '') {
-    throw new Error(`${name} changed HEAD error representation body suppression.`);
-  }
-  if (!hasErrorCode(unsupported, 'NOT_ACCEPTABLE')) {
-    throw new Error(`${name} changed unsupported error representation fallback semantics.`);
-  }
-  if (committed !== 'handler-owned') {
-    throw new Error(`${name} rewrote an already-committed response through the error provider.`);
-  }
-}
-
-function createRepresentationFixture(): ModuleType {
-  @Controller('/error-representations')
-  class ErrorRepresentationController {
-    @Get('/json')
-    json(): never {
-      throw new NotFoundException('Matched resource missing.');
-    }
-
-    @Head('/head')
-    head(): never {
-      throw new NotFoundException('HEAD resource missing.');
-    }
-
-    @Get('/committed')
-    async committed(_input: undefined, context: RequestContext): Promise<never> {
-      context.response.setStatus(202);
-      await context.response.send('handler-owned');
-      throw new NotFoundException('Committed response must not be replaced.');
-    }
-  }
-
-  class AppModule {}
-  defineModule(AppModule, { controllers: [ErrorRepresentationController] });
-  return AppModule;
-}
-
-function createErrorRepresentationOptions(): WebHttpErrorRepresentationBootstrapOptions {
-  return {
-    cors: false,
-    errorRepresentation: {
-      html: {
-        render({ json }: { readonly json: { readonly error: { readonly code: string; readonly status: number } } }) {
-          return `<html><body>${String(json.error.status)}:${json.error.code}</body></html>`;
-        },
-      },
-    },
-    middleware: [],
-  };
 }
 
 async function closeAfterAssertion(app: NetworkApp | WebApp, name: string, assertion: () => Promise<void>): Promise<void> {
@@ -213,8 +116,29 @@ export async function assertNetworkHttpErrorRepresentationPortability<
       head: await fetch(`${baseUrl}/error-representations/head`, { headers: { accept: 'text/html' }, method: 'HEAD' }),
       html: await fetch(`${baseUrl}/not-registered`, { headers: { accept: 'text/html' } }),
       json: await fetch(`${baseUrl}/error-representations/json`, { headers: { accept: 'application/json' } }),
+      jsonHead: await fetch(`${baseUrl}/error-representations/head`, { headers: { accept: 'application/json' }, method: 'HEAD' }),
+      successHead: await fetch(`${baseUrl}/error-representations/success-head`, { method: 'HEAD' }),
       unsupported: await fetch(`${baseUrl}/not-registered`, { headers: { accept: 'image/avif' } }),
+      unsupportedHead: await fetch(`${baseUrl}/not-registered`, { headers: { accept: 'image/avif' }, method: 'HEAD' }),
     });
+  });
+
+  const providerlessApp = await options.bootstrap(
+    createRepresentationFixture(),
+    options.createBootstrapOptions({
+      ...createProviderlessErrorRepresentationOptions(),
+      observers: [],
+      port: 0,
+    }),
+  );
+
+  await closeAfterAssertion(providerlessApp, options.name, async () => {
+    await providerlessApp.listen();
+    const baseUrl = resolveListeningUrl(providerlessApp, options.name);
+    await assertProviderlessHeadResponse(
+      options.name,
+      await fetch(`${baseUrl}/not-registered`, { method: 'HEAD' }),
+    );
   });
 }
 
@@ -243,7 +167,22 @@ export async function assertWebHttpErrorRepresentationPortability<
       head: await app.dispatch(request('/error-representations/head', 'text/html', 'HEAD')),
       html: await app.dispatch(request('/not-registered', 'text/html')),
       json: await app.dispatch(request('/error-representations/json', 'application/json')),
+      jsonHead: await app.dispatch(request('/error-representations/head', 'application/json', 'HEAD')),
+      successHead: await app.dispatch(request('/error-representations/success-head', '*/*', 'HEAD')),
       unsupported: await app.dispatch(request('/not-registered', 'image/avif')),
+      unsupportedHead: await app.dispatch(request('/not-registered', 'image/avif', 'HEAD')),
     });
+  });
+
+  const providerlessApp = await options.bootstrap(
+    createRepresentationFixture(),
+    options.createBootstrapOptions(createProviderlessErrorRepresentationOptions()),
+  );
+
+  await closeAfterAssertion(providerlessApp, options.name, async () => {
+    await assertProviderlessHeadResponse(
+      options.name,
+      await providerlessApp.dispatch(new Request('https://runtime.test/not-registered', { method: 'HEAD' })),
+    );
   });
 }

--- a/packages/testing/src/portability/error-representation-portability.ts
+++ b/packages/testing/src/portability/error-representation-portability.ts
@@ -112,11 +112,16 @@ export async function assertNetworkHttpErrorRepresentationPortability<
     await app.listen();
     const baseUrl = resolveListeningUrl(app, options.name);
     await assertRepresentationResponses(options.name, {
+      binary: await fetch(`${baseUrl}/error-representations/binary-head`),
+      binaryHead: await fetch(`${baseUrl}/error-representations/binary-head`, { method: 'HEAD' }),
       committed: await fetch(`${baseUrl}/error-representations/committed`, { headers: { accept: 'text/html' } }),
       head: await fetch(`${baseUrl}/error-representations/head`, { headers: { accept: 'text/html' }, method: 'HEAD' }),
       html: await fetch(`${baseUrl}/not-registered`, { headers: { accept: 'text/html' } }),
       json: await fetch(`${baseUrl}/error-representations/json`, { headers: { accept: 'application/json' } }),
       jsonHead: await fetch(`${baseUrl}/error-representations/head`, { headers: { accept: 'application/json' }, method: 'HEAD' }),
+      plain: await fetch(`${baseUrl}/error-representations/plain-head`),
+      plainHead: await fetch(`${baseUrl}/error-representations/plain-head`, { method: 'HEAD' }),
+      success: await fetch(`${baseUrl}/error-representations/success-head`),
       successHead: await fetch(`${baseUrl}/error-representations/success-head`, { method: 'HEAD' }),
       unsupported: await fetch(`${baseUrl}/not-registered`, { headers: { accept: 'image/avif' } }),
       unsupportedHead: await fetch(`${baseUrl}/not-registered`, { headers: { accept: 'image/avif' }, method: 'HEAD' }),
@@ -163,11 +168,16 @@ export async function assertWebHttpErrorRepresentationPortability<
       method,
     });
     await assertRepresentationResponses(options.name, {
+      binary: await app.dispatch(request('/error-representations/binary-head', '*/*')),
+      binaryHead: await app.dispatch(request('/error-representations/binary-head', '*/*', 'HEAD')),
       committed: await app.dispatch(request('/error-representations/committed', 'text/html')),
       head: await app.dispatch(request('/error-representations/head', 'text/html', 'HEAD')),
       html: await app.dispatch(request('/not-registered', 'text/html')),
       json: await app.dispatch(request('/error-representations/json', 'application/json')),
       jsonHead: await app.dispatch(request('/error-representations/head', 'application/json', 'HEAD')),
+      plain: await app.dispatch(request('/error-representations/plain-head', '*/*')),
+      plainHead: await app.dispatch(request('/error-representations/plain-head', '*/*', 'HEAD')),
+      success: await app.dispatch(request('/error-representations/success-head', '*/*')),
       successHead: await app.dispatch(request('/error-representations/success-head', '*/*', 'HEAD')),
       unsupported: await app.dispatch(request('/not-registered', 'image/avif')),
       unsupportedHead: await app.dispatch(request('/not-registered', 'image/avif', 'HEAD')),


### PR DESCRIPTION
## Summary

Suppress response bodies for framework-managed `HEAD` outcomes while preserving the selected status, headers, and response commit semantics. Application-owned custom response writers and already-committed responses retain their existing ownership behavior.

Linked context: Closes #3069

## Changes

- suppress ordinary and simple JSON fast-path bodies for framework-managed successful `HEAD` responses
- suppress provider-less canonical JSON bodies for `HEAD` errors, including route misses and `406` outcomes
- preserve GET-equivalent `Content-Type` metadata for JSON, plain text, binary, formatter, explicit-header, and canonical error responses
- preserve explicit status, response headers, negotiated representation headers, redirect, abort, committed-response, and custom response-writer ownership
- prevent Express from reserializing a framework-suppressed `HEAD` body as empty text and mutating response metadata
- extend shared network and fetch-style adapter portability coverage for successful, negotiated, canonical JSON, provider-less, unsupported, plain-text, and binary `HEAD` responses
- record patch Changeset intent for `@fluojs/http`, `@fluojs/testing`, and `@fluojs/platform-express`

## Testing

Canonical GitHub CI for current head [`929aaf23`](https://github.com/fluojs/fluo/commit/929aaf23b8c3a7336c2909c20da490a2c4ed71c0) passed all checks in [workflow run 31675363104](https://github.com/fluojs/fluo/actions/runs/31675363104):

- `Build and typecheck`
- `Lint`
- `Test`
  - packages: 385 test files passed; 4,433 tests passed and 1 skipped
  - examples: 8 test files and 23 tests passed
  - tooling: 40 test files and 466 tests passed
- `Verify`
- `Verify changeset release lane`
- `Verify platform consistency governance`
- `Official web runtime adapter portability (bun)`
- `Official web runtime adapter portability (deno)`
- `Official web runtime adapter portability (cloudflare-workers)`
- `Resolve PR verification scope`

Direct portability/conformance evidence:

- [shared network and fetch-style portability runner](https://github.com/fluojs/fluo/blob/929aaf23b8c3a7336c2909c20da490a2c4ed71c0/packages/testing/src/portability/error-representation-portability.ts)
- [shared successful/error representation fixture and assertions](https://github.com/fluojs/fluo/blob/929aaf23b8c3a7336c2909c20da490a2c4ed71c0/packages/testing/src/portability/error-representation-portability-fixture.ts)
- [Express adapter consuming test](https://github.com/fluojs/fluo/blob/929aaf23b8c3a7336c2909c20da490a2c4ed71c0/packages/platform-express/src/adapter.test.ts)
- [Fastify adapter consuming test](https://github.com/fluojs/fluo/blob/929aaf23b8c3a7336c2909c20da490a2c4ed71c0/packages/platform-fastify/src/adapter.test.ts)
- [Node.js adapter consuming test](https://github.com/fluojs/fluo/blob/929aaf23b8c3a7336c2909c20da490a2c4ed71c0/packages/platform-nodejs/src/index.test.ts)
- [Bun adapter consuming test](https://github.com/fluojs/fluo/blob/929aaf23b8c3a7336c2909c20da490a2c4ed71c0/packages/platform-bun/src/adapter.test.ts)
- [Deno adapter consuming test](https://github.com/fluojs/fluo/blob/929aaf23b8c3a7336c2909c20da490a2c4ed71c0/packages/platform-deno/src/fetch-handler.test.ts)

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Changeset intent: patch releases for `@fluojs/http`, `@fluojs/testing`, and `@fluojs/platform-express`.

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] No public exports changed; source-level summary and `@param` / `@returns` requirements are not applicable.
- [x] Existing README examples remain accurate and complementary to the regression coverage.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] The existing documented `HEAD` contract remains accurate; no README correction was required.
- [x] Application-owned custom writer and committed-response limitations remain explicit and unchanged.
- [x] Runtime invariants are covered by dispatcher and adapter portability regression tests.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md), [docs/contracts/platform-conformance-authoring-checklist.md](docs/contracts/platform-conformance-authoring-checklist.md), and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] No governance or platform contract docs changed, so English/Korean mirror updates are not applicable.
- [x] No platform contract docs changed; discoverability and docs-index companion updates are not applicable.
- [x] Cross-runtime behavior is backed by the directly linked shared portability runner, fixture, consuming adapter tests, and current-head CI portability checks.