### PR TITLE
Resolve #3039: Share cache store teardown completion

### DIFF
--- a/.changeset/share-cache-store-teardown.md
+++ b/.changeset/share-cache-store-teardown.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/cache-manager': patch
+---
+
+Share cache store teardown completion and failures across concurrent or repeated service and lifecycle close calls.

--- a/docs/architecture/caching.ko.md
+++ b/docs/architecture/caching.ko.md
@@ -47,7 +47,7 @@
 | 실패 격리 | `safeGet`, `safeSet`, `safeDel`은 저장소 오류를 삼킵니다. 캐시 실패가 다른 정상 핸들러를 실패시키지 않습니다. | `packages/cache-manager/src/interceptor.ts` |
 | 진행 중 로드 무효화 | `CacheService.del(...)`은 아직 로딩 중인 키를 표시하여, 같은 로드 주기 중 무효화된 키가 `remember(...)`에 의해 다시 채워지지 않도록 합니다. | `packages/cache-manager/src/service.ts` |
 | 전체 reset | `CacheService.reset()`은 내부 reset version을 증가시키고, 진행 중/대기 중인 load bookkeeping과 진행 중 무효화 마커를 지운 뒤, 하위 저장소를 reset합니다. | `packages/cache-manager/src/service.ts` |
-| 저장소 teardown | 애플리케이션 종료 중 `CacheService`는 custom store의 `close()` hook을 호출하고, `close()`가 없으면 `dispose()`를 호출하므로 리소스를 소유한 store가 socket, pool, timer 또는 기타 외부 handle을 해제할 수 있습니다. | `packages/cache-manager/src/types.ts`, `packages/cache-manager/src/service.ts` |
+| 저장소 teardown | 애플리케이션 종료 중 `CacheService`는 custom store의 `close()` hook을 호출하고, `close()`가 없으면 `dispose()`를 호출하므로 리소스를 소유한 store가 socket, pool, timer 또는 기타 외부 handle을 해제할 수 있습니다. 동시에 또는 반복해서 호출한 service/lifecycle close는 실패를 포함한 첫 teardown promise를 공유하므로, 하나의 authoritative completion boundary 뒤에서 teardown이 한 번만 실행됩니다. | `packages/cache-manager/src/types.ts`, `packages/cache-manager/src/service.ts` |
 
 ## 제약 사항
 

--- a/docs/architecture/caching.md
+++ b/docs/architecture/caching.md
@@ -47,7 +47,7 @@ This document defines the current cache contract across `@fluojs/cache-manager`,
 | Failure containment | `safeGet`, `safeSet`, and `safeDel` swallow store errors. Cache failures do not fail otherwise successful handlers. | `packages/cache-manager/src/interceptor.ts` |
 | In-flight invalidation | `CacheService.del(...)` marks keys that are still loading so `remember(...)` does not repopulate a key that was invalidated during the same load cycle. | `packages/cache-manager/src/service.ts` |
 | Full reset | `CacheService.reset()` increments an internal reset version, clears in-flight and pending load bookkeeping, clears in-flight invalidation markers, and resets the underlying store. | `packages/cache-manager/src/service.ts` |
-| Store teardown | During application shutdown, `CacheService` calls a custom store `close()` hook, or `dispose()` when `close()` is absent, so resource-owning stores can release sockets, pools, timers, or other external handles. | `packages/cache-manager/src/types.ts`, `packages/cache-manager/src/service.ts` |
+| Store teardown | During application shutdown, `CacheService` calls a custom store `close()` hook, or `dispose()` when `close()` is absent, so resource-owning stores can release sockets, pools, timers, or other external handles. Concurrent and repeated service or lifecycle close calls share the first teardown promise, including its failure, so teardown runs once behind one authoritative completion boundary. | `packages/cache-manager/src/types.ts`, `packages/cache-manager/src/service.ts` |
 
 ## Constraints
 

--- a/packages/cache-manager/README.ko.md
+++ b/packages/cache-manager/README.ko.md
@@ -216,7 +216,7 @@ CacheModule.forRoot({
 
 Redis cache prefix를 cache가 아닌 데이터와 공유하지 마세요. `del(key)`은 이 패키지가 해석한 정확한 캐시 키를 삭제하고, `reset()`은 위에서 설명한 store 소유 캐시 namespace만 삭제합니다.
 
-애플리케이션이 종료될 때 `CacheService`는 새 store read/write를 중단하고 이미 시작된 store 작업을 기다린 뒤, `close()` 또는 `dispose()`를 노출하는 custom store로 shutdown을 전달합니다. store가 socket, pool, timer 또는 기타 외부 리소스를 소유한다면 이 optional hook 중 하나를 사용하세요.
+애플리케이션이 종료될 때 `CacheService`는 새 store read/write를 중단하고 이미 시작된 store 작업을 기다린 뒤, `close()` 또는 `dispose()`를 노출하는 custom store로 shutdown을 전달합니다. 동시에 또는 반복해서 호출된 `close()`와 lifecycle hook은 첫 teardown의 완료 및 실패를 공유하므로, store teardown은 한 번만 실행되고 모든 호출자가 같은 shutdown 경계를 관찰합니다. store가 socket, pool, timer 또는 기타 외부 리소스를 소유한다면 이 optional hook 중 하나를 사용하세요.
 
 `CacheStore` 계약을 구현한 custom store는 `store` 옵션에 직접 전달할 수 있습니다. in-process LRU store, Redis 외 원격 캐시, 또는 cache operation을 관찰해야 하는 테스트 더블에 적합합니다.
 
@@ -276,7 +276,7 @@ class ProductController {
 - `NormalizedCacheModuleOptions`: 기본값이 적용된 정규화 설정 모양과 일치하는 compatibility-only type export입니다. 애플리케이션 코드에서는 `CacheModuleOptions`를 우선 사용하세요. 이 타입은 이전에 배포된 declaration surface를 참조한 소비자가 계속 컴파일되도록 공개 상태를 유지합니다.
 
 ### 서비스
-- `CacheService`: 수동 캐시 작업(`get`, `set`, `del`, `remember`, `reset`, `close`)을 위한 기본 API입니다. 애플리케이션 shutdown은 같은 `close()` 경로를 호출하며, 이 경로는 `close()` 또는 `dispose()`를 노출하는 custom store로 teardown을 전달합니다.
+- `CacheService`: 수동 캐시 작업(`get`, `set`, `del`, `remember`, `reset`, `close`)을 위한 기본 API입니다. 애플리케이션 shutdown은 같은 `close()` 경로를 호출하며, 이 경로는 `close()` 또는 `dispose()`를 노출하는 custom store로 teardown을 전달하고 동시에 또는 반복해서 호출한 caller가 첫 teardown 완료를 공유하도록 합니다.
 
 ### 데코레이터
 - `@CacheTTL(seconds)`: 특정 핸들러의 TTL을 설정합니다.

--- a/packages/cache-manager/README.md
+++ b/packages/cache-manager/README.md
@@ -216,7 +216,7 @@ CacheModule.forRoot({
 
 Avoid sharing a Redis cache prefix with non-cache data. `del(key)` removes the exact cache key resolved by this package, while `reset()` removes only the store-owned cache namespace described above.
 
-When the application closes, `CacheService` stops new store reads/writes, waits for already-started store operations, and then forwards shutdown to custom stores that expose `close()` or `dispose()`. Use one of those optional hooks when a store owns sockets, pools, timers, or other external resources.
+When the application closes, `CacheService` stops new store reads/writes, waits for already-started store operations, and then forwards shutdown to custom stores that expose `close()` or `dispose()`. Concurrent and repeated `close()` or lifecycle-hook calls share that first teardown completion and failure, so every caller observes the same shutdown boundary while store teardown runs once. Use one of those optional hooks when a store owns sockets, pools, timers, or other external resources.
 
 Custom stores can be passed directly through `store` when they implement the `CacheStore` contract. This is the right option for in-process LRU stores, remote caches other than Redis, or test doubles that need to observe cache operations.
 
@@ -276,7 +276,7 @@ On that supported HTTP path, eviction is deferred until a framework response wri
 - `NormalizedCacheModuleOptions`: Compatibility-only type export matching the normalized configuration shape after defaults are applied. Prefer `CacheModuleOptions` for application code; this type remains public so consumers that referenced the previously shipped declaration surface can keep compiling.
 
 ### Services
-- `CacheService`: Main API for manual cache operations (`get`, `set`, `del`, `remember`, `reset`, `close`). Application shutdown calls the same `close()` path, which forwards teardown to custom stores exposing `close()` or `dispose()`.
+- `CacheService`: Main API for manual cache operations (`get`, `set`, `del`, `remember`, `reset`, `close`). Application shutdown calls the same `close()` path, which forwards teardown to custom stores exposing `close()` or `dispose()` and shares the first teardown completion across concurrent or repeated callers.
 
 ### Decorators
 - `@CacheTTL(seconds)`: Sets the TTL for a specific handler.

--- a/packages/cache-manager/src/cache-service.shutdown.test.ts
+++ b/packages/cache-manager/src/cache-service.shutdown.test.ts
@@ -36,6 +36,74 @@ function createDeferred<T>(): Deferred<T> {
 }
 
 describe('CacheService shutdown ordering', () => {
+  it('shares teardown completion across concurrent and repeated close callers', async () => {
+    // Given
+    const closeDeferred = createDeferred<void>();
+    const close = vi.fn(() => closeDeferred.promise);
+    const store: CacheStore = {
+      close,
+      async del() {},
+      async get() {
+        return undefined;
+      },
+      async reset() {},
+      async set() {},
+    };
+    const cache = new CacheService(store, cacheOptions);
+
+    // When
+    const firstClose = cache.close();
+    const concurrentLifecycleClose = cache.onModuleDestroy();
+
+    await vi.waitFor(() => {
+      expect(close).toHaveBeenCalledTimes(1);
+    });
+    const sharedConcurrentCompletion = concurrentLifecycleClose === firstClose;
+    closeDeferred.resolve();
+    await Promise.all([firstClose, concurrentLifecycleClose]);
+    const repeatedClose = cache.close();
+
+    // Then
+    expect(sharedConcurrentCompletion).toBe(true);
+    expect(repeatedClose).toBe(firstClose);
+    await expect(repeatedClose).resolves.toBeUndefined();
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('shares teardown failure across concurrent and repeated close callers', async () => {
+    // Given
+    const failure = new Error('store close failed');
+    const close = vi.fn(async () => {
+      throw failure;
+    });
+    const store: CacheStore = {
+      close,
+      async del() {},
+      async get() {
+        return undefined;
+      },
+      async reset() {},
+      async set() {},
+    };
+    const cache = new CacheService(store, cacheOptions);
+
+    // When
+    const firstClose = cache.close();
+    const concurrentLifecycleClose = cache.onModuleDestroy();
+    const concurrentResults = await Promise.allSettled([firstClose, concurrentLifecycleClose]);
+    const repeatedClose = cache.close();
+
+    // Then
+    expect(concurrentLifecycleClose).toBe(firstClose);
+    expect(concurrentResults).toEqual([
+      { status: 'rejected', reason: failure },
+      { status: 'rejected', reason: failure },
+    ]);
+    expect(repeatedClose).toBe(firstClose);
+    await expect(repeatedClose).rejects.toBe(failure);
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
   it('waits for an in-flight store get before closing the store exactly once', async () => {
     // Given
     const events: string[] = [];

--- a/packages/cache-manager/src/service.ts
+++ b/packages/cache-manager/src/service.ts
@@ -19,6 +19,7 @@ export class CacheService {
   private readonly pendingInvalidations = new Map<string, number>();
   private readonly invalidatedInflight = new Set<string>();
   private closed = false;
+  private closePromise: Promise<void> | undefined;
   private resetVersion = 0;
   private storeOperationTail: Promise<void> = Promise.resolve();
 
@@ -239,11 +240,13 @@ export class CacheService {
   /**
    * Close the configured store when it exposes an optional teardown hook.
    *
+   * Concurrent and repeated calls share the first teardown completion and failure.
+   *
    * @returns A promise that resolves after store teardown completes.
    */
-  async close(): Promise<void> {
-    if (this.closed) {
-      return;
+  close(): Promise<void> {
+    if (this.closePromise) {
+      return this.closePromise;
     }
 
     this.closed = true;
@@ -253,7 +256,7 @@ export class CacheService {
     this.pendingInvalidations.clear();
     this.invalidatedInflight.clear();
 
-    await this.runStoreOperation(async () => {
+    this.closePromise = this.runStoreOperation(async () => {
       if (this.store.close) {
         await this.store.close();
         return;
@@ -263,6 +266,8 @@ export class CacheService {
         await this.store.dispose();
       }
     });
+
+    return this.closePromise;
   }
 
   private async deleteFromStore(key: string): Promise<void> {


### PR DESCRIPTION
## Summary

Make `CacheService.close()` provide one authoritative completion boundary for concurrent and repeated service or lifecycle shutdown calls.

Linked context: Closes #3039

## Changes

- Memoize the first cache store teardown promise as soon as shutdown starts.
- Return the same completion and failure to concurrent `close()` / `onModuleDestroy()` callers while executing store teardown once.
- Add success and rejection regressions for repeated and lifecycle-hook calls.
- Align the package README and caching architecture contract in English and Korean.
- Add a patch Changeset for `@fluojs/cache-manager`.

## Testing

Passed:
- `pnpm --dir packages/cache-manager test` (147/147)
- `pnpm --dir packages/cache-manager typecheck`
- `pnpm --dir packages/cache-manager build`
- `pnpm exec biome check packages/cache-manager/src/service.ts packages/cache-manager/src/cache-service.shutdown.test.ts`
- changed-file LSP diagnostics (0 errors)
- `pnpm docs:sync-check`
- `pnpm verify:platform-consistency-governance`
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main`

Canonical full-suite note:
- `pnpm verify` reached and passed repository build, typecheck, lint, and public-export TSDoc gates, then failed in unrelated GraphQL/Studio SSE and multipart stream tests.
- `pnpm verify:release-readiness` likewise reached the split package suite and failed in the same unrelated GraphQL/Studio SSE cases.
- The failures reproduce when those unchanged tests are run alone, and `git diff --exit-code origin/main -- packages/graphql packages/cli packages/runtime/src/multipart.test.ts` confirms this PR does not modify those paths.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Patch rationale: this restores the documented `CacheService.close()` completion contract without changing the public API shape.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No export surface was added or removed. The existing public `CacheService.close()` TSDoc now states the concurrent/repeated completion behavior.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

This is a contract-preserving correction: new operations remain gated when shutdown starts, while every shutdown caller now observes the same store teardown completion or failure.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests, such as `createPlatformConformanceHarness(...)` for platform component contracts or `createHttpAdapterPortabilityHarness(...)` for HTTP adapter portability contracts.

No platform adapter contract changed. The EN/KO cache architecture pair and package README pair were updated together; package regressions cover the lifecycle behavior.